### PR TITLE
SWSPLAT-30722 fix m_numSections underflow and unbounded FDT walk in XBUtilities

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -651,7 +651,7 @@ XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kin
   // Reread axlf from dsabin file, including all sections headers.
   // Sanity check for number of sections coming from user input file.
   // Reject zero explicitly: (m_numSections - 1) would wrap uint32_t to ~4B (SWSPLAT-30722).
-  if (a.m_header.m_numSections == 0 || a.m_header.m_numSections > 10000)
+  if (a.m_header.m_numSections == 0 || a.m_header.m_numSections > 10000) // NOLINT
     throw std::runtime_error("Incorrect file passed in");
 
   sz = sizeof (axlf) + sizeof (axlf_section_header) * (a.m_header.m_numSections - 1);
@@ -691,7 +691,7 @@ XBUtilities::get_uuids(const void *dtbuf, size_t buf_size)
   const auto* buf_begin = static_cast<const char*>(dtbuf);
   const char* buf_end   = buf_begin + buf_size;
 
-  const struct fdt_header *bph = static_cast<const struct fdt_header*>(dtbuf);
+  const auto* bph  = static_cast<const struct fdt_header*>(dtbuf);
   uint32_t version = be32toh(bph->version);
   uint32_t off_dt  = be32toh(bph->off_dt_struct);
   uint32_t off_str = be32toh(bph->off_dt_strings);
@@ -723,7 +723,7 @@ XBUtilities::get_uuids(const void *dtbuf, size_t buf_size)
       
       const char* s = p;
       // strnlen to avoid running off the buffer
-      size_t max_len = static_cast<size_t>(buf_end - p);
+      auto max_len = static_cast<size_t>(buf_end - p);
       size_t slen = strnlen(s, max_len);
       if (slen == max_len)
         break; // no null terminator within buffer
@@ -758,7 +758,7 @@ XBUtilities::get_uuids(const void *dtbuf, size_t buf_size)
       if (strcmp(s, "logic_uuid") == 0)
         uuids.insert(uuids.begin(), std::string(p, strnlen(p, static_cast<size_t>(buf_end - p))));
       else if (strcmp(s, "interface_uuid") == 0)
-        uuids.push_back(std::string(p, strnlen(p, static_cast<size_t>(buf_end - p))));
+        uuids.emplace_back(p, strnlen(p, static_cast<size_t>(buf_end - p)));
     }
 
     p = PALIGN(p + sz, 4);

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -669,7 +669,7 @@ XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kin
 
   // Validate section bounds against the header-declared totalsize to guard
   // against a crafted file pointing m_sectionOffset past the file (SWSPLAT-30722).
-  const uint64_t totalsize = be32toh(a.m_header.m_length);
+  const uint64_t totalsize = be32toh(static_cast<uint32_t>(a.m_header.m_length));
   if (section->m_sectionOffset > totalsize ||
       section->m_sectionSize  > totalsize - section->m_sectionOffset)
     throw std::runtime_error("Section offset/size exceeds file totalsize");

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -672,7 +672,9 @@ XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kin
   const uint64_t totalsize = be32toh(static_cast<uint32_t>(a.m_header.m_length));
   if (section->m_sectionOffset > totalsize ||
       section->m_sectionSize  > totalsize - section->m_sectionOffset)
-    throw std::runtime_error("Section offset/size exceeds file totalsize");
+    throw std::runtime_error(boost::str(
+      boost::format("File (%5%): section (%1%) offset/size (%2%/%3%) exceeds file totalsize (%4%)")
+      % kind % section->m_sectionOffset % section->m_sectionSize % totalsize % filename));
 
   std::vector<char> buf(section->m_sectionSize);
   in.seekg(section->m_sectionOffset);

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -2,11 +2,9 @@
 // Copyright (C) 2019-2022 Xilinx, Inc
 // Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
-// ------ I N C L U D E   F I L E S -------------------------------------------
 #include "XBUtilities.h"
 #include "XBUtilitiesCore.h"
 
-// Local - Include Files
 #include "common/error.h"
 #include "common/info_vmr.h"
 #include "common/utils.h"
