### PR TITLE
Add xrt_ci_test.yml workflow for u50 board testing

### DIFF
--- a/.github/workflows/xrt_ci_test.yml
+++ b/.github/workflows/xrt_ci_test.yml
@@ -1,0 +1,215 @@
+name: XRT CI Test (U50)
+
+on:
+  workflow_dispatch:
+
+env:
+  RELEASE: '2026.2'
+  PIPELINE: 'xrt'
+  ENV: 'prod'
+
+concurrency:
+  group: xrt-ci-test-u50-${{ github.run_number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: centos8
+            packageType: rpm
+          - os: rhel9
+            packageType: rpm
+          - os: rhel8.10
+            packageType: rpm
+          - os: rhel10.0
+            packageType: rpm
+          - os: hip
+            packageType: deb
+          - os: npu
+            packageType: deb
+          - os: npu2404
+            packageType: deb
+    runs-on: [self-hosted, Ubuntu-22.04]
+    steps:
+      - name: Set env variables
+        run: |
+          echo "XRT_VERSION_PATCH=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          echo "PATH=/usr/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Checkout XRT
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: ${{ github.workspace }}/${{ github.run_number }}
+          submodules: recursive
+
+      - name: Checkout composite workflows
+        uses: actions/checkout@v3
+        with:
+          repository: actions-int/composite-workflows
+          github-server-url: ${{ secrets.SERVER_URL }}
+          token: ${{ secrets.ACCESS_TOKEN }}
+          path: composite-workflows
+          ref: main
+
+      - name: XRT build
+        uses: ./composite-workflows/build
+        with:
+          pipeline: ${{ env.PIPELINE }}
+          osVersion: ${{ matrix.os }}
+          packageType: ${{ matrix.packageType }}
+          workspace: ${{ github.workspace }}
+          buildNumber: ${{ github.run_number }}
+          accessToken: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+          appConfig: ${{ secrets.APP_CONFIG }}
+          appConfig1: ${{ secrets.APP_CONFIG1 }}
+          appConfig2: ${{ secrets.APP_CONFIG2 }}
+          appConfig3: ${{ secrets.APP_CONFIG3 }}
+
+  package-download:
+    needs: build
+    runs-on: [self-hosted, Ubuntu-22.04]
+    steps:
+      - name: Checkout composite workflows
+        uses: actions/checkout@v3
+        with:
+          repository: actions-int/composite-workflows
+          token: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+          path: composite-workflows
+          ref: main
+
+      - name: Download packages
+        uses: ./composite-workflows/package-download
+        with:
+          runNumber: ${{ github.run_number }}
+          pipeline: ${{ env.PIPELINE }}
+          env: ${{ env.ENV }}
+          release: ${{ env.RELEASE }}
+          sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}
+          accessToken: ${{ secrets.ACCESS_TOKEN }}
+          NPATH: ${{ secrets.NPATH }}
+          USER: ${{ secrets.USER }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+
+  extract-platforms:
+    needs: package-download
+    runs-on: [self-hosted, Ubuntu-22.04]
+    outputs:
+      board_list: ${{ steps.extract.outputs.board_list }}
+    steps:
+      - name: Checkout extraction-action
+        uses: actions/checkout@v3
+        with:
+          repository: actions-int/extraction-action
+          ref: 'gevadlam/add-testsPath-boardFilter'
+          token: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+          path: ./.github/actions/extraction-action
+
+      - name: Extract u50 platforms
+        id: extract
+        uses: ./.github/actions/extraction-action
+        with:
+          release: ${{ env.RELEASE }}
+          env: ${{ env.ENV }}
+          pipeline: ${{ env.PIPELINE }}
+          boardType: 'pcie'
+          boardMode: 'hw'
+          testsPath: '/proj/sdxbf/xrt-test/2026.2'
+          boardFilter: '^xilinx_u50'
+
+  pcie-hw-tests:
+    needs: extract-platforms
+    runs-on: [self-hosted, Ubuntu-22.04]
+    strategy:
+      fail-fast: false
+      matrix:
+        board_list: ${{ fromJson(needs.extract-platforms.outputs.board_list) }}
+    steps:
+      - name: Checkout composite workflows
+        uses: actions/checkout@v3
+        with:
+          repository: actions-int/composite-workflows
+          token: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+          path: composite-workflows
+          ref: main
+
+      - name: Run pcie-hw tests for ${{ matrix.board_list }}
+        uses: ./composite-workflows/pcie-hw
+        with:
+          organization: ${{ github.repository }}
+          runNumber: ${{ github.run_number }}
+          buildNumber: ${{ github.run_number }}_${{ github.run_attempt }}
+          release: ${{ env.RELEASE }}
+          env: ${{ env.ENV }}
+          pipeline: ${{ env.PIPELINE }}
+          boardType: 'pcie'
+          boardState: 'gating'
+          boardMode: 'hw'
+          workspace: ${{ github.workspace }}
+          USER: ${{ secrets.USER }}
+          board: ${{ matrix.board_list }}
+          runnerName: ${{ runner.name }}
+          accessToken: ${{ secrets.ACCESS_TOKEN }}
+          sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}
+          apiKey: ${{ secrets.apiKey }}
+          NPATH: ${{ secrets.NPATH }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+
+  test-summary:
+    runs-on: [self-hosted, Ubuntu-22.04]
+    needs: pcie-hw-tests
+    if: always()
+    steps:
+      - name: Checkout XOAH URL action
+        uses: actions/checkout@v3
+        with:
+          repository: actions-int/XOAH-URL-action
+          ref: 'XOAH_URL_action'
+          token: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+          path: ./.github/actions/XOAH-URL-action
+
+      - name: Generate test summary URL
+        id: summary
+        uses: ./.github/actions/XOAH-URL-action
+        with:
+          pipeline: ${{ env.PIPELINE }}
+          release: ${{ env.RELEASE }}
+          runNumber: ${{ github.run_number }}_${{ github.run_attempt }}
+          env: ${{ env.ENV }}
+
+      - name: Print test summary URL
+        run: |
+          echo '### [tests logs summary](${{ steps.summary.outputs.url }})' >> $GITHUB_STEP_SUMMARY
+
+  cleanup-build:
+    needs: test-summary
+    runs-on: [self-hosted, Ubuntu-22.04]
+    steps:
+      - name: Checkout composite workflows
+        uses: actions/checkout@v3
+        with:
+          repository: actions-int/composite-workflows
+          token: ${{ secrets.ACCESS_TOKEN }}
+          github-server-url: ${{ secrets.SERVER_URL }}
+          path: composite-workflows
+          ref: main
+
+      - name: Cleanup
+        uses: ./composite-workflows/cleanup
+        with:
+          runNumber: ${{ github.run_number }}
+          pipeline: ${{ env.PIPELINE }}
+          env: ${{ env.ENV }}
+          release: ${{ env.RELEASE }}
+          sshKey: ${{ secrets.CI_PRIVATE_SSH_KEY }}
+          accessToken: ${{ secrets.ACCESS_TOKEN }}
+          NPATH: ${{ secrets.NPATH }}
+          USER: ${{ secrets.USER }}
+          github-server-url: ${{ secrets.SERVER_URL }}


### PR DESCRIPTION
New workflow_dispatch-triggered CI pipeline for u50 PCIE boards. Uses the updated extraction-action (v0.0.3) with testsPath override to discover u50 platforms from /proj/sdxbf/xrt-test/2026.2/ and boardFilter to select only xilinx_u50 platforms.

Full pipeline: build → package-download → extract-platforms → pcie-hw-tests (matrix over 3 u50 variants) → test-summary → cleanup.
