### PR TITLE
SWSPLAT-30732 fix off-by-one in device::get_memory_type() bounds check

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -349,7 +349,7 @@ device::
 get_memory_type(size_t memidx) const
 {
   auto mem_topology = get_axlf_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY);
-  if (!mem_topology || mem_topology->m_count < static_cast<int32_t>(memidx))
+  if (!mem_topology || static_cast<int32_t>(memidx) >= mem_topology->m_count)
     throw error(EINVAL, "invalid memory bank index");
 
   const auto& mem = mem_topology->m_mem_data[memidx];


### PR DESCRIPTION
#### Problem solved by the commit
The guard used m_count < static_cast<int32_t>(memidx), which allows memidx == m_count to pass. This causes m_mem_data[memidx] to read one element (~40 bytes) past the end of the mem_topology section (CWE-193). The result is used for memory-type classification; incorrect type can propagate to downstream BO allocation decisions.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered 
SWSPLAT-30732 (CWE-193, CVSS 2.3). Discovered by Mythos AI security audit (MYTHOS-RyzenAI-XRT-L1).

#### How problem was solved, alternative solutions (if any) and why they were rejected 
Changed the comparison to static_cast<int32_t>(memidx) >= m_count, which correctly rejects memidx == m_count (one-past-end) and also makes the signed/unsigned comparison explicit and safe.

#### Risks (if any) associated the changes in the commit 
Negligible — the condition is now strictly correct; previously valid indices (memidx < m_count) continue to pass.

#### What has been tested and how, request additional testing if necessary 
Code inspection. Recommend adding a test with memidx == m_count and verifying EINVAL is thrown.

