### PR TITLE
AIESW-32262: Fix xrt::bo::get_memory_group() for cross-device imported BOs

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -170,6 +170,25 @@ public:
   }
 };
 
+// derive memory bank on the importing device from BO physical address
+static uint32_t
+get_imported_group_id(const device_type& dev, uint64_t paddr, uint32_t fallback)
+{
+  auto* core_dev = dev.get_core_device();
+  if (!core_dev)
+    return fallback;
+
+  auto mem_topology = core_dev->get_axlf_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY);
+  if (!mem_topology)
+    return fallback;
+
+  auto memidx = xrt_core::xclbin::address_to_memidx(mem_topology, paddr);
+  if (memidx == std::numeric_limits<int32_t>::max())
+    return fallback;
+
+  return static_cast<uint32_t>(memidx);
+}
+
 } // namespace
 
 namespace xrt {
@@ -212,6 +231,11 @@ private:
     xcl_bo_flags xflags {prop.flags};
     grpid = xflags.bank;
     flags = static_cast<bo::flags>(xflags.flags & ~XRT_BO_FLAGS_MEMIDX_MASK);
+
+    // imported BOs share physical backing from another device; remap the
+    // bank index against this device's MEM_TOPOLOGY
+    if (is_imported())
+      grpid = get_imported_group_id(device, addr, grpid);
   }
 
   // Usage logger for logging buffer stats


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
get_memory_group() returned the wrong bank index for a BO imported
from another device — it used the exporting device's stale bank flag
instead of a value valid on the importing device.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[AIESW-32262](https://jira.xilinx.com/browse/AIESW-32262)
#### How problem was solved, alternative solutions (if any) and why they were rejected
bo_impl::get_bo_properties() now recomputes grpid for imported BOs
(gated by is_imported()) from the BO's physical address, which is
valid on the importing device, using the already-existing but unused
address_to_memidx() helper against the importing device's own
GROUP_TOPOLOGY.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on telluride board with provided test in the ticket [AIESW-32262](https://jira.xilinx.com/browse/AIESW-32262)
#### Documentation impact (if any)
NA