### PR TITLE
EDGEML-14552: Fix _WINDOWS macro usage and const reference

### DIFF
--- a/src/runtime_src/core/common/memalign.h
+++ b/src/runtime_src/core/common/memalign.h
@@ -28,7 +28,7 @@ posix_memalign(void **memptr, size_t alignment, size_t size)
 {
 #if defined(__linux__)
   return ::posix_memalign(memptr,alignment,size);
-#elif defined(_WINDOWS)
+#elif defined(_WIN32)
   // this is not good, _aligned_malloc requires _aligned_free
   // power of 2
   if (!alignment || (alignment & (alignment - 1)))
@@ -51,7 +51,7 @@ namespace detail {
 template <typename MyType>
 struct aligned_ptr_deleter
 {
-#if defined(_WINDOWS)
+#if defined(_WIN32)
   void operator() (MyType* ptr)  { _aligned_free(ptr); }
 #else
   void operator() (MyType* ptr)  { free(ptr); }
@@ -74,7 +74,7 @@ aligned_alloc(size_t align, size_t size)
   if (!align || (align & (align - 1)))
     throw std::runtime_error("xrt_core::aligned_alloc requires power of 2 for alignment");
 
-#if defined(_WINDOWS)
+#if defined(_WIN32)
   return aligned_ptr_t<MyType>(reinterpret_cast<MyType*>(_aligned_malloc(size, align)));
 #else
   return aligned_ptr_t<MyType>(reinterpret_cast<MyType*>(::aligned_alloc(align, size)));

--- a/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
@@ -68,7 +68,7 @@ SectionAIEResourcesBin::getSubSectionEnum(const std::string& sSubSectionName)
 const std::string&
 SectionAIEResourcesBin::getSubSectionName(SectionAIEResourcesBin::SubSection eSubSection)
 {
-  auto subSectionTable = getSubSectionTable();
+  const auto& subSectionTable = getSubSectionTable();
   auto iter = std::find_if(subSectionTable.begin(), subSectionTable.end(), [&](const auto& entry) {return entry.second == eSubSection;});
 
   if (iter == subSectionTable.end())


### PR DESCRIPTION
Problem solved by the commit
Two categories of issues exposed by EWDK 28000.1839 (VS 2026/v145):
1. memalign.h and SectionAIEResourcesBin.cxx used non-standard _WINDOWS macro guards. MSVC does not guarantee _WINDOWS is defined; the standard predefined macro is _WIN32. This caused incorrect conditional compilation under v145.
2. SectionAIEResourcesBin.cxx called getSubSectionTable() and bound the result to a non-const local, triggering a v145 warning-as-error on binding a temporary to a non-const reference. Also updates the xdp submodule pointer to the commit that fixes the same _WINDOWS → _WIN32 issue in pl_device_intf.cpp.

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered Discovered during a full x64 stack build with EWDK 28000.1839. The v145 compiler is stricter about non-standard macros and reference binding of temporaries compared to v143.

How problem was solved, alternative solutions (if any) and why they were rejected _WINDOWS → _WIN32: replaced all three occurrences in memalign.h with _WIN32, which is always defined by MSVC on Windows targets. Defining _WINDOWS in the build system was rejected as it masks the root cause. SectionAIEResourcesBin.cxx: changed the local binding to `const auto&` so the temporary returned by getSubSectionTable() is bound to a const reference, which is well-formed C++. Storing a copy was considered but rejected as unnecessary overhead.

Risks (if any) associated the changes in the commit None. _WIN32 is the correct standard macro. The const& change is semantically equivalent for a read-only iteration.

What has been tested and how, request additional testing if necessary Full x64 stack build with EWDK 28000.1839 completed successfully. Additional testing requested: ARM64 build verification.

Documentation impact (if any)
None.

