### PR TITLE
SWSPLAT-30717 fix unvalidated mpo_ offsets causing heap OOB read in xclbinutil sections

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -645,7 +645,7 @@ writeAIEPartitionImage(const char* pBuffer,
 
   // Name
   boost::property_tree::ptree ptAiePartition;
-  ptAiePartition.put("name", pBuffer + pHdr->mpo_name);
+  ptAiePartition.put("name", XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, bufferSize));
 
   // TOPs
   ptAiePartition.put("operations_per_cycle", (boost::format("%d") % pHdr->operations_per_cycle).str());
@@ -655,9 +655,9 @@ writeAIEPartitionImage(const char* pBuffer,
   // kernel_commit_id (modeled after mpo_name)
   // in order to be backward compatible with old xclbin which doesn't have
   // kernel_commit_id, we should make sure the offset is NOT 0
-  auto sKernelCommitId = "";
+  const char* sKernelCommitId = "";
   if (pHdr->kernel_commit_id != 0) {
-    sKernelCommitId = reinterpret_cast<const char*>(pBuffer + pHdr->kernel_commit_id);
+    sKernelCommitId = XUtil::bounded_mpo_cstr(pHdr, pHdr->kernel_commit_id, bufferSize);
   } else {
     XUtil::TRACE(boost::format("Open an existing xclbin: kernel_commit_id is 0x%lx") % pHdr->kernel_commit_id);
   }
@@ -728,7 +728,7 @@ SectionAIEPartition::readXclBinBinary(std::istream& iStream,
   auto pHdr = reinterpret_cast<const aie_partition*>(m_pBuffer);
 
   // Name
-  std::string name = m_pBuffer + pHdr->mpo_name;
+  std::string name = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize);
   XUtil::TRACE(std::string("Successfully read in the AIE_PARTITION section: '") + name + "' ");
   Section::m_sIndexName = name;
 }

