### PR TITLE
SWSPLAT-30720 fix path traversal in file_repo::resolve_key()

### DIFF
--- a/src/runtime_src/core/common/runner/repo.cpp
+++ b/src/runtime_src/core/common/runner/repo.cpp
@@ -294,13 +294,24 @@ class file_repo : public base_repo
   std::string
   resolve_key(const std::string& key) const override
   {
-    return (m_base_dir / std::filesystem::path(key)).string();
+    // Guard against path traversal from recipe-supplied keys
+    // (SWSPLAT-30720 / CWE-22).  Absolute keys (e.g. "/etc/passwd")
+    // and relative escapes (e.g. "../../secret") would bypass
+    // m_base_dir via std::filesystem::operator/ without this check.
+    auto resolved = (m_base_dir / key).lexically_normal();
+    auto rel = resolved.lexically_relative(m_base_dir);
+    if (rel.empty() || *rel.begin() == "..")
+      throw std::runtime_error("repo: artifact key escapes artifact directory: " + key);
+
+    return resolved.string();
   }
-  
+
 public:
   explicit
   file_repo(std::filesystem::path artifacts_dir)
-   : m_base_dir(std::move(artifacts_dir))
+    // Normalize at construction so lexically_relative() works correctly even
+    // when artifacts_dir contains redundant separators or "." components.
+   : m_base_dir(std::move(artifacts_dir).lexically_normal())
   {}
 
   // get() - Get artifact by key


### PR DESCRIPTION
#### Problem solved by the commit
file_repo resolved artifact keys from the run-recipe JSON as m_base_dir / key with no validation. std::filesystem::operator/ discards m_base_dir when key is absolute (e.g. "/etc/passwd"), and traversal keys (e.g. "../../secret") escape the directory lexically. The resolved path was then opened/mmap'd and its contents made available to the recipe execution graph — enabling arbitrary file read as the inference-process user (CWE-22).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered 
SWSPLAT-30720 (CWE-22, CVSS 5.3). Discovered by Mythos AI security audit (MYTHOS-RyzenAI-XRT-M2).

#### How problem was solved, alternative solutions (if any) and why they were rejected 
Normalize m_base_dir once at construction (lexically_normal()) so that lexically_relative() works correctly regardless of redundant separators or "." components. In resolve_key(), compute the normalized resolved path, then verify it is strictly under m_base_dir by checking that lexically_relative() returns a non-empty path whose first component is not "..". Throw on any violation before any file is opened.

#### Risks (if any) associated the changes in the commit Low — purely tightens key validation; behavior for well-formed relative keys within m_base_dir is unchanged.

#### What has been tested and how, request additional testing if necessary 
Code inspection. Recommend testing with absolute keys ("/etc/passwd"), traversal keys ("../../secret"), and normal keys ("model.bin").

