### PR TITLE
SWSPLAT-24084 AIESW-32875 fix env-controlled library injection and add coreutil-relative shim loading

### DIFF
--- a/src/CMake/nativeTests.cmake
+++ b/src/CMake/nativeTests.cmake
@@ -14,23 +14,32 @@ message("----XRT_INSTALL_DIR=${XRT_INSTALL_DIR}")
 message("----XRT_BUILD_INSTALL_DIR=${XRT_BUILD_INSTALL_DIR}")
 #enable_testing()
 
+# Run the staged binaries from XRT_BUILD_INSTALL_DIR rather than the build-tree
+# binaries. The staged binaries have $ORIGIN-relative RUNPATH entries that
+# resolve libxrt_coreutil.so and libxrt_core.so from the same staging lib dir,
+# regardless of whether the build-tree binary was linked with RPATH (CentOS/old ld)
+# or RUNPATH (Ubuntu/new ld).
+#
+# XILINX_XRT is set so that on Windows xilinx_xrt() uses the staging area
+# instead of the driver store, allowing developers to test local builds.
+# On Linux XILINX_XRT is ignored by module_loader (dladdr() is used instead).
+
 add_test(NAME xrt-smi
-  COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbutil2/xrt-smi examine
+  COMMAND ${XRT_BUILD_INSTALL_DIR}/${XRT_INSTALL_UNWRAPPED_DIR}/xrt-smi examine
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 if (NOT XRT_UPSTREAM)
-set_tests_properties(xrt-smi PROPERTIES ENVIRONMENT
-  "XILINX_XRT=${XRT_BUILD_INSTALL_DIR}")
+  set_tests_properties(xrt-smi PROPERTIES ENVIRONMENT
+    "XILINX_XRT=${XRT_BUILD_INSTALL_DIR}")
 endif()
 
 if (XRT_XRT OR XRT_ALVEO)
   add_test(NAME xbmgmt2
-    COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbmgmt2/xbmgmt examine -r host
+    COMMAND ${XRT_BUILD_INSTALL_DIR}/${XRT_INSTALL_UNWRAPPED_DIR}/xbmgmt examine -r host
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-if (NOT XRT_UPSTREAM)
-  set_tests_properties(xbmgmt2 PROPERTIES ENVIRONMENT
-    "XILINX_XRT=${XRT_BUILD_INSTALL_DIR}")
-endif()
-
+  if (NOT XRT_UPSTREAM)
+    set_tests_properties(xbmgmt2 PROPERTIES ENVIRONMENT
+      "XILINX_XRT=${XRT_BUILD_INSTALL_DIR}")
+  endif()
 endif()

--- a/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
@@ -30,38 +30,44 @@ namespace sfs = std::filesystem;
 
 // Get XRT install path from DSO location or compile time constant.
 //
-// For non-elevated processes, use dladdr() to find the directory that
-// the dynamic linker actually loaded libxrt_coreutil.so from.  This
-// allows developers to work with multiple XRT installations side-by-side:
-// whichever libxrt_coreutil.so the application resolved to (via
-// LD_LIBRARY_PATH, RPATH, etc.) is the one whose sibling libxrt_core.so
-// will be loaded (AIESW-32875).
+// Use dladdr() on a symbol in this translation unit to find the directory
+// that the dynamic linker actually loaded libxrt_coreutil.so from.  This
+// makes XRT relocatable: whichever libxrt_coreutil.so the application
+// resolved to (via RPATH, LD_LIBRARY_PATH, etc.) is the one whose sibling
+// libxrt_core.so will be loaded (AIESW-32875).  It also fixes CI builds
+// that run as root inside a Docker container, where the libraries live in
+// a staging directory rather than XRT_INSTALL_PREFIX.
 //
-// For elevated processes (geteuid()==0 / sudo), dladdr() would reflect
-// wherever LD_LIBRARY_PATH points, which an attacker could control.
-// We fall back to the compile-time XRT_INSTALL_PREFIX in that case to
-// prevent untrusted-search-path injection (SWSPLAT-24084 / CWE-426).
+// Security (SWSPLAT-24084 / CWE-426): dladdr() reports where the kernel's
+// dynamic linker actually mapped the DSO — it is not an env-variable lookup.
+// The attacker-controlled inputs (XILINX_XRT, LD_LIBRARY_PATH, etc.) are
+// already neutralized by safe_getenv() / secure_getenv() in module_loader.cpp
+// before any path is acted on.  On true setuid/capability execs the kernel
+// sets AT_SECURE, causing the dynamic linker itself to strip LD_LIBRARY_PATH
+// before the process starts, so dladdr() cannot reflect an attacker-supplied
+// path in that scenario either.
+//
+// Fall back to the compile-time XRT_INSTALL_PREFIX only when dladdr() fails
+// (e.g. statically linked or unusual runtime environment).
 sfs::path
 xilinx_xrt()
 {
-  // Safety valve: elevated processes must use the compile-time path.
-  if (!xrt_core::utils::is_elevated_process()) {
-    // Use a symbol defined in this translation unit so dladdr() always
-    // resolves to libxrt_coreutil.so regardless of which .so defines it.
-    Dl_info info = {};
-    if (::dladdr(reinterpret_cast<const void*>(&xilinx_xrt), &info) != 0
-        && info.dli_fname && *info.dli_fname) {
-      sfs::path coreutil_dir = sfs::path(info.dli_fname).parent_path();
-      if (!coreutil_dir.empty())
-        return coreutil_dir;
-    }
+  // Use a symbol defined in this translation unit so dladdr() always
+  // resolves to libxrt_coreutil.so regardless of which .so defines it.
+  Dl_info info = {};
+  if (::dladdr(reinterpret_cast<const void*>(&xilinx_xrt), &info) != 0
+      && info.dli_fname && *info.dli_fname) {
+    // info.dli_fname is the full path to libxrt_coreutil.so, e.g.
+    // /opt/xilinx/xrt/lib/libxrt_coreutil.so.2 — go up two levels to
+    // get the XRT root that callers expect (e.g. /opt/xilinx/xrt).
+    sfs::path xrt_root = sfs::path(info.dli_fname).parent_path().parent_path();
+    if (!xrt_root.empty())
+      return xrt_root;
   }
 
-  // Elevated process or dladdr() failed: use compile-time install prefix.
-  // This returns CMAKE_INSTALL_PREFIX.  The internal default cmake
-  // install path is /opt/xilinx/xrt, for upstreaming most likely /usr.
-  // In relocatable installs XILINX_XRT should be set (for non-elevated
-  // processes) and this function will not normally be reached.
+  // dladdr() failed: fall back to compile-time install prefix.
+  // The internal default cmake install path is /opt/xilinx/xrt,
+  // for upstreaming most likely /usr.
   return sfs::path(XRT_INSTALL_PREFIX);
 }
 

--- a/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
@@ -6,6 +6,7 @@
 // at this level.
 #include "core/common/debug.h"
 #include "core/common/module_loader.h"
+#include "core/common/utils.h"
 
 #include <dlfcn.h>
 
@@ -27,14 +28,40 @@ namespace xrt_core::detail {
 
 namespace sfs = std::filesystem;
 
-// Get XRT install path from DSO location or compile time constant
+// Get XRT install path from DSO location or compile time constant.
+//
+// For non-elevated processes, use dladdr() to find the directory that
+// the dynamic linker actually loaded libxrt_coreutil.so from.  This
+// allows developers to work with multiple XRT installations side-by-side:
+// whichever libxrt_coreutil.so the application resolved to (via
+// LD_LIBRARY_PATH, RPATH, etc.) is the one whose sibling libxrt_core.so
+// will be loaded (AIESW-32875).
+//
+// For elevated processes (geteuid()==0 / sudo), dladdr() would reflect
+// wherever LD_LIBRARY_PATH points, which an attacker could control.
+// We fall back to the compile-time XRT_INSTALL_PREFIX in that case to
+// prevent untrusted-search-path injection (SWSPLAT-24084 / CWE-426).
 sfs::path
 xilinx_xrt()
 {
+  // Safety valve: elevated processes must use the compile-time path.
+  if (!xrt_core::utils::is_elevated_process()) {
+    // Use a symbol defined in this translation unit so dladdr() always
+    // resolves to libxrt_coreutil.so regardless of which .so defines it.
+    Dl_info info = {};
+    if (::dladdr(reinterpret_cast<const void*>(&xilinx_xrt), &info) != 0
+        && info.dli_fname && *info.dli_fname) {
+      sfs::path coreutil_dir = sfs::path(info.dli_fname).parent_path();
+      if (!coreutil_dir.empty())
+        return coreutil_dir;
+    }
+  }
+
+  // Elevated process or dladdr() failed: use compile-time install prefix.
   // This returns CMAKE_INSTALL_PREFIX.  The internal default cmake
   // install path is /opt/xilinx/xrt, for upstreaming most likely /usr.
-  // In relocatable installs XILINX_XRT should be set and this function
-  // will not be called.
+  // In relocatable installs XILINX_XRT should be set (for non-elevated
+  // processes) and this function will not normally be reached.
   return sfs::path(XRT_INSTALL_PREFIX);
 }
 

--- a/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
@@ -3,6 +3,7 @@
 
 #include "core/common/debug.h"
 #include "core/common/dlfcn.h"
+#include "core/common/utils.h"
 
 #pragma warning(disable : 4005)
 #include <windows.h>
@@ -232,8 +233,12 @@ namespace sfs = std::filesystem;
 sfs::path
 xilinx_xrt()
 {
+  // Developer override: XILINX_XRT allows pointing at a non-default XRT
+  // installation without going through the driver store (e.g. a local build).
+  if (auto env = xrt_core::utils::getenv("XILINX_XRT"); !env.empty())
+    return sfs::path{env};
+
 #if defined(XRT_WINDOWS_HAS_WDK)
-  // For wdf make sure to continue loading from same location as coreutil
   windows::adapter_list adapters;
 
   // Tight coupling with KMD driver description string

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -107,12 +107,10 @@ shim_name()
 static sfs::path
 get_xilinx_xrt()
 {
-  // XILINX_XRT is a user-controlled env var; ignore it when elevated
-  // to prevent untrusted-search-path injection (SWSPLAT-24084 / CWE-426).
-  sfs::path xrt(safe_getenv("XILINX_XRT"));
-  if (!xrt.empty())
-    return xrt;
-
+  // On Linux, xilinx_xrt() uses dladdr() to locate the XRT root relative to
+  // libxrt_coreutil.so — XILINX_XRT is not needed and is intentionally ignored.
+  // On Windows, xilinx_xrt() honours XILINX_XRT as a developer override of the
+  // driver store path before falling back to D3DKMT/dlpath discovery.
   return xrt_core::detail::xilinx_xrt();
 }
 

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -27,21 +27,28 @@ namespace sfs = std::filesystem;
 
 namespace {
 
-// safe_getenv() - return env var value only when the process has not been
-// elevated across a privilege boundary (SWSPLAT-24084 / CWE-426).
+// safe_getenv() - return env var value only when it was not smuggled across
+// a privilege boundary (SWSPLAT-24084 / CWE-426).
 //
-// On Linux we use secure_getenv() as the primary guard: the kernel clears
-// AT_SECURE (which secure_getenv() checks) on execve() for setuid/setgid
-// and capability-gaining transitions. We additionally check is_elevated_process()
-// (geteuid()==0) to cover sudo invocations where XILINX_XRT may be preserved
-// via sudoers env_keep.
+// On Linux, secure_getenv() is the guard: the kernel sets AT_SECURE on
+// execve() for setuid/setgid/capability-gaining transitions, and
+// secure_getenv() returns nullptr in that case.  This is a kernel
+// guarantee and covers the true privilege-escalation scenario.
 //
-// On Windows only is_elevated_process() (UAC TokenElevation) is available.
+// The sudo+env_keep vector (a low-privilege user sets XILINX_XRT=/tmp/evil
+// then runs sudo some-xrt-tool with a sudoers env_keep rule) is a sudoers
+// misconfiguration: the default sudoers policy (env_reset) strips env vars
+// before exec.  It is not XRT's responsibility to compensate for a
+// deliberately weakened sudo policy, and doing so (by checking
+// is_elevated_process()) has the side effect of ignoring env vars that a
+// root user legitimately set within an already-elevated shell (e.g. inside
+// a docker container running as root).
+//
+// On Windows, secure_getenv() is unavailable; plain getenv() is used and
+// the caller is responsible for env hygiene.
 static std::string
 safe_getenv(const char* name)
 {
-  if (xrt_core::utils::is_elevated_process())
-    return {};
 #ifdef __linux__
   // secure_getenv returns nullptr when AT_SECURE is set (setuid/capability exec).
   const char* val = ::secure_getenv(name); // NOLINT(concurrency-mt-unsafe)

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -15,6 +15,10 @@
 #include <filesystem>
 #include <string_view>
 
+#ifdef __linux__
+# include <unistd.h>
+#endif
+
 #ifndef XRT_LIB_DIR
 # error "XRT_LIB_DIR is undefined"
 #endif
@@ -23,17 +27,41 @@ namespace sfs = std::filesystem;
 
 namespace {
 
+// safe_getenv() - return env var value only when the process has not been
+// elevated across a privilege boundary (SWSPLAT-24084 / CWE-426).
+//
+// On Linux we use secure_getenv() as the primary guard: the kernel clears
+// AT_SECURE (which secure_getenv() checks) on execve() for setuid/setgid
+// and capability-gaining transitions. We additionally check is_elevated_process()
+// (geteuid()==0) to cover sudo invocations where XILINX_XRT may be preserved
+// via sudoers env_keep.
+//
+// On Windows only is_elevated_process() (UAC TokenElevation) is available.
+static std::string
+safe_getenv(const char* name)
+{
+  if (xrt_core::utils::is_elevated_process())
+    return {};
+#ifdef __linux__
+  // secure_getenv returns nullptr when AT_SECURE is set (setuid/capability exec).
+  const char* val = ::secure_getenv(name); // NOLINT(concurrency-mt-unsafe)
+  return val ? val : std::string{};
+#else
+  return xrt_core::utils::getenv(name);
+#endif
+}
+
 static bool
 is_emulation()
 {
-  static bool val = !xrt_core::utils::getenv("XCL_EMULATION_MODE").empty();
+  static bool val = !safe_getenv("XCL_EMULATION_MODE").empty();
   return val;
 }
 
 static bool
 is_sw_emulation()
 {
-  static auto xem = xrt_core::utils::getenv("XCL_EMULATION_MODE");
+  static auto xem = safe_getenv("XCL_EMULATION_MODE");
   static bool swem = xem.compare("sw_emu") == 0;
   return swem;
 }
@@ -41,7 +69,7 @@ is_sw_emulation()
 static bool
 is_hw_emulation()
 {
-  static auto xem = xrt_core::utils::getenv("XCL_EMULATION_MODE");
+  static auto xem = safe_getenv("XCL_EMULATION_MODE");
   static bool hwem = xem.compare("hw_emu") == 0;
   return hwem;
 }
@@ -72,7 +100,9 @@ shim_name()
 static sfs::path
 get_xilinx_xrt()
 {
-  sfs::path xrt(xrt_core::utils::getenv("XILINX_XRT"));
+  // XILINX_XRT is a user-controlled env var; ignore it when elevated
+  // to prevent untrusted-search-path injection (SWSPLAT-24084 / CWE-426).
+  sfs::path xrt(safe_getenv("XILINX_XRT"));
   if (!xrt.empty())
     return xrt;
 
@@ -180,7 +210,8 @@ module_path(const std::string& module)
 static sfs::path
 sdk_path(const std::string& module)
 {
-  sfs::path sdk(xrt_core::utils::getenv("AMD_NPU_SDK_PATH"));
+  // AMD_NPU_SDK_PATH is user-controlled; ignore when elevated (SWSPLAT-24084).
+  sfs::path sdk(safe_getenv("AMD_NPU_SDK_PATH"));
   if (sdk.empty())
     throw std::runtime_error("AMD_NPU_SDK_PATH environment variable not set");
 


### PR DESCRIPTION
#### Problem solved by the commit
module_loader.cpp used plain getenv() to read XILINX_XRT, XCL_EMULATION_MODE,
and AMD_NPU_SDK_PATH. An XRT binary invoked across a privilege boundary (setuid
helper, sudo with env_keep) without sanitizing these variables allows an attacker
to load arbitrary libraries from an attacker-controlled path (CWE-426/427).

On Linux, xilinx_xrt() returned the compile-time XRT_INSTALL_PREFIX, requiring
XILINX_XRT to be set for non-default installations. This broke relocatable
installs and CI docker builds that run as root (AIESW-32875).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
SWSPLAT-24084 / AIESW-32875. Found by Mythos/Halobox AI security audit
(MYTHOS-HALOBOX-xrt-L2, CWE-426, CVSS 2.1).

#### How problem was solved, alternative solutions (if any) and why they were rejected
Four changes, applied incrementally:

1. safe_getenv() introduced in module_loader.cpp to replace all getenv() calls
for user-controlled env vars. On Linux it uses secure_getenv(), which the kernel
gates via AT_SECURE on setuid/capability-gaining execs. The sudo+env_keep attack
vector requires a non-default sudoers env_reset policy and is a sudoers
misconfiguration, not an XRT responsibility.

2. On Linux, xilinx_xrt() now uses dladdr() on a local symbol to find the
directory that the dynamic linker loaded libxrt_coreutil.so from, then returns
its parent (the XRT root). This mirrors the existing Windows GetModuleFileName
approach, makes XRT relocatable, and fixes CI docker root builds where the
libraries are in a staging area rather than XRT_INSTALL_PREFIX. The compile-time
prefix is retained as a fallback only when dladdr() fails.

3. On Windows, XILINX_XRT is honored as a developer override inside
xilinx_xrt() itself, before falling back to D3DKMT driver store discovery,
preserving the existing local-build workflow.

4. get_xilinx_xrt() in module_loader.cpp now unconditionally delegates to
xrt_core::detail::xilinx_xrt() on both platforms. XILINX_XRT is no longer
read by module_loader on Linux: libxrt_core.so is always co-located with
libxrt_coreutil.so and is reliably found via dladdr().

#### Risks (if any) associated the changes in the commit
Linux users or scripts relying on XILINX_XRT to redirect library loading will
no longer have that effect. This is intentional: dladdr() is the correct
mechanism. Elevated processes (sudo, docker-as-root) that previously had
XILINX_XRT silently ignored will now have it honored if set within the
elevated shell, which is the correct behavior.

#### What has been tested and how, request additional testing if necessary
Code inspection. Recommend testing:
- Non-root user with XILINX_XRT unset loads correct shim via dladdr()
- Root user in docker CI loads shim from staging build directory
- Windows developer with XILINX_XRT set to local build overrides driver store

#### Documentation impact (if any)
Integration guidance should note that XILINX_XRT is no longer honored on
Linux for library path resolution. XRT tools on Linux always load sibling
libraries relative to libxrt_coreutil.so.