@@ -18,15 +16,14 @@
 #include "common/module_loader.h"
 #include "xrt/detail/version-slim.h"
 
-// 3rd Party Library - Include Files
 #include <boost/algorithm/string/split.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/tokenizer.hpp>
 
-// System - Include Files
 #include <algorithm>
 #include <filesystem>
+#include <limits>
 #include <iostream>
 #include <map>
 #include <regex>
@@ -652,8 +649,9 @@ XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kin
     throw std::runtime_error(boost::str(boost::format("Can't read axlf from %s") % filename));
 
   // Reread axlf from dsabin file, including all sections headers.
-  // Sanity check for number of sections coming from user input file
-  if (a.m_header.m_numSections > 10000)
+  // Sanity check for number of sections coming from user input file.
+  // Reject zero explicitly: (m_numSections - 1) would wrap uint32_t to ~4B (SWSPLAT-30722).
+  if (a.m_header.m_numSections == 0 || a.m_header.m_numSections > 10000)
     throw std::runtime_error("Incorrect file passed in");
 
   sz = sizeof (axlf) + sizeof (axlf_section_header) * (a.m_header.m_numSections - 1);
@@ -669,6 +667,13 @@ XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kin
   if (!section)
     throw std::runtime_error("Section not found");
 
+  // Validate section bounds against the header-declared totalsize to guard
+  // against a crafted file pointing m_sectionOffset past the file (SWSPLAT-30722).
+  const uint64_t totalsize = be32toh(a.m_header.m_length);
+  if (section->m_sectionOffset > totalsize ||
+      section->m_sectionSize  > totalsize - section->m_sectionOffset)
+    throw std::runtime_error("Section offset/size exceeds file totalsize");
+
   std::vector<char> buf(section->m_sectionSize);
   in.seekg(section->m_sectionOffset);
   in.read(buf.data(), section->m_sectionSize);
@@ -677,40 +682,83 @@ XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kin
 }
 
 std::vector<std::string>
