### PR TITLE
SWSPLAT-30733 fix negative array index in ert_write/read_return_code macros

### DIFF
--- a/src/runtime_src/core/include/xrt/detail/ert.h
+++ b/src/runtime_src/core/include/xrt/detail/ert.h
@@ -233,18 +233,23 @@ struct ert_cmd_chain_data {
 };
 
 #ifndef U30_DEBUG
+/* Guard against malformed packet where count <= extra_cu_masks (SWSPLAT-30733 / CWE-787).
+ * Both fields are uint32_t; cast to int before arithmetic to prevent unsigned
+ * wraparound producing a large positive value that becomes a negative index. */
 #define ert_write_return_code(cmd, value) \
 do { \
   struct ert_start_kernel_cmd *skcmd = (struct ert_start_kernel_cmd *)cmd; \
-  int end_idx = skcmd->count - 1 - skcmd->extra_cu_masks; \
-  skcmd->data[end_idx] = value; \
+  int end_idx = (int)skcmd->count - 1 - (int)skcmd->extra_cu_masks; \
+  if (end_idx >= 0) \
+    skcmd->data[end_idx] = value; \
 } while (0)
 
 #define ert_read_return_code(cmd, ret) \
 do { \
   struct ert_start_kernel_cmd *skcmd = (struct ert_start_kernel_cmd *)cmd; \
-  int end_idx = skcmd->count - 1 - skcmd->extra_cu_masks; \
-  ret = skcmd->data[end_idx]; \
+  int end_idx = (int)skcmd->count - 1 - (int)skcmd->extra_cu_masks; \
+  if (end_idx >= 0) \
+    ret = skcmd->data[end_idx]; \
 } while (0)
 #else
 /* These are for debug legacy U30 firmware */


### PR DESCRIPTION
#### Problem solved by the commit
count and extra_cu_masks are both uint32_t. Without explicit casts, count - 1 - extra_cu_masks is unsigned arithmetic: when count == 0, the intermediate result wraps to 0xFFFFFFFF before the subtraction, and the subsequent cast to int end_idx produces a large negative value. skcmd->data[end_idx] then writes or reads before the packet buffer (CWE-787 / CWE-125). ert_read_return_code had the identical bug but was not mentioned in the original finding.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered 
SWSPLAT-30733 (CWE-787, CVSS 3.8). Discovered by Mythos AI security audit (MYTHOS-RyzenAI-XRT-L2). Current callers are gated behind PS-kernel/KDS paths, but the header is shared and any future consumer would inherit the bug.

#### How problem was solved, alternative solutions (if any) and why they were rejected 
Cast both operands to int before arithmetic so the subtraction is signed and cannot wrap. Add end_idx >= 0 guard before the array access. Silent skip (rather than assert/throw) is appropriate here because the header must remain C-compatible for kernel consumers.

#### Risks (if any) associated the changes in the commit 
Negligible — a malformed packet with count <= extra_cu_masks already produces undefined behaviour; the guard makes it a safe no-op instead.

#### What has been tested and how, request additional testing if necessary 
Code inspection. Existing ERT command tests cover the normal path.