### PR TITLE
[XRT-SMI] Update TCT tests to follow different logic from strix and report throughput

### DIFF
--- a/src/runtime_src/core/tools/common/SmiWatchMode.h
+++ b/src/runtime_src/core/tools/common/SmiWatchMode.h
@@ -70,7 +70,7 @@ public:
  * by any XRT-SMI report. It handles:
  * - Element filter parsing for watch mode options
  * - Signal handling (Ctrl+C interruption) with graceful cleanup
- * - Optional terminal clear between updates (examine --watch only)
+ * - Terminal clear between updates (disabled for streaming firmware-log/event-trace watch)
  * - Optional refresh interval (seconds; 0 = no delay between updates)
  * - Cross-platform compatibility (Windows/POSIX)
  * 
@@ -119,7 +119,8 @@ public:
    * @param output Output stream for the report (typically std::cout)
    * @param report_generator Function to generate report content for each iteration
    * @param refresh_interval_seconds Seconds to sleep after each update before the next (default 0 = no sleep)
-   * @param refresh_terminal If true, clear the terminal before each update after the first (examine reports only).
+   * @param refresh_terminal If true, clear the terminal before each update (default true).
+   *                         Set false for streaming watch modes (firmware-log, event-trace).
    *
    * @note Blocks until user interrupts with Ctrl+C
    */
@@ -128,5 +129,5 @@ public:
                  std::ostream& output,
                  const ReportGenerator& report_generator,
                  unsigned refresh_interval_seconds = 0,
-                 bool refresh_terminal = false);
+                 bool refresh_terminal = true);
 };

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -10,6 +10,7 @@
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
 #include "core/common/archive.h"
+#include "core/common/smi/smi.h"
 
 // System - Include Files
 #include <filesystem>
@@ -17,17 +18,62 @@
 using json = nlohmann::json;
 namespace XBU = XBUtilities;
 
-/* This host application measures the average TCT latency and TCT throughput 
+/* This host application measures the average TCT latency and TCT throughput
  * for all columns tests.
- * The ELF code loopbacks the small chunk of input data from DDR through 
+ * The ELF code loopbacks the small chunk of input data from DDR through
  * a AIE MM2S Shim DMA channel back to DDR through a S2MM Shim DMA channel.
  * TCT is used for dma transfer completion. Host app measures the time for
- * predefined number of Tokens and calculate the latency and throughput.
+ * predefined number of Tokens and calculate the latency and throughput from
+ * the total elapsed time.
  */
 
-//Number of Sample Tokens to measure the throughtput. 
-//This is an assumption coming from elf code running on the device.
-static constexpr int samples = 20000;
+// Number of sample tokens on Strix; assumption from ELF running on the device.
+static constexpr int strix_samples = 20000;
+
+static json
+run_tct_workload(const std::shared_ptr<xrt_core::device>& dev,
+                 const xrt_core::archive* archive,
+                 const std::vector<std::string>& artifacts)
+{
+  const std::string recipe_data = archive->data("recipe_tct_all_column.json");
+  const std::string profile_data = archive->data("profile_tct_all_column.json");
+  const auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, artifacts);
+
+  xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
+  runner.execute();
+  runner.wait();
+
+  return json::parse(runner.get_report());
+}
+
+static void
+calculate_tct_metrics(const json& report,
+                      int strix_token_samples,
+                      double& avg_latency_us,
+                      double& throughput_tct_s)
+{
+  const auto iterations = report["iterations"].get<int>();
+  const double elapsed_us = report["cpu"]["elapsed"].get<double>();
+
+  if (strix_token_samples > 0) {
+    avg_latency_us = elapsed_us / strix_token_samples;
+    throughput_tct_s = (strix_token_samples * iterations * 1000000.0) / elapsed_us; // NOLINT: elapsed is in microseconds
+  } else {
+    avg_latency_us = elapsed_us / iterations;
+    throughput_tct_s = (iterations * 1000000.0) / elapsed_us; // NOLINT: elapsed is in microseconds
+  }
+}
+
+static void
+log_tct_results(boost::property_tree::ptree& ptree,
+                double avg_latency_us,
+                double throughput_tct_s)
+{
+  if (XBU::getVerbose())
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT (all columns): %.1f us") % avg_latency_us));
+
+  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput (all columns): %.1f TCT/s") % throughput_tct_s));
+}
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTAllColumn::TestTCTAllColumn()
@@ -44,38 +90,31 @@ TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
     XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