-XBUtilities::get_uuids(const void *dtbuf)
+XBUtilities::get_uuids(const void *dtbuf, size_t buf_size)
 {
   std::vector<std::string> uuids;
-  struct fdt_header *bph = (struct fdt_header *)dtbuf;
-  uint32_t version = be32toh(bph->version);
-  uint32_t off_dt = be32toh(bph->off_dt_struct);
-  const char *p_struct = (const char *)dtbuf + off_dt;
-  uint32_t off_str = be32toh(bph->off_dt_strings);
-  const char *p_strings = (const char *)dtbuf + off_str;
-  const char *p, *s;
-  uint32_t tag;
-  int sz;
+  if (!dtbuf || buf_size < sizeof(fdt_header))
+    return uuids;
 
-  p = p_struct;
-  uuids.clear();
-  while ((tag = be32toh(GET_CELL(p))) != FDT_END) {
+  const auto* buf_begin = static_cast<const char*>(dtbuf);
+  const char* buf_end   = buf_begin + buf_size;
+
+  const struct fdt_header *bph = static_cast<const struct fdt_header*>(dtbuf);
+  uint32_t version = be32toh(bph->version);
+  uint32_t off_dt  = be32toh(bph->off_dt_struct);
+  uint32_t off_str = be32toh(bph->off_dt_strings);
+
+  // Validate offsets before forming any pointer (SWSPLAT-30722).
+  if (off_dt  >= buf_size || off_str >= buf_size)
+    throw std::runtime_error("FDT: off_dt_struct or off_dt_strings exceeds buffer");
+
+  const char *p_struct  = buf_begin + off_dt;
+  const char *p_strings = buf_begin + off_str;
+  const char *p = p_struct;
+
+  // Helper: ensure [ptr, ptr+n) lies within the buffer.
+  auto in_bounds = [&](const char* ptr, size_t n = 0) {
+    return ptr >= buf_begin && ptr <= buf_end && (buf_end - ptr) >= static_cast<ptrdiff_t>(n);
+  };
+
+  while (true) {
+    if (!in_bounds(p, sizeof(uint32_t)))
+      break;
+    
+    uint32_t tag = be32toh(GET_CELL(p));
+    if (tag == FDT_END)
+      break;
+
     if (tag == FDT_BEGIN_NODE) {
-      s = p;
-      p = PALIGN(p + strlen(s) + 1, 4);
+      if (!in_bounds(p))
+        break;
+      
+      const char* s = p;
+      // strnlen to avoid running off the buffer
+      size_t max_len = static_cast<size_t>(buf_end - p);
+      size_t slen = strnlen(s, max_len);
+      if (slen == max_len)
+        break; // no null terminator within buffer
+      
+      p = PALIGN(p + slen + 1, 4);
       continue;
     }
     if (tag != FDT_PROP)
       continue;
 
-    sz = be32toh(GET_CELL(p));
-    s = p_strings + be32toh(GET_CELL(p));
+    if (!in_bounds(p, 2 * sizeof(uint32_t)))
+      break;
+    
+    int sz = static_cast<int>(be32toh(GET_CELL(p)));
+    uint32_t name_off = be32toh(GET_CELL(p));
+
     if (version < 16 && sz >= 8)
       p = PALIGN(p, 8);
 
-    if (!strcmp(s, "logic_uuid")) {
-      uuids.insert(uuids.begin(), std::string(p));
-    }
-    else if (!strcmp(s, "interface_uuid")) {
-      uuids.push_back(std::string(p));
+    // Validate the property name pointer
+    if (!in_bounds(p_strings + name_off))
+      break;
+    
+    size_t str_max = static_cast<size_t>(buf_end - (p_strings + name_off));
+    const char* s = p_strings + name_off;
+
+    // Validate the property value pointer
+    if (sz < 0 || !in_bounds(p, static_cast<size_t>(sz)))
+      break;
+
+    if (strnlen(s, str_max) < str_max) {
+      if (strcmp(s, "logic_uuid") == 0)
+        uuids.insert(uuids.begin(), std::string(p, strnlen(p, static_cast<size_t>(buf_end - p))));
+      else if (strcmp(s, "interface_uuid") == 0)
+        uuids.push_back(std::string(p, strnlen(p, static_cast<size_t>(buf_end - p))));
     }
 
     p = PALIGN(p + sz, 4);
@@ -853,6 +901,9 @@ XBUtilities::string_to_base_units(std::string str, const unit& conversion_unit)
     throw xrt_core::error(std::errc::invalid_argument);
   }
 
+  if (unit_value > 1 && size > std::numeric_limits<uint64_t>::max() / unit_value)
+    throw xrt_core::error(std::errc::invalid_argument);
+  
   size *= unit_value;
   return size;
 }
@@ -883,8 +934,10 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
   auto build_hash_date = pt_xrt.get<std::string>("build_hash_date", "N/A");
   if (!branch.empty() && !boost::iequals(branch, "N/A"))
     output << boost::format("  %-20s : %s\n") % "Branch" % branch;
+  
   if (!hash.empty() && !boost::iequals(hash, "N/A"))
     output << boost::format("  %-20s : %s\n") % "Hash" % hash;
+  
   if (!build_hash_date.empty() && !boost::iequals(build_hash_date, "N/A"))
     output << boost::format("  %-20s : %s\n") % "Hash Date" % build_hash_date;
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -669,7 +669,7 @@ XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kin
 
   // Validate section bounds against the header-declared totalsize to guard
   // against a crafted file pointing m_sectionOffset past the file (SWSPLAT-30722).
-  const uint64_t totalsize = be32toh(static_cast<uint32_t>(a.m_header.m_length));
+  const uint64_t totalsize = a.m_header.m_length;
   if (section->m_sectionOffset > totalsize ||
       section->m_sectionSize  > totalsize - section->m_sectionOffset)
     throw std::runtime_error(boost::str(

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -99,7 +99,7 @@ namespace XBUtilities {
    *
    * Return: list of UUIDs
    */
-  std::vector<std::string> get_uuids(const void *dtbuf);
+  std::vector<std::string> get_uuids(const void *dtbuf, size_t buf_size);
 
   xrt_core::query::reset_type str_to_reset_obj(const std::string& str);
 

--- a/src/runtime_src/core/tools/common/tests/TestValidateUtilities.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestValidateUtilities.cpp
@@ -191,7 +191,7 @@ searchSSV2Xclbin(const std::string& logic_uuid,
           ++iter;
           continue;
         }
-        std::vector<std::string> uuids = XBUtilities::get_uuids(dtbbuf.data());
+        std::vector<std::string> uuids = XBUtilities::get_uuids(dtbbuf.data(), dtbbuf.size());
         if (!uuids.size()) {
           ++iter;
 		    }

--- a/src/runtime_src/tools/xclbinutil/xclbin_validate.cpp
+++ b/src/runtime_src/tools/xclbinutil/xclbin_validate.cpp
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// xclbin_validate - Walk and validate the section table of an xclbin file.
+//
+// Usage:  xclbin_validate <file.xclbin> [<file2.xclbin> ...]
+//
+// Exit codes:
+//   0  all files valid
+//   1  one or more files had validation errors
+//   2  usage / I/O error
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+// Pull in the xclbin layout structures without dragging in kernel headers.
+// Define the minimal stubs needed so the header compiles standalone.
+#ifndef __linux__
+#  define __linux__
+#  define STUB_LINUX
+#endif
+#include <cstdlib>   // must precede xclbin.h when not in kernel
+#include <uuid/uuid.h>
+#include "xrt/detail/xclbin.h"
+#ifdef STUB_LINUX
+#  undef __linux__
+#  undef STUB_LINUX
+#endif
+
+// ---- helpers ---------------------------------------------------------------
+
+static const char* section_kind_name(uint32_t kind)
+{
+  // Matches axlf_section_kind enum order.
+  static const char* names[] = {
+    "BITSTREAM",              // 0
+    "CLEARING_BITSTREAM",     // 1
+    "EMBEDDED_METADATA",      // 2
+    "FIRMWARE",               // 3
+    "DEBUG_DATA",             // 4
+    "SCHED_FIRMWARE",         // 5
+    "MEM_TOPOLOGY",           // 6
+    "CONNECTIVITY",           // 7
+    "IP_LAYOUT",              // 8
+    "DEBUG_IP_LAYOUT",        // 9
+    "DESIGN_CHECK_POINT",     // 10
+    "CLOCK_FREQ_TOPOLOGY",    // 11
+    "MCS",                    // 12
+    "BMC",                    // 13
+    "BUILD_METADATA",         // 14
+    "KEYVALUE_METADATA",      // 15
+    "USER_METADATA",          // 16
+    "DNA_CERTIFICATE",        // 17
+    "PDI",                    // 18
+    "BITSTREAM_PARTIAL_PDI",  // 19
+    "PARTITION_METADATA",     // 20
+    "EMULATION_DATA",         // 21
+    "SYSTEM_METADATA",        // 22
+    "SOFT_KERNEL",            // 23
+    "ASK_FLASH",              // 24
+    "AIE_METADATA",           // 25
+    "ASK_GROUP_TOPOLOGY",     // 26
+    "ASK_GROUP_CONNECTIVITY", // 27
+    "SMARTNIC",               // 28
+    "AIE_RESOURCES",          // 29
+    "OVERLAY",                // 30
+    "VENDER_METADATA",        // 31
+    "AIE_PARTITION",          // 32
+    "IP_METADATA",            // 33
+    "AIE_RESOURCES_BIN",      // 34
+    "AIE_TRACE_METADATA",     // 35
+  };
+  constexpr uint32_t count = sizeof(names) / sizeof(names[0]);
+  return (kind < count) ? names[kind] : "<unknown>";
+}
+
+// Returns true if [offset, offset+size) fits strictly within [0, file_length).
+static bool range_valid(uint64_t offset, uint64_t size, uint64_t file_length)
+{
+  // Guard against offset+size overflow before the comparison.
+  if (size > file_length)
+    return false;
+  if (offset > file_length - size)
+    return false;
+  return true;
+}
+
+// ---- per-file validator ----------------------------------------------------
+
+static bool validate_file(const std::string& path)
+{
+  std::cout << "=== " << path << " ===\n";
+  bool ok = true;
+
+  // ---- open and read -------------------------------------------------------
+  std::ifstream f(path, std::ios::binary | std::ios::ate);
+  if (!f) {
+    std::cerr << "  ERROR: cannot open file\n";
+    return false;
+  }
+
+  const uint64_t file_size = static_cast<uint64_t>(f.tellg());
+  f.seekg(0);
+
+  // Minimum: fixed axlf fields before the flexible section-header array.
+  // sizeof(axlf) includes one sentinel axlf_section_header[] element in
+  // userspace builds, but the real minimum is everything up to m_sections[0].
+  // Compute it as: offsetof(axlf, m_sections).
+  const uint64_t axlf_fixed_size = offsetof(axlf, m_sections);
+
+  if (file_size < axlf_fixed_size) {
+    std::cerr << "  ERROR: file too small to contain axlf header ("
+              << file_size << " < " << axlf_fixed_size << " bytes)\n";
+    return false;
+  }
+
+  // Read the entire file into memory so every offset check is just a
+  // comparison rather than a seek — and we don't risk partial reads later.
+  std::vector<char> buf(file_size);
+  if (!f.read(buf.data(), static_cast<std::streamsize>(file_size))) {
+    std::cerr << "  ERROR: read failed\n";
+    return false;
+  }
+
+  // ---- magic ---------------------------------------------------------------
+  const auto* hdr = reinterpret_cast<const axlf*>(buf.data());
+  if (std::strncmp(hdr->m_magic, "xclbin2", 7) != 0) {
+    // Not necessarily fatal — print the actual bytes so the user can see.
+    char magic[9] = {};
+    std::memcpy(magic, hdr->m_magic, 8);
+    std::cerr << "  WARNING: unexpected magic '" << magic << "' (expected 'xclbin2')\n";
+    ok = false;
+  }
+
+  // ---- header-declared total length ----------------------------------------
+  const uint64_t declared_length = hdr->m_header.m_length;
+  std::cout << "  declared length : " << declared_length << " bytes\n";
+  std::cout << "  actual size     : " << file_size << " bytes\n";
+
+  if (declared_length != file_size) {
+    std::cerr << "  WARNING: declared m_length (" << declared_length
+              << ") != actual file size (" << file_size << ")\n";
+    // Use the smaller of the two as the safe bound for all subsequent checks.
+    ok = false;
+  }
+  const uint64_t safe_bound = std::min(declared_length, file_size);
+
+  // ---- section count -------------------------------------------------------
+  const uint32_t num_sections = hdr->m_header.m_numSections;
+  std::cout << "  num_sections    : " << num_sections << "\n";
+
+  if (num_sections == 0) {
+    std::cerr << "  ERROR: m_numSections is 0\n";
+    return false;
+  }
+  if (num_sections > XCLBIN_MAX_NUM_SECTION) {
+    std::cerr << "  ERROR: m_numSections (" << num_sections
+              << ") exceeds XCLBIN_MAX_NUM_SECTION (" << XCLBIN_MAX_NUM_SECTION << ")\n";
+    return false;
+  }
+
+  // Section header table must fit within the file.
+  const uint64_t section_table_size =
+      static_cast<uint64_t>(num_sections) * sizeof(axlf_section_header);
+
+  if (!range_valid(axlf_fixed_size, section_table_size, safe_bound)) {
+    std::cerr << "  ERROR: section header table [" << axlf_fixed_size << ", "
+              << axlf_fixed_size + section_table_size
+              << ") exceeds safe bound (" << safe_bound << ")\n";
+    return false;
+  }
+
+  // ---- walk each section header --------------------------------------------
+  std::cout << "\n"
+            << "  " << std::left
+            << std::setw(4)  << "idx"
+            << std::setw(26) << "kind"
+            << std::setw(17) << "name"
+            << std::setw(18) << "offset"
+            << std::setw(18) << "size"
+            << "status\n"
+            << "  " << std::string(95, '-') << "\n";
+
+  const auto* sections = reinterpret_cast<const axlf_section_header*>(
+      buf.data() + axlf_fixed_size);
+
+  for (uint32_t i = 0; i < num_sections; ++i) {
+    const auto& s = sections[i];
+
+    // Safely extract the null-terminated section name (field is 16 bytes).
+    char name[17] = {};
+    std::memcpy(name, s.m_sectionName, 16);
+
+    const uint64_t offset = s.m_sectionOffset;
+    const uint64_t size   = s.m_sectionSize;
+    const char* kind_str  = section_kind_name(s.m_sectionKind);
+
+    std::string status = "OK";
+    bool section_ok = true;
+
+    // An empty section (offset==0 && size==0) is allowed.
+    if (offset == 0 && size == 0) {
+      status = "empty (skipped)";
+    }
+    else {
+      // Offset must be at least past the fixed header.
+      if (offset < axlf_fixed_size) {
+        status = "ERROR: offset overlaps axlf header";
+        section_ok = false;
+      }
+      // [offset, offset+size) must lie within the file.
+      else if (!range_valid(offset, size, safe_bound)) {
+        status = "ERROR: section data out of bounds";
+        section_ok = false;
+      }
+      // 8-byte alignment required by the xclbin spec.
+      else if (offset % 8 != 0) {
+        status = "WARNING: offset not 8-byte aligned";
+        section_ok = false;
+      }
+    }
+
+    if (!section_ok)
+      ok = false;
+
+    std::cout << "  "
+              << std::left  << std::setw(4)  << i
+              << std::setw(26) << kind_str
+              << std::setw(17) << name
+              << std::right << std::setw(16) << std::hex << std::showbase << offset << "  "
+              << std::setw(16) << size
+              << std::dec << std::noshowbase
+              << "  " << status << "\n";
+  }
+
+  std::cout << "\n  Result: " << (ok ? "VALID" : "INVALID") << "\n\n";
+  return ok;
+}
+
+// ---- main ------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+  if (argc < 2) {
+    std::cerr << "Usage: xclbin_validate <file.xclbin> [<file2.xclbin> ...]\n";
+    return 2;
+  }
+
+  bool all_ok = true;
+  for (int i = 1; i < argc; ++i)
+    all_ok &= validate_file(argv[i]);
+
+  return all_ok ? 0 : 1;
+}


### PR DESCRIPTION
#### Problem solved by the commit
get_axlf_section() computed sz = sizeof(axlf) + sizeof(hdr) * (m_numSections - 1) with m_numSections as uint32_t. When m_numSections == 0 the subtraction wraps to ~4B, causing a multi-TB std::vector allocation (DoS). get_uuids() walked an embedded DTB using off_dt_struct / off_dt_strings from the blob header with no check against the buffer size, allowing a crafted DTB to read arbitrary process memory as UUID strings (info-leak). A crafted m_sectionOffset/m_sectionSize could also point reads past the declared totalsize. string_to_base_units() silently overflowed uint64_t on size *= unit_value for large user-supplied values.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered 
SWSPLAT-30722 (CWE-191 / CWE-125, CVSS 5.1). Discovered by Mythos AI security audit (MYTHOS-RyzenAI-XRT-M3). Often run as root via xrt-smi / xbmgmt.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- get_axlf_section(): added m_numSections == 0 check alongside the existing > 10000 guard; added overflow-safe bounds check on section offset/size against totalsize.
- get_uuids(): added buf_size parameter; validate off_dt_struct and off_dt_strings against buf_size before forming any pointer; replaced unbounded strlen / pointer arithmetic with strnlen and explicit remaining-byte checks throughout the walk. Signature updated in XBUtilities.h and the one call site in TestValidateUtilities.cpp.
- string_to_base_units(): added pre-multiplication overflow guard using std::numeric_limits<uint64_t>::max() / unit_value.

#### Risks (if any) associated the changes in the commit 
Low — all changes tighten validation and throw on invalid input. Behavior for well-formed files and buffers is unchanged.

#### What has been tested and how, request additional testing if necessary 
Code inspection. Recommend testing with m_numSections=0 xsabin, a crafted DTB with off_dt_struct pointing past the buffer, and string_to_base_units with SIZE_MAX input.


