### PR TITLE
AIESW-38806 Remove use of npu3 dll for ML Timeline

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -398,7 +398,7 @@ void
 load()
 {
   static xrt_core::module_loader
-  xdp_ml_timeline_loader(xrt_core::utils::is_env("AMD_XDP_NPU3") ? "xdp_ml_timeline_plugin_npu3" : "xdp_ml_timeline_plugin",
+  xdp_ml_timeline_loader("xdp_ml_timeline_plugin",
                          register_callbacks,
                          warning_callbacks_empty);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

https://jira.xilinx.com/browse/AIESW-38806 ML Timeline plugin is loaded from driver installation. But _npu3.dlls are not installed in driver installation. Thats why, the plugin failed to load. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test on npu3

#### Documentation impact (if any)
