### PR TITLE
Release version-git.h for inter release feature check (#9923)

### DIFF
--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -161,7 +161,7 @@ endif()
 
 # xrt component install
 install(FILES
-  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version.h
+  ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-git.h
   ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/xrt/detail
   COMPONENT ${XRT_BASE_DEV_COMPONENT})
@@ -178,6 +178,7 @@ if (XRT_ALVEO AND (NOT XRT_EDGE) AND (NOT WIN32) AND XRT_ENABLE_DKMS)
   set (XRT_DKMS_INSTALL_DIR "/usr/src/xrt-${XRT_VERSION_STRING}")
   install(FILES
     ${PROJECT_BINARY_DIR}/gen/xrt/detail/version.h
+    ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-git.h
     ${PROJECT_BINARY_DIR}/gen/xrt/detail/version-slim.h
     DESTINATION ${XRT_DKMS_INSTALL_DIR}/driver/include
     COMPONENT ${XRT_DEV_COMPONENT})


### PR DESCRIPTION
#### Problem solved by the commit
XRT client code relying on Git metadata is not cool, but occasionally needed.  For example, in the middle of a release cycle where a feature is introduced, users of XRT may need a compile time check for the availability.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The problem is that upstreamed builds of XRT (Debian and Fedora) carry no Git metadata, and version-git.h would provide no help.  It is the users responsibility to relax the compile time guard with the XRT_VERSION_CODE greater than or equal to next minor release.

#### How problem was solved, alternative solutions (if any) and why they were rejected
As an example, assume code is developed against XRT 2.22, a feature was enabled at commit level 8195.   This feature can be used in the code under the following conditions:

  #include <xrt/detail/version-git.h>
  #if (XRT_HEAD_COMMITS >= 8195) || (XRT_VERSION_CODE >= XRT_VERSION(2,23))
  ...new code...
  #else
  ...old code...
  #endif

`XRT_HEAD_COMMITS` require Git metadata but `XRT_VERSION_CODE` does not.

(cherry picked from commit a21f10d59b51e9235b7c90b804470fce9650cfa0)

