### PR TITLE
SWSPLAT-39875 fix xrt.ini CWD config injection when running with elevated privileges

### DIFF
--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -95,25 +95,38 @@ get_ini_path()
 {
   std::string full_path;
   try {
-    //The env variable should be the full path which includes xrt.ini
-    auto xrt_path = std::filesystem::path(xrt_core::utils::getenv("XRT_INI_PATH"));
-    if (std::filesystem::exists(xrt_path))
-      return xrt_path.string();
+    // When running with elevated privileges, ignore user-controllable search
+    // paths (CWD and environment variables) to prevent config injection via
+    // a planted xrt.ini in an attacker-writable directory (SWSPLAT-39875 / CWE-427).
+    // Non-privileged users retain the full search order including CWD.
+    const bool is_root = xrt_core::utils::is_elevated_process();
 
-    //The env variable should be the full path which includes sdaccel.ini
-    auto sda_path = std::filesystem::path(xrt_core::utils::getenv("SDACCEL_INI_PATH"));
-    if (std::filesystem::exists(sda_path))
-      return sda_path.string();
+    if (!is_root) {
+      // The env variable should be the full path which includes xrt.ini
+      auto xrt_path = std::filesystem::path(xrt_core::utils::getenv("XRT_INI_PATH"));
+      if (std::filesystem::exists(xrt_path))
+        return xrt_path.string();
+
+      // The env variable should be the full path which includes sdaccel.ini
+      auto sda_path = std::filesystem::path(xrt_core::utils::getenv("SDACCEL_INI_PATH"));
+      if (std::filesystem::exists(sda_path))
+        return sda_path.string();
+    }
 
     auto exe_path = std::filesystem::path(get_self_path()).parent_path();
     full_path = verify_ini_path(exe_path);
     if (!full_path.empty())
       return full_path;
 
-    auto self_path = std::filesystem::current_path();
-    full_path = verify_ini_path(self_path);
-    if (!full_path.empty())
-      return full_path;
+    if (!is_root) {
+      // CWD is only searched for non-root processes. When root, a planted
+      // xrt.ini in an attacker-writable directory would run with elevated
+      // privileges (SWSPLAT-39875).
+      auto self_path = std::filesystem::current_path();
+      full_path = verify_ini_path(self_path);
+      if (!full_path.empty())
+        return full_path;
+    }
 
   }
   catch (const std::filesystem::filesystem_error&) {
@@ -154,6 +167,12 @@ struct tree
   void
   reread(const std::string& fnm)
   {
+    // Refuse to load an arbitrary caller-supplied ini path when running with
+    // elevated privileges — same policy as get_ini_path() (SWSPLAT-39875 / CWE-427).
+    if (xrt_core::utils::is_elevated_process()) {
+      std::cerr << "[XRT] Ignoring xrt.ini reread request when running with elevated privileges\n";
+      return;
+    }
     read(fnm);
   }
 

--- a/src/runtime_src/core/common/detail/linux/utils.h
+++ b/src/runtime_src/core/common/detail/linux/utils.h
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <unistd.h>
 
 namespace xrt_core::utils::detail {
 
@@ -40,6 +41,14 @@ getenv(const char* name)
     return value;
 
   return {};
+}
+
+// Returns true when the process is running with elevated privileges (euid==0).
+// Used to harden config-file search paths (SWSPLAT-39875 / CWE-427).
+inline bool
+is_elevated_process()
+{
+  return ::geteuid() == 0;
 }
 
 } // xrt_core::utils::detail

--- a/src/runtime_src/core/common/detail/windows/utils.h
+++ b/src/runtime_src/core/common/detail/windows/utils.h
@@ -72,6 +72,25 @@ strerror(int err)
   return buffer;
 }
 
+// Returns true when the process token is UAC-elevated (i.e. running as
+// Administrator). Checks token elevation rather than group membership so
+// the result is correct even when UAC is active (SWSPLAT-39875 / CWE-427).
+inline bool
+is_elevated_process()
+{
+  HANDLE token = nullptr;
+  if (!::OpenProcessToken(::GetCurrentProcess(), TOKEN_QUERY, &token))
+    return false; // cannot determine — fail safe to non-elevated behaviour
+
+  TOKEN_ELEVATION elevation = {};
+  DWORD size = sizeof(elevation);
+  bool elevated = ::GetTokenInformation(token, TokenElevation,
+                                        &elevation, size, &size)
+                  && elevation.TokenIsElevated;
+  ::CloseHandle(token);
+  return elevated;
+}
+
 } // xrt_core::utils::detail
 #endif
 

--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -354,4 +354,10 @@ strerror(int err)
   return detail::strerror(err);
 }
 
+bool
+is_elevated_process()
+{
+  return detail::is_elevated_process();
+}
+
 } // xrt_core::utils

--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -154,6 +154,15 @@ XRT_CORE_COMMON_EXPORT
 std::string
 strerror(int err);
 
+// is_elevated_process() - returns true when running with elevated privileges.
+//
+// On Linux: true when effective UID is 0 (root).
+// On Windows: true when the process token is UAC-elevated (Run as Administrator).
+// Used to restrict untrusted config-file search paths (SWSPLAT-39875 / CWE-427).
+XRT_CORE_COMMON_EXPORT
+bool
+is_elevated_process();
+
 } // xrt_core::utils
 
 #endif


### PR DESCRIPTION
#### Problem solved by the commit
get_ini_path() fell back to std::filesystem::current_path() for all processes regardless of privilege level. An attacker who can write to a directory from which an admin runs "sudo xbutil/xbmgmt" can plant an xrt.ini that controls plugin load paths (Runtime.external_ip_metadata, profiling plugin paths, hw_em launch script), achieving local privilege escalation (CWE-427). The same bypass was possible via the debug() reread path and via XRT_INI_PATH / SDACCEL_INI_PATH environment variables when running as root.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered 
SWSPLAT-39875 (CWE-427, CVSS 5.4). Discovered by Mythos security audit.

#### How problem was solved, alternative solutions (if any) and why they were rejected 
Added xrt_core::utils::is_elevated_process() following the existing detail/ pattern used by getenv/strerror:
- detail/linux/utils.h: geteuid()==0
- detail/windows/utils.h: TokenElevation UAC check via GetTokenInformation (checks token elevation rather than group membership so non-elevated Administrators are not affected)
- utils.h/utils.cpp: public declaration and delegation

config_reader.cpp uses is_elevated_process() to skip CWD, environment variable paths, and reread() when elevated. Non-root/non-elevated users retain the full existing search order including CWD. All platform- specific #ifdef code is removed from config_reader.cpp.

#### Risks (if any) associated the changes in the commit 
Low for non-privileged users — behavior unchanged. Elevated processes (root / Run-as-Administrator) will no longer pick up xrt.ini from CWD or env vars; the executable-directory search still applies.

#### What has been tested and how, request additional testing if necessary 
Code inspection. Recommend testing: (1) non-root user with xrt.ini in CWD still loaded; (2) root user with xrt.ini in CWD not loaded; (3) root user with xrt.ini in executable directory still loaded.
