### PR TITLE
Increase default ML Timeline debug buffer size and add new ML_timeline_settings.buffer_config

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -260,14 +260,14 @@ get_ml_timeline()
 inline std::string
 get_ml_timeline_settings_buffer_size()
 {
-  static std::string value = detail::get_string_value("ML_timeline_settings.buffer_size", "192K");
+  static std::string value = detail::get_string_value("ML_timeline_settings.buffer_size", "1920K");
   return value;
 }
 
-inline unsigned int
-get_ml_timeline_settings_num_buffer_segments()
+inline std::string
+get_ml_timeline_settings_buffer_config()
 {
-  static unsigned int value = detail::get_uint_value("ML_timeline_settings.num_buffer_segments", 0);
+  static unsigned int value = detail::get_uint_value("ML_timeline_settings.buffer_config", "");
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -267,7 +267,7 @@ get_ml_timeline_settings_buffer_size()
 inline std::string
 get_ml_timeline_settings_buffer_config()
 {
-  static unsigned int value = detail::get_uint_value("ML_timeline_settings.buffer_config", "");
+  static std::string value = detail::get_string_value("ML_timeline_settings.buffer_config", "");
   return value;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Increase default size of ML Timeline debug buffer to capture more data without overwriting
2. Introduce ML_timeline_settings.buffer_config to accept ML Timeline debug buffer configuration with shim column, index of uC
3. Remove ML_timeline_settings.num_buffer_segments config in xrt.ini

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-39288

#### How problem was solved, alternative solutions (if any) and why they were rejected
Input config info from user

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Unit test

#### Documentation impact (if any)
