### PR TITLE
Add Windows PE security compiler and linker flags

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -41,6 +41,7 @@ if (MSVC)
     /Zc:__cplusplus
     /Zi           # generate pdb files even in release mode
     /sdl          # enable security checks
+    /Gs           # control stack checking calls
     /Qspectre     # compile with the Spectre mitigations switch
     /ZH:SHA_256   # enable secure source code hashing
     /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
@@ -58,8 +59,11 @@ if (MSVC)
     $<$<NOT:$<CONFIG:Debug>>:/LTCG>            # enable link time code generation for release builds
     $<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>         # enable COMDAT folding
     $<$<NOT:$<CONFIG:Debug>>:/OPT:REF>         # eliminates functions and data that are never referenced
-    /DEBUG      # instruct linker to create debugging info
-    /guard:cf   # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+    /DEBUG           # instruct linker to create debugging info
+    /guard:cf        # enable linker control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
+    /DYNAMICBASE     # enable ASLR
+    /HIGHENTROPYVA   # enable 64-bit ASLR
+    /LARGEADDRESSAWARE # enable large address awareness
     /experimental:deterministic # deterministic build
     )
   if (NOT ${CMAKE_CXX_COMPILER} MATCHES "(arm64|ARM64)")


### PR DESCRIPTION
Windows PE security compliance requires /Gs (control stack checking calls), /DYNAMICBASE (ASLR), /HIGHENTROPYVA (64-bit ASLR), and /LARGEADDRESSAWARE to be present on all shipped Windows binaries. These flags were missing from the XRT Windows build in nativeWin.cmake, making the xrt subcomponent non-compliant. Because xrt must be buildable standalone, the flags must be self-contained in nativeWin.cmake and cannot rely on a parent CMake scope.

No functional bug. The gap was discovered during a security compliance audit of Windows PE compiler and linker flags across the ipu_compiler stack (SWDEV-577794). The flags were never added to nativeWin.cmake; there is no single PR that introduced the omission.

Added /Gs to the existing add_compile_options block in nativeWin.cmake. Added /DYNAMICBASE, /HIGHENTROPYVA, and /LARGEADDRESSAWARE to the existing add_link_options block. The CETCOMPAT flag is unchanged and remains gated on non-ARM64 via the existing conditional, as ARM64 does not use the usermode PE CET hint.

Alternative considered: setting the flags only in the parent src/CMakeLists.txt of the XRT-MCDM repo. Rejected because xrt is a standalone-buildable subcomponent and must carry all required security flags in its own cmake files.

Low. /Gs with no argument defaults to the compiler page size (4096 bytes on x64/ARM64), which is the standard safe value. /DYNAMICBASE, /HIGHENTROPYVA, and /LARGEADDRESSAWARE are standard PE hardening flags with no functional impact on correct code.

Full x64 and ARM64 Release builds completed successfully via build_ipu_stack.bat. Build logs verified: /Gs appears on all CL.exe invocations in the xrt subtree; /DYNAMICBASE, /HIGHENTROPYVA, /LARGEADDRESSAWARE appear on all link.exe invocations. PE headers of shipped DLLs confirmed via dumpbin /headers.

None.


