### PR TITLE
Fix windows regression from SWSPLAT-24084 (#9915)

### DIFF
--- a/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/windows/xilinx_xrt.h
@@ -230,14 +230,12 @@ namespace xrt_core::detail {
 
 namespace sfs = std::filesystem;
 
+// The system Xilinx XRT installation path is determined by querying
+// the driver store for the AMD XDNA(TM) NPU adapter.  If not found,
+// the coreutil path is returned.
 sfs::path
-xilinx_xrt()
+system_xilinx_xrt()
 {
-  // Developer override: XILINX_XRT allows pointing at a non-default XRT
-  // installation without going through the driver store (e.g. a local build).
-  if (auto env = xrt_core::utils::getenv("XILINX_XRT"); !env.empty())
-    return sfs::path{env};
-
 #if defined(XRT_WINDOWS_HAS_WDK)
   windows::adapter_list adapters;
 
@@ -259,11 +257,22 @@ xilinx_xrt()
 #endif
 }
 
+sfs::path
+xilinx_xrt()
+{
+  // Developer override: XILINX_XRT allows pointing at a non-default XRT
+  // installation without going through the driver store (e.g. a local build).
+  if (auto env = xrt_core::utils::getenv("XILINX_XRT"); !env.empty())
+    return sfs::path{env};
+
+  return system_xilinx_xrt();
+}
+
 std::vector<sfs::path>
 platform_repo_path()
 {
-  // For time being, platform repo is same as xilinx_xrt
-  return {xilinx_xrt()};
+  // Platform repo path defaults to driver store even if XILINX_XRT is set
+  return {system_xilinx_xrt()};
 }
 
 } // xrt_core::detail


### PR DESCRIPTION
#### Problem solved by the commit
Repo path on windows is default relative to driver store; ignore XILINX_XRT always.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This was a bug introduced in #9915, where XILINX_XRT check was moved to the code path used by repo path.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Refactor detail::xilinx_xrt().