-  
+
   try {
-    std::string recipe_data = archive->data("recipe_tct_all_column.json");
-    std::string profile_data = archive->data("profile_tct_all_column.json"); 
-    
-    // Extract artifacts using helper method
-    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
-      "tct_all_col.xclbin", 
-      "tct_4col.elf" 
-    });
-    
-    // Create runner with archive data
-    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
-    
-    runner.execute();
-    runner.wait();
+    using query = xrt_core::query::pcie_id;
+    const auto pcie_id = xrt_core::device_query<query>(dev);
+    xrt_core::smi::smi_hardware_config smi_hrdw;
+    const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+    const bool is_strix = XBU::is_strix_hardware(hardware_type);
 
-    // Get final metrics from the last run 
-    auto report = json::parse(runner.get_report());
-    double latency = report["cpu"]["latency"].get<double>(); // Should be in microseconds
-    double throughput = report["cpu"]["throughput"].get<double>(); // Should be in operations/second
+    const std::vector<std::string> artifacts = is_strix
+      ? std::vector<std::string>{"tct_all_col.xclbin", "tct_4col.elf"}
+      : std::vector<std::string>{"tct_4col.elf"};
 
-    if(XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT (all columns): %.1f us") % (latency/samples)));
-    
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput (all columns): %.1f TCT/s") % (samples * throughput)));
+    const auto report = run_tct_workload(dev, archive, artifacts);
+
+    double avg_latency_us = 0.0;
+    double throughput_tct_s = 0.0;
+    calculate_tct_metrics(report, is_strix ? strix_samples : 0, avg_latency_us, throughput_tct_s);
+
+    log_tct_results(ptree, avg_latency_us, throughput_tct_s);
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch(const std::exception& e) {
+  catch (const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
   }
-  
+
   return ptree;
 }

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.h
@@ -7,6 +7,26 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+/**
+ * Measure average Tile Completion Token (TCT) latency and throughput with all
+ * AIE columns active.
+ *
+ * On Strix/PHX (AIE2), the workload uses an xclbin plus ELF and applies a
+ * fixed per-ELF token count when deriving metrics from runner elapsed time.
+ *
+ * On MDS (NPU3 / AIE4), the workload follows the same overall pattern as the
+ * df-bw validate test: the runner loads the TCT ELF, executes it repeatedly,
+ * and reports elapsed time, average latency, and throughput. Differences from
+ * df-bw are:
+ *   - Each ELF run transfers a 256 KiB buffer (two 256 KiB bindings in the
+ *     recipe/profile).
+ *   - The profile runs 1000 iterations; metrics are derived from runner
+ *     elapsed time and iteration count (no fixed token/sample assumption).
+ *   - Completion is detected via the TCT opcode rather than a MASK poll.
+ *
+ * The host-side test reports average TCT latency (us) and TCT throughput
+ * (TCT/s) from the runner report.
+ */
 class TestTCTAllColumn : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*) override;

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -7,8 +7,10 @@
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
 #include "xrt/xrt_device.h"
+#include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
 #include "core/common/archive.h"
+#include "core/common/smi/smi.h"
 
 // System - Include Files
 #include <filesystem>
@@ -16,16 +18,62 @@
 using json = nlohmann::json;
 namespace XBU = XBUtilities;
 
-/* This host application measures the average TCT latency and TCT throughput 
+/* This host application measures the average TCT latency and TCT throughput
  * for one columns tests.
- * The ELF code loopbacks the small chunk of input data from DDR through 
+ * The ELF code loopbacks the small chunk of input data from DDR through
  * a AIE MM2S Shim DMA channel back to DDR through a S2MM Shim DMA channel.
  * TCT is used for dma transfer completion. Host app measures the time for
- * predefined number of Tokens and calculate the latency and throughput.
+ * predefined number of Tokens and calculate the latency and throughput from
+ * the total elapsed time.
  */
 