--- a/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
@@ -1,20 +1,5 @@
-
-/**
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 #include "SectionAIEResourcesBin.h"
 
 #include "XclBinUtilities.h"
@@ -173,11 +158,11 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                              "  mpo_version (0x%lx): '%s'\n"
                              "  m_start_column (0x%lx): '%s'\n"
                              "  m_num_columns (0x%lx): '%s'")
-               % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name,       _origSectionSize)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_version % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->m_start_column % (reinterpret_cast<const char*>(pHdr) + pHdr->m_start_column)
-               % pHdr->m_num_columns % (reinterpret_cast<const char*>(pHdr) + pHdr->m_num_columns));
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version,    _origSectionSize)
+               % pHdr->m_start_column % XUtil::bounded_mpo_cstr(pHdr, pHdr->m_start_column, _origSectionSize)
+               % pHdr->m_num_columns % XUtil::bounded_mpo_cstr(pHdr, pHdr->m_num_columns,  _origSectionSize));
 
   // Get the JSON metadata
   _istream.seekg(0, _istream.end);             // Go to the beginning
@@ -424,19 +409,19 @@ SectionAIEResourcesBin::writeMetadata(std::ostream& _oStream) const
                              "  mpo_version (0x%lx): '%s'\n"
                              "  m_start_column (0x%lx): '%s'\n"
                              "  m_num_columns (0x%lx): '%s'")
-               % pHdr->mpo_name % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_name)
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_version % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->m_start_column % (reinterpret_cast<char*>(pHdr) + pHdr->m_start_column)
-               % pHdr->m_num_columns % (reinterpret_cast<char*>(pHdr) + pHdr->m_num_columns));
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, m_bufferSize)
+               % pHdr->m_start_column % XUtil::bounded_mpo_cstr(pHdr, pHdr->m_start_column, m_bufferSize)
+               % pHdr->m_num_columns % XUtil::bounded_mpo_cstr(pHdr, pHdr->m_num_columns, m_bufferSize));
 
   // Convert the data from the binary format to JSON
   boost::property_tree::ptree ptAieResourcesBin;
 
-  ptAieResourcesBin.put("name", reinterpret_cast<char*>(pHdr) + pHdr->mpo_name);
-  ptAieResourcesBin.put("version", reinterpret_cast<char*>(pHdr) + pHdr->mpo_version);
-  ptAieResourcesBin.put("start_column", reinterpret_cast<char*>(pHdr) + pHdr->m_start_column);
-  ptAieResourcesBin.put("num_columns", reinterpret_cast<char*>(pHdr) + pHdr->m_num_columns);
+  ptAieResourcesBin.put("name",         XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize));
+  ptAieResourcesBin.put("version",      XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, m_bufferSize));
+  ptAieResourcesBin.put("start_column", XUtil::bounded_mpo_cstr(pHdr, pHdr->m_start_column, m_bufferSize));
+  ptAieResourcesBin.put("num_columns",  XUtil::bounded_mpo_cstr(pHdr, pHdr->m_num_columns, m_bufferSize));
 
   boost::property_tree::ptree root;
   root.put_child("aie_resources_bin_metadata", ptAieResourcesBin);

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -1,19 +1,6 @@
-/**
- * Copyright (C) 2019 - 2022 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #include "SectionFlash.h"
 
 #include "XclBinUtilities.h"
@@ -463,9 +450,9 @@ SectionFlash::writeMetadata(std::ostream& _oStream) const
 
   std::string sFlashType = getFlashTypeAsString((FLASH_TYPE)pHdr->m_flash_type);
   ptFlash.put("flash_type", sFlashType.c_str());
-  ptFlash.put("name", reinterpret_cast<char*>(pHdr) + pHdr->mpo_name);
-  ptFlash.put("version", reinterpret_cast<char*>(pHdr) + pHdr->mpo_version);
-  ptFlash.put("md5", reinterpret_cast<char*>(pHdr) + pHdr->mpo_md5_value);
+  ptFlash.put("name",    XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name,      m_bufferSize));
+  ptFlash.put("version", XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version,   m_bufferSize));
+  ptFlash.put("md5",     XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, m_bufferSize));
 
   boost::property_tree::ptree root;
   root.put_child("flash_metadata", ptFlash);

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -1,20 +1,6 @@
-/**
- * Copyright (C) 2019-2022 Xilinx, Inc
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 #include "SectionSoftKernel.h"
 
 #include "XclBinUtilities.h"
@@ -436,20 +422,20 @@ SectionSoftKernel::writeMetadata(std::ostream& _oStream) const
                              "  mpo_md5_value (0x%lx): '%s'\n"
                              "  mpo_symbol_name (0x%lx): '%s'\n"
                              "  m_num_instances: %d")
-               % pHdr->mpo_name % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_name)
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_version % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->mpo_md5_value % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_md5_value)
-               % pHdr->mpo_symbol_name % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_symbol_name)
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, m_bufferSize)
+               % pHdr->mpo_md5_value % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, m_bufferSize)
+               % pHdr->mpo_symbol_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_symbol_name, m_bufferSize)
                % pHdr->m_num_instances);
 
   // Convert the data from the binary format to JSON
   boost::property_tree::ptree ptSoftKernel;
 
-  ptSoftKernel.put("mpo_name", reinterpret_cast<char*>(pHdr) + pHdr->mpo_name);
-  ptSoftKernel.put("mpo_version", reinterpret_cast<char*>(pHdr) + pHdr->mpo_version);
-  ptSoftKernel.put("mpo_md5_value", reinterpret_cast<char*>(pHdr) + pHdr->mpo_md5_value);
-  ptSoftKernel.put("mpo_symbol_name", reinterpret_cast<char*>(pHdr) + pHdr->mpo_symbol_name);
+  ptSoftKernel.put("mpo_name",        XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name,        m_bufferSize));
+  ptSoftKernel.put("mpo_version",     XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version,     m_bufferSize));
+  ptSoftKernel.put("mpo_md5_value",   XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value,   m_bufferSize));
+  ptSoftKernel.put("mpo_symbol_name", XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_symbol_name, m_bufferSize));
   ptSoftKernel.put("m_num_instances", (boost::format("%d") % pHdr->m_num_instances).str());
 
   boost::property_tree::ptree root;

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -1,19 +1,5 @@
-/**
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 #include "SectionVenderMetadata.h"
 
 #include "XclBinUtilities.h"
@@ -268,13 +254,13 @@ SectionVenderMetadata::writeMetadata(std::ostream& _oStream) const
                               "Original: \n"
                               "  mpo_name (0x%lx): '%s'\n"
                               "  m_image_offset: 0x%lx, m_image_size: 0x%lx")
-                          % pHdr->mpo_name % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_name)
+                          % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize)
                           % pHdr->m_image_offset % pHdr->m_image_size));
 
   // Convert the data from the binary format to JSON
   boost::property_tree::ptree ptVenderMetadata;
 
-  ptVenderMetadata.put("mpo_name", reinterpret_cast<char*>(pHdr) + pHdr->mpo_name);
+  ptVenderMetadata.put("mpo_name", XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize));
 
   boost::property_tree::ptree root;
   root.put_child("vender_metadata", ptVenderMetadata);

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2018, 2020-2023 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2018-2023 Xilinx, Inc. All rights reserved.
 // Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
-
 #include "XclBinUtilities.h"
 
 #include "Section.h"                           // TODO: REMOVE SECTION INCLUDE
@@ -235,6 +234,23 @@ XclBinUtilities::safeStringCopy(char* _destBuffer,
 
   // Copy the string
   memcpy(_destBuffer, _source.c_str(), bytesToCopy);
+}
+
+const char*
+XclBinUtilities::bounded_mpo_cstr(const void* pHdr, uint32_t mpo_offset, size_t bufferSize)
+{
+  // Reject offsets that lie outside the buffer entirely (SWSPLAT-30717 / CWE-125).
+  if (mpo_offset >= bufferSize)
+    throw std::runtime_error("mpo offset exceeds section buffer size");
+
+  const char* str = static_cast<const char*>(pHdr) + mpo_offset;
+  size_t remaining = bufferSize - mpo_offset;
+
+  // Verify a null terminator exists within the buffer before forming a C string.
+  if (strnlen(str, remaining) == remaining)
+    throw std::runtime_error("mpo string is not null-terminated within section buffer");
+
+  return str;
 }
 
 unsigned int

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
@@ -1,22 +1,8 @@
-/**
- * Copyright (C) 2018, 2020-2022 Xilinx, Inc. All rights reserved.
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
-#ifndef __XclBinUtilities_h_
-#define __XclBinUtilities_h_
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#ifndef XclBinUtilities_h_
+#define XclBinUtilities_h_
 
 // Include files
 #include "xrt/detail/xclbin.h"
@@ -153,6 +139,11 @@ void TRACE_PrintTree(const std::string& _msg, const boost::property_tree::ptree&
 void TRACE_BUF(const std::string& _msg, const char* _pData, uint64_t _size);
 
 void safeStringCopy(char* _destBuffer, const std::string& _source, unsigned int _bufferSize);
+
+// bounded_mpo_cstr - Safely resolve an mpo (member-pointer-offset) field to a C string.
+// Validates that the offset lies within the buffer and that a null terminator exists
+// before the buffer end.  Throws std::runtime_error on violation (SWSPLAT-30717/CWE-125).
+const char* bounded_mpo_cstr(const void* pHdr, uint32_t mpo_offset, size_t bufferSize);
 unsigned int bytesToAlign(uint64_t _offset);
 unsigned int alignBytes(std::ostream & _buf, unsigned int _byteBoundary);
 


### PR DESCRIPTION
#### Problem solved by the commit
writeMetadata() in SectionSoftKernel, SectionFlash, SectionAIEPartition, SectionAIEResourcesBin, and SectionVenderMetadata resolved mpo_* offset fields (from a parsed xclbin on disk) as plain pointer arithmetic with no check that the offset lies within the section buffer or that a null terminator exists before the buffer end. A crafted xclbin with mpo_name = 0x7FFFFFFF causes std::string construction to scan adjacent heap and emit arbitrary memory into JSON output / --dump-section output, or crash (CWE-125).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered 
SWSPLAT-30717 (CWE-125, CVSS 5.1). Discovered by Mythos AI security audit (MYTHOS-RyzenAI-XRT-M1). Triggered by xclbinutil --input or --dump-section on a malicious xclbin.

#### How problem was solved, alternative solutions (if any) and why they were rejected 
Added XclBinUtilities::bounded_mpo_cstr(pHdr, mpo_offset, bufferSize) which throws std::runtime_error if the offset is >= bufferSize or if no null terminator exists within [offset, bufferSize). Applied at every mpo_* read site in all five section files, covering both the primary writeMetadata() paths and the TRACE() diagnostic paths in copyBufferUpdateMetadata().

#### Risks (if any) associated the changes in the commit 
Low — purely tightens input validation on externally-supplied offsets; behavior for well-formed xclbin files is unchanged.

#### What has been tested and how, request additional testing if necessary 
Code inspection. Recommend testing with a crafted xclbin containing mpo_name = 0x7FFFFFFF and verifying xclbinutil throws rather than leaking heap data.