-//This is an assumption coming from elf code running on the device.
-static constexpr int samples = 10000;
+// Number of sample tokens on Strix; assumption from ELF running on the device.
+static constexpr int strix_samples = 10000;
+
+static json
+run_tct_workload(const std::shared_ptr<xrt_core::device>& dev,
+                 const xrt_core::archive* archive,
+                 const std::vector<std::string>& artifacts)
+{
+  const std::string recipe_data = archive->data("recipe_tct_one_column.json");
+  const std::string profile_data = archive->data("profile_tct_one_column.json");
+  const auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, artifacts);
+
+  xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
+  runner.execute();
+  runner.wait();
+
+  return json::parse(runner.get_report());
+}
+
+static void
+calculate_tct_metrics(const json& report,
+                      int strix_token_samples,
+                      double& avg_latency_us,
+                      double& throughput_tct_s)
+{
+  const auto iterations = report["iterations"].get<int>();
+  const double elapsed_us = report["cpu"]["elapsed"].get<double>();
+
+  if (strix_token_samples > 0) {
+    avg_latency_us = elapsed_us / strix_token_samples;
+    throughput_tct_s = (strix_token_samples * iterations * 1000000.0) / elapsed_us; // NOLINT: elapsed is in microseconds
+  } else {
+    avg_latency_us = elapsed_us / iterations;
+    throughput_tct_s = (iterations * 1000000.0) / elapsed_us; // NOLINT: elapsed is in microseconds
+  }
+}
+
+static void
+log_tct_results(boost::property_tree::ptree& ptree,
+                double avg_latency_us,
+                double throughput_tct_s)
+{
+  if (XBU::getVerbose())
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % avg_latency_us));
+
+  XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % throughput_tct_s));
+}
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestTCTOneColumn::TestTCTOneColumn()
@@ -36,39 +84,34 @@ boost::property_tree::ptree
 TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
 {
   boost::property_tree::ptree ptree = get_test_header();
+
   if (archive == nullptr) {
     ptree.put("status", XBValidateUtils::test_token_failed);
     XBValidateUtils::logger(ptree, "Error", "No archive found, skipping test");
     return ptree;
   }
-  
+
   try {
-    std::string recipe_data = archive->data("recipe_tct_one_column.json");
-    std::string profile_data = archive->data("profile_tct_one_column.json"); 
-    
-    // Extract artifacts using helper method
-    auto artifacts_repo = XBU::extract_artifacts_from_archive(archive, {
-      "tct_one_col.xclbin", 
-      "tct_1col.elf" 
-    });
-    
-    // Create runner with recipe, profile, and artifacts repository
-    xrt_core::runner runner(xrt::device(dev), recipe_data, profile_data, artifacts_repo);
-    runner.execute();
-    runner.wait();
+    using query = xrt_core::query::pcie_id;
+    const auto pcie_id = xrt_core::device_query<query>(dev);
+    xrt_core::smi::smi_hardware_config smi_hrdw;
+    const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+    const bool is_strix = XBU::is_strix_hardware(hardware_type);
 
-    // Get final metrics from the last run 
-    auto report = json::parse(runner.get_report());
-    double latency = report["cpu"]["latency"].get<double>(); // Should be in microseconds
-    double throughput = report["cpu"]["throughput"].get<double>(); // Should be in operations/second
+    const std::vector<std::string> artifacts = is_strix
+      ? std::vector<std::string>{"tct_one_col.xclbin", "tct_1col.elf"}
+      : std::vector<std::string>{"tct_1col.elf"};
 
-    if(XBU::getVerbose())
-      XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average time for TCT: %.1f us") % (latency / samples)));
+    const auto report = run_tct_workload(dev, archive, artifacts);
 
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average TCT throughput: %.1f TCT/s") % (samples * throughput)));
+    double avg_latency_us = 0.0;
+    double throughput_tct_s = 0.0;
+    calculate_tct_metrics(report, is_strix ? strix_samples : 0, avg_latency_us, throughput_tct_s);
+
+    log_tct_results(ptree, avg_latency_us, throughput_tct_s);
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
-  catch(const std::exception& e) {
+  catch (const std::exception& e) {
     XBValidateUtils::logger(ptree, "Error", e.what());
     ptree.put("status", XBValidateUtils::test_token_failed);
   }

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.h
@@ -7,6 +7,26 @@
 #include "tools/common/TestRunner.h"
 #include "xrt/xrt_device.h"
 
+/**
+ * Measure average Tile Completion Token (TCT) latency and throughput with one
+ * AIE column active.
+ *
+ * On Strix/PHX (AIE2), the workload uses an xclbin plus ELF and applies a
+ * fixed per-ELF token count when deriving metrics from runner elapsed time.
+ *
+ * On MDS (NPU3 / AIE4), the workload follows the same overall pattern as the
+ * df-bw validate test: the runner loads the TCT ELF, executes it repeatedly,
+ * and reports elapsed time, average latency, and throughput. Differences from
+ * df-bw are:
+ *   - Each ELF run transfers a 256 KiB buffer (two 256 KiB bindings in the
+ *     recipe/profile).
+ *   - The profile runs 1000 iterations; metrics are derived from runner
+ *     elapsed time and iteration count (no fixed token/sample assumption).
+ *   - Completion is detected via the TCT opcode rather than a MASK poll.
+ *
+ * The host-side test reports average TCT latency (us) and TCT throughput
+ * (TCT/s) from the runner report.
+ */
 class TestTCTOneColumn : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*) override;

--- a/src/runtime_src/core/tools/xbutil2/EventTracing/OO_EventTraceExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/EventTracing/OO_EventTraceExamine.cpp
@@ -128,13 +128,13 @@ handle_logging(const xrt_core::device* device) const {
       auto report_generator = [this, &parser](const xrt_core::device* dev) -> std::string {
         return generate_parsed_logs(dev, parser, true);
       };
-      smi_watch_mode::run_watch_mode(device, out, report_generator);
+      smi_watch_mode::run_watch_mode(device, out, report_generator, 0, false);
     } else {
       // Raw mode: no parser needed
       auto report_generator = [this](const xrt_core::device* dev) -> std::string {
         return generate_raw_logs(dev, true);
       };
-      smi_watch_mode::run_watch_mode(device, out, report_generator);
+      smi_watch_mode::run_watch_mode(device, out, report_generator, 0, false);
     }
   } else {
     if (output_helper.is_raw_mode() || !config) {

--- a/src/runtime_src/core/tools/xbutil2/FirmwareLogging/OO_FirmwareLogExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/FirmwareLogging/OO_FirmwareLogExamine.cpp
@@ -153,13 +153,13 @@ handle_logging(const xrt_core::device* device) const {
       auto report_generator = [this, &parser](const xrt_core::device* dev) -> std::string {
         return generate_parsed_logs(dev, parser, true);
       };
-      smi_watch_mode::run_watch_mode(device, out, report_generator);
+      smi_watch_mode::run_watch_mode(device, out, report_generator, 0, false);
     } else {
       // Raw mode: no parser needed
       auto report_generator = [this](const xrt_core::device* dev) -> std::string {
         return generate_raw_logs(dev, true);
       };
-      smi_watch_mode::run_watch_mode(device, out, report_generator);
+      smi_watch_mode::run_watch_mode(device, out, report_generator, 0, false);
     }
   } else {
     if (output_helper.is_raw_mode() || !config) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -338,7 +338,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
             return console.str();
           };
       smi_watch_mode::run_watch_mode(device.get(), std::cout, examine_watch_snapshot,
-          *options.m_watchIntervalSec, true);
+          *options.m_watchIntervalSec);
     } else {
       XBU::produce_reports(device, reportsToProcess, schemaVersion, {}, std::cout, oSchemaOutput);
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The TCT validate tests did not handle MDS (NPU3) correctly: they assumed fixed Strix token counts when computing latency and throughput. This change adds an MDS path that uses runner elapsed time and iteration count, keeps Strix behavior unchanged, and shares a common workload runner between both platforms. Separately, xrt-smi watch mode now refreshes the terminal on each step for snapshot-style reports (examine, context-health), while firmware-log and event-trace streaming watch modes are unchanged. The shim also maps firmware log configure failures to a clear “Invalid firmware log level” message.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
TCT tests use one run_tct_workload() path and branch only in calculate_tct_metrics() (Strix uses fixed samples × iterations; MDS uses iterations only). We rejected duplicating full Strix/MDS run functions and using the runner’s precomputed latency/throughput fields, which do not match the MDS workload model. Watch mode defaults refresh_terminal to true, with firmware-log and event-trace explicitly opting out.

#### Risks (if any) associated the changes in the commit
The reported TCT numbers would now change

#### What has been tested and how, request additional testing if necessary
Tested on npu3 platform. This TCT throughput seems close to no-op throughput so numbers make more sense now : 
```
C:\Users\aktondak>xrt-smi validate --advanced -r tct-all-col
-------------------------------------------------------------------------
                    DISCLAIMER  (xrt-smi --advanced)
You are running a developer command that may change system configuration.
                Continue only if you understand the risks.
-------------------------------------------------------------------------
Validate Device           : [00c5:00:01.1]
    Platform              : NPU Medusa
    Power Mode            : performance
-------------------------------------------------------------------------------
Test 1 [00c5:00:01.1]     : tct-all-col
    Details               : Average TCT throughput (all columns): 10273.5 TCT/s
    Test Status           : [PASSED]
```

#### Documentation impact (if any)
None