### PR TITLE
dynamic tracing compiler coalesce result buffer support

### DIFF
--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -10,6 +10,7 @@
 #include "core/include/xrt/experimental/xrt_module.h"
 
 #include <cstdint>
+#include <string>
 
 // Provide access to xrt::xclbin data that is not directly exposed
 // to end users via xrt::xclbin.   These functions are used by
@@ -84,6 +85,11 @@ dump_scratchpad_mem(const xrt::hw_context& hwctx);
 // Dump log buffer contents into a file when ini option is enabled
 void
 dump_uc_log_buffer(const xrt::hw_context& hwctx);
+
+// Append a per-run dtrace JSON result to the hw context coalesce buffer
+void
+append_dtrace_result(const xrt::hw_context& hwctx, 
+                     const std::string& key, const std::string& result_json);
 
 // Returns map of kernel names to their corresponding elf files
 // registered with the hardware context.

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -212,6 +212,33 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     }
   };  // struct uc_log_buffer
 
+  // struct dtrace_result_buffer - coalesce per-run dtrace JSON result for this hwctx
+  struct dtrace_result_buffer
+  {
+    std::unique_ptr<xrt_core::dtrace_buffer_dumper> m_dtrace_dumper;
+
+    static std::unique_ptr<xrt_core::dtrace_buffer_dumper>
+    init_dtrace_buffer_dumper(xrt_core::hwctx_handle* ctx_hdl)
+    {
+      // Configure coalesce buffer size for this hw context slot
+      xrt_core::dtrace_buffer_dumper::config config {};
+      config.slot_idx = ctx_hdl->get_slotidx();
+      config.max_bytes = static_cast<size_t>(xrt_core::config::get_dtrace_coalesce_result_memory_mb()) * 1024 * 1024;
+      return std::make_unique<xrt_core::dtrace_buffer_dumper>(std::move(config));
+    }
+
+    explicit
+    dtrace_result_buffer(xrt_core::hwctx_handle* ctx_hdl)
+      : m_dtrace_dumper(init_dtrace_buffer_dumper(ctx_hdl))
+    {}
+
+    void
+    append(const std::string& key, const std::string& result_json)
+    {
+      m_dtrace_dumper->append(key, result_json);
+    }
+  };  // struct dtrace_result_buffer
+
   std::shared_ptr<xrt_core::device> m_core_device;
   xrt::xclbin m_xclbin;
 
@@ -235,6 +262,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
   access_mode m_mode;
   std::unique_ptr<xrt_core::hwctx_handle> m_hdl;
   std::unique_ptr<uc_log_buffer> m_uc_log_buf;
+  std::unique_ptr<dtrace_result_buffer> m_dtrace_result_buf;
 
   // During preemption, when a hardware context is interrupted
   // L2 memory contents are saved to a scratchpad memory allocated
@@ -406,10 +434,26 @@ public:
     return shared_from_this();
   }
 
+  void
+  append_dtrace_result(const std::string& key, const std::string& result_json)
+  {
+    // Lazily create the coalesce buffer on first append for this hw context
+    if (!m_hdl)
+      return;
+
+    if (!m_dtrace_result_buf)
+      m_dtrace_result_buf = std::make_unique<dtrace_result_buffer>(m_hdl.get());
+
+    m_dtrace_result_buf->append(key, result_json);
+  }
+
   ~hw_context_impl()
   {
     // This trace point measures the time to tear down a hw context on the device
     XRT_TRACE_POINT_SCOPE(xrt_hw_context_dtor);
+
+    // dump dtrace buffered results before shim hwctx handle is destroyed
+    m_dtrace_result_buf.reset();
 
     // dump uC log buffer before shim hwctx handle is destroyed
     m_uc_log_buf.reset();
@@ -801,6 +845,14 @@ xrt::hw_context::cfg_type
 get_cfg_map(const xrt::hw_context& hwctx)
 {
   return hwctx.get_handle()->get_cfg_map();
+}
+
+void
+append_dtrace_result(const xrt::hw_context& hwctx,
+                     const std::string& key, const std::string& result_json)
+{
+  // Append a per-run dtrace JSON result to the hw context coalesce buffer
+  hwctx.get_handle()->append_dtrace_result(key, result_json);
 }
 
 } // xrt_core::hw_context_int

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -41,13 +41,16 @@
 
 namespace {
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, bugprone-implicit-widening-of-multiplication-result)
 constexpr std::size_t
 operator""_kb(unsigned long long v) { return 1024U * v; }
 
+constexpr std::size_t
+operator""_mb(unsigned long long v) { return 1024U * 1024U * v; }
+
 constexpr double
 operator""_mhz(long double v) { return static_cast<double>(v) * 1'000'000.0; }
-// NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, bugprone-implicit-widening-of-multiplication-result)
 
 template <typename T>
 using span = xrt::detail::span<T>;
@@ -223,7 +226,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
       // Configure coalesce buffer size for this hw context slot
       xrt_core::dtrace_buffer_dumper::config config {};
       config.slot_idx = ctx_hdl->get_slotidx();
-      config.max_bytes = static_cast<size_t>(xrt_core::config::get_dtrace_coalesce_result_memory_mb()) * 1024 * 1024;
+      config.max_bytes = static_cast<size_t>(xrt_core::config::get_dtrace_coalesce_result_memory_mb()) * 1_mb;
       return std::make_unique<xrt_core::dtrace_buffer_dumper>(std::move(config));
     }
 
@@ -437,6 +440,10 @@ public:
   void
   append_dtrace_result(const std::string& key, const std::string& result_json)
   {
+    // Concurrent run clones can dump dtrace on the same hw context;
+    // protect lazy init and append with m_mutex
+    std::lock_guard lk(m_mutex);
+
     // Lazily create the coalesce buffer on first append for this hw context
     if (!m_hdl)
       return;

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -215,33 +215,6 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     }
   };  // struct uc_log_buffer
 
-  // struct dtrace_result_buffer - coalesce per-run dtrace JSON result for this hwctx
-  struct dtrace_result_buffer
-  {
-    std::unique_ptr<xrt_core::dtrace_buffer_dumper> m_dtrace_dumper;
-
-    static std::unique_ptr<xrt_core::dtrace_buffer_dumper>
-    init_dtrace_buffer_dumper(xrt_core::hwctx_handle* ctx_hdl)
-    {
-      // Configure coalesce buffer size for this hw context slot
-      xrt_core::dtrace_buffer_dumper::config config {};
-      config.slot_idx = ctx_hdl->get_slotidx();
-      config.max_bytes = static_cast<size_t>(xrt_core::config::get_dtrace_coalesce_result_memory_mb()) * 1_mb;
-      return std::make_unique<xrt_core::dtrace_buffer_dumper>(std::move(config));
-    }
-
-    explicit
-    dtrace_result_buffer(xrt_core::hwctx_handle* ctx_hdl)
-      : m_dtrace_dumper(init_dtrace_buffer_dumper(ctx_hdl))
-    {}
-
-    void
-    append(const std::string& key, const std::string& result_json)
-    {
-      m_dtrace_dumper->append(key, result_json);
-    }
-  };  // struct dtrace_result_buffer
-
   std::shared_ptr<xrt_core::device> m_core_device;
   xrt::xclbin m_xclbin;
 
@@ -265,7 +238,7 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
   access_mode m_mode;
   std::unique_ptr<xrt_core::hwctx_handle> m_hdl;
   std::unique_ptr<uc_log_buffer> m_uc_log_buf;
-  std::unique_ptr<dtrace_result_buffer> m_dtrace_result_buf;
+  std::unique_ptr<xrt_core::dtrace_buffer_dumper> m_dtrace_result_buf;
 
   // During preemption, when a hardware context is interrupted
   // L2 memory contents are saved to a scratchpad memory allocated
@@ -370,6 +343,29 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     }
   }
 
+  // Initializes dtrace coalesce buffer
+  static std::unique_ptr<xrt_core::dtrace_buffer_dumper>
+  init_dtrace_buffer_dumper(xrt_core::hwctx_handle* ctx_hdl)
+  {
+    // Coalesce dtrace result requires both buffer mode and JSON output format
+    static auto dtrace_coalesce_enabled = xrt_core::config::get_dtrace_coalesce_result()
+                                       && xrt_core::config::get_dtrace_output_json_format();
+    if (!ctx_hdl || !dtrace_coalesce_enabled)
+      return nullptr;
+
+    try {
+      xrt_core::dtrace_buffer_dumper::config config {};
+      config.slot_idx = ctx_hdl->get_slotidx();
+      config.max_bytes = static_cast<size_t>(xrt_core::config::get_dtrace_coalesce_result_memory_mb()) * 1_mb;
+      return std::make_unique<xrt_core::dtrace_buffer_dumper>(std::move(config));
+    }
+    catch (const std::exception& e) {
+      xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_hw_context",
+                              std::string{"Failed to create dtrace coalesce results buffer : "} + e.what());
+      return nullptr;
+    }
+  }
+
   // Gets partition size from xclbin if AIE partition section is present
   static uint32_t
   get_partition_size_from_xclbin(const xrt::xclbin& xclbin)
@@ -449,7 +445,7 @@ public:
       return;
 
     if (!m_dtrace_result_buf)
-      m_dtrace_result_buf = std::make_unique<dtrace_result_buffer>(m_hdl.get());
+      m_dtrace_result_buf = init_dtrace_buffer_dumper(m_hdl.get());
 
     m_dtrace_result_buf->append(key, result_json);
   }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -723,10 +723,19 @@ class module_run_aie_gen2_plus : public module_run
 
     dtrace_util(const std::string& ctrl_file_path, const std::string& map_data,
                 uint32_t log_level, uint32_t output_fmt)
-      : dtrace_handle(create_dtrace_handle(ctrl_file_path.c_str(), map_data.c_str(), log_level, output_fmt),
+      : dtrace_handle(create_dtrace_handle(ctrl_file_path, map_data, log_level, output_fmt),
                       destroy_dtrace_handle) {}
   };
   dtrace_util m_dtrace;
+
+  // Check dtrace coalesce buffer result is enabled based on both 
+  // buffer results and json output format config
+  bool
+  is_dtrace_buffer_result() const
+  {
+    return xrt_core::config::get_dtrace_coalesce_result()
+      && xrt_core::config::get_dtrace_output_json_format();
+  }
 
   // Creates dtrace util object.
   // Sets path (run-level overrides config file).
@@ -1142,19 +1151,30 @@ public:
     m_dtrace.ctrl_bo.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
 
     try {
-      // dtrace output is dumped into current working directory
-      // output is a python/json file
-      std::string result_file_path = std::filesystem::current_path().string()
-                                   + "/dtrace_dump"
-                                   + postfix
-                                   + (xrt_core::config::get_dtrace_output_json_format() ? ".json" : ".py");
+      if (is_dtrace_buffer_result()) {
+        // dtrace output is serialized and buffered into result buffer
+        std::string result_key = "dtrace_dump" + postfix;
 
-      get_dtrace_result_file(m_dtrace.dtrace_handle.get(), result_file_path.c_str());
+        // Get result as JSON string from aiebu
+        std::string result_json = get_dtrace_result_buffer(m_dtrace.dtrace_handle.get());
 
-      xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
-                              std::string{"[dtrace] : dtrace buffer dumped successfully to - "} + result_file_path);
+        // Append JSON string to hwctx buffer
+        xrt_core::hw_context_int::append_dtrace_result(m_hwctx, result_key, result_json);
+      }
+      else {
+        // dtrace output is dumped into current working directory
+        // output is a python/json file
+        std::string result_file_name = "dtrace_dump"
+                                    + postfix
+                                    + (xrt_core::config::get_dtrace_output_json_format() ? ".json" : ".py");
+
+        get_dtrace_result_file(m_dtrace.dtrace_handle.get(), result_file_name);
+
+        xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
+                                std::string{"[dtrace] : dtrace buffer dumped successfully to - "} + result_file_name);
+      }
     }
-    catch (const std::exception &e) {
+    catch (const std::exception& e) {
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
                               std::string{"[dtrace] : dtrace buffer dump failed, "} + e.what());
     }

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1157,6 +1157,11 @@ public:
 
         // Get result as JSON string from aiebu
         std::string result_json = get_dtrace_result_buffer(m_dtrace.dtrace_handle.get());
+        if (result_json == "null") {
+          xrt_core::message::send(xrt_core::message::severity_level::warning, "xrt_module",
+                                  "[dtrace] : failed to get dtrace result buffer");
+          return;
+        }
 
         // Append JSON string to hwctx buffer
         xrt_core::hw_context_int::append_dtrace_result(m_hwctx, result_key, result_json);

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -434,7 +434,7 @@ append(const std::string& key, const std::string& result_json)
         write_to_file();
 
       m_spilled = true;
-      const auto max_mb = m_config.max_bytes / (1024 * 1024);
+      const auto max_mb = m_config.max_bytes / (1024 * 1024); // NOLINT
       xrt_core::message::send(xrt_core::message::severity_level::warning, "dtrace_buffer_dumper",
                               std::string{"[dtrace] : coalesce buffer limit ("} + std::to_string(max_mb) + " MB) reached. "
                               + "Further dtrace results will not be buffered for hardware context "

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #define XCL_DRIVER_DLL_EXPORT  // in same dll as xrt_bo.h
 #define XRT_API_SOURCE         // in same dll as api
@@ -10,9 +10,11 @@
 #include "core/common/uc_log_schema.h"
 
 #include <cstring>
+#include <filesystem>
 #include <stdexcept>
 #include <sstream>
 #include <array>
+#include <utility>
 
 namespace xrt_core {
 
@@ -367,6 +369,104 @@ flush()
 {
   // process chunks to dump the remaining data
   process_chunks();
+}
+
+dtrace_buffer_dumper::
+dtrace_buffer_dumper(config cfg)
+  : m_config(std::move(cfg))
+  , m_results(nlohmann::ordered_json::object())
+{}
+
+dtrace_buffer_dumper::
+~dtrace_buffer_dumper()
+{
+  // Flush coalesced results before destruction
+  try {
+    flush();
+  }
+  catch (const std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "dtrace_buffer_dumper",
+                            std::string{"Error during cleanup: "} + e.what());
+  }
+}
+
+void
+dtrace_buffer_dumper::
+write_to_file()
+{
+  // Write coalesced JSON to a timestamped file in the current working directory
+  const std::string result_file_path = std::filesystem::current_path().string()
+                                     + "/dtrace_dump"
+                                     + "_ctx_" + std::to_string(m_config.slot_idx)
+                                     + "_" + xrt_core::get_timestamp_for_filename()
+                                     + ".json";
+
+  std::ofstream json_file(result_file_path);
+  if (!json_file)
+    throw std::runtime_error("[dtrace] : failed to open file for dumping dtrace buffer result");
+
+  json_file << m_results.dump(4) << "\n";
+
+  xrt_core::message::send(xrt_core::message::severity_level::debug, "dtrace_buffer_dumper",
+                          std::string{"[dtrace] : dtrace buffer dumped successfully to - "}
+                          + result_file_path);
+
+  m_results = nlohmann::ordered_json::object();
+}
+
+void
+dtrace_buffer_dumper::
+append(const std::string& key, const std::string& result_json)
+{
+  // No-op once the coalesce buffer has spilled or been disabled
+  if (m_spilled)
+    return;
+
+  try {
+    auto entry = nlohmann::ordered_json::parse(result_json);
+    m_results[key] = std::move(entry);
+
+    if (m_results.dump(4).size() > m_config.max_bytes) {
+      m_results.erase(key);
+
+      // Flush buffered runs, warn that the cap was reached, and disable further appends
+      if (!m_results.empty())
+        write_to_file();
+
+      m_spilled = true;
+      const auto max_mb = m_config.max_bytes / (1024 * 1024);
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "dtrace_buffer_dumper",
+                              std::string{"[dtrace] : coalesce buffer limit ("} + std::to_string(max_mb) + " MB) reached. "
+                              + "Further dtrace results will not be buffered for hardware context "
+                              + std::to_string(m_config.slot_idx));
+
+      return;
+    }
+
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "dtrace_buffer_dumper",
+                            std::string{"[dtrace] : dtrace buffered successfully for key - "} + key);
+  }
+  catch (const std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "dtrace_buffer_dumper",
+                            std::string{"[dtrace] : failed to append coalesced result: "} + e.what());
+  }
+}
+
+void
+dtrace_buffer_dumper::
+flush()
+{
+  // Skip if already spilled or nothing remains to write
+  if (m_spilled || m_results.empty())
+    return;
+
+  try {
+    write_to_file();
+  }
+  catch (const std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "dtrace_buffer_dumper",
+                            std::string{"[dtrace] : dtrace buffer dump failed, "} + e.what());
+  }
 }
 
 } // xrt_core

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -426,36 +426,33 @@ void
 dtrace_buffer_dumper::
 append(const std::string& key, const std::string& result_json)
 {
-  // No-op once the coalesce buffer has spilled or been disabled
-  if (m_spilled)
-    return;
-
   try {
     auto entry = nlohmann::ordered_json::parse(result_json);
-    const auto entry_size = entry.dump(4).size();
-    m_results[key] = std::move(entry);
-    m_accumulated_bytes += entry_size;
+    // No probes fired
+    if (entry.empty())
+      return;
 
-    // Cap limits in-memory coalesce size. When exceeded, discard the run that
-    // triggered overflow, spill any previously buffered runs to disk, then stop
-    // accepting further appends for this hardware context.
-    if (m_accumulated_bytes > m_config.max_bytes) {
-      m_accumulated_bytes -= entry_size;
-      m_results.erase(key);
+    // Spill to disk when the next append would exceed the in-memory cap, then
+    // continue buffering into a fresh in-memory batch.
+    const auto entry_size = entry.dump(4).size();
+    if (m_accumulated_bytes + entry_size > m_config.max_bytes) {
+      const auto max_mb = m_config.max_bytes / (1024 * 1024); // NOLINT
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "dtrace_buffer_dumper",
+                              std::string{"[dtrace] : coalesce result buffer limit ("} + std::to_string(max_mb) + " MB) reached, spilled to disk.");
 
       if (!m_results.empty())
         write_to_file();
 
-      m_spilled = true;
-      const auto max_mb = m_config.max_bytes / (1024 * 1024); // NOLINT
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "dtrace_buffer_dumper",
-                              std::string{"[dtrace] : coalesce buffer limit ("} + std::to_string(max_mb) + " MB) reached. "
-                              + "Further dtrace results will not be buffered for hardware context "
-                              + std::to_string(m_config.slot_idx));
-
-      return;
+      // If single run entry exceeds the cap, spill it immediately.
+      if (entry_size > m_config.max_bytes) {
+        m_results[key] = std::move(entry);
+        write_to_file();
+        return;
+      }
     }
 
+    m_results[key] = std::move(entry);
+    m_accumulated_bytes += entry_size;
     xrt_core::message::send(xrt_core::message::severity_level::debug, "dtrace_buffer_dumper",
                             std::string{"[dtrace] : dtrace buffered successfully for key - "} + key);
   }
@@ -469,8 +466,8 @@ void
 dtrace_buffer_dumper::
 flush()
 {
-  // Skip if already spilled or nothing remains to write
-  if (m_spilled || m_results.empty())
+  // Skip if nothing remains to write
+  if (m_results.empty())
     return;
 
   try {

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -406,12 +406,20 @@ write_to_file()
     throw std::runtime_error("[dtrace] : failed to open file for dumping dtrace buffer result");
 
   json_file << m_results.dump(4) << "\n";
+  if (!json_file)
+    throw std::runtime_error("[dtrace] : failed to write dtrace buffer result to file");
+
+  json_file.flush();
+  if (!json_file)
+    throw std::runtime_error("[dtrace] : failed to flush dtrace buffer result file");
 
   xrt_core::message::send(xrt_core::message::severity_level::debug, "dtrace_buffer_dumper",
                           std::string{"[dtrace] : dtrace buffer dumped successfully to - "}
                           + result_file_path);
 
+  // Clear after the write completes without error
   m_results = nlohmann::ordered_json::object();
+  m_accumulated_bytes = 0;
 }
 
 void
@@ -424,12 +432,17 @@ append(const std::string& key, const std::string& result_json)
 
   try {
     auto entry = nlohmann::ordered_json::parse(result_json);
+    const auto entry_size = entry.dump(4).size();
     m_results[key] = std::move(entry);
+    m_accumulated_bytes += entry_size;
 
-    if (m_results.dump(4).size() > m_config.max_bytes) {
+    // Cap limits in-memory coalesce size. When exceeded, discard the run that
+    // triggered overflow, spill any previously buffered runs to disk, then stop
+    // accepting further appends for this hardware context.
+    if (m_accumulated_bytes > m_config.max_bytes) {
+      m_accumulated_bytes -= entry_size;
       m_results.erase(key);
 
-      // Flush buffered runs, warn that the cap was reached, and disable further appends
       if (!m_results.empty())
         write_to_file();
 

--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -434,7 +434,7 @@ append(const std::string& key, const std::string& result_json)
 
     // Spill to disk when the next append would exceed the in-memory cap, then
     // continue buffering into a fresh in-memory batch.
-    const auto entry_size = entry.dump(4).size();
+    const auto entry_size = result_json.size();
     if (m_accumulated_bytes + entry_size > m_config.max_bytes) {
       const auto max_mb = m_config.max_bytes / (1024 * 1024); // NOLINT
       xrt_core::message::send(xrt_core::message::severity_level::warning, "dtrace_buffer_dumper",

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -137,8 +137,10 @@ public:
 /**
  * dtrace_buffer_dumper - Coalesces per-run dtrace JSON results for a hw context.
  *
- * Accumulates JSON in memory up to max_bytes. On overflow, spills buffered runs
- * to disk, logs a warning, and disables further appends for this instance.
+ * Accumulates JSON in memory up to max_bytes.
+ * On overflow, the run that would exceed the cap is discarded, previously
+ * buffered runs are spilled to disk, a warning is logged, and further appends
+ * are disabled for this instance.
  */
 class dtrace_buffer_dumper
 {
@@ -173,6 +175,7 @@ public:
 private:
   config m_config;
   nlohmann::ordered_json m_results;
+  size_t m_accumulated_bytes = 0;
   bool m_spilled = false;
 
   // Write buffered JSON to file, log success, and clear the buffer

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef xrtcore_util_buffer_dumper_h_
 #define xrtcore_util_buffer_dumper_h_
+#include "core/common/json/nlohmann/json.hpp"
 #include "core/common/uc_log.h"
 #include "core/include/xrt/xrt_bo.h"
 
 #include <atomic>
 #include <condition_variable>
 #include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <future>
 #include <mutex>
@@ -130,6 +132,52 @@ public:
   // Synchronously flush all pending data
   void
   flush();
+};
+
+/**
+ * dtrace_buffer_dumper - Coalesces per-run dtrace JSON results for a hw context.
+ *
+ * Accumulates JSON in memory up to max_bytes. On overflow, spills buffered runs
+ * to disk, logs a warning, and disables further appends for this instance.
+ */
+class dtrace_buffer_dumper
+{
+public:
+  struct config
+  {
+    uint32_t slot_idx = 0;
+    size_t max_bytes = 0;
+  };
+
+  explicit
+  dtrace_buffer_dumper(config cfg);
+
+  // Flush result on destruction
+  ~dtrace_buffer_dumper();
+
+  // Delete copy and move operations
+  dtrace_buffer_dumper(const dtrace_buffer_dumper&) = delete;
+  dtrace_buffer_dumper(dtrace_buffer_dumper&&) = delete;
+  dtrace_buffer_dumper& operator=(const dtrace_buffer_dumper&) = delete;
+  dtrace_buffer_dumper& operator=(dtrace_buffer_dumper&&) = delete;
+
+  // Append run's JSON result under the given key
+  // Spill buffered results on overflow and disable further appends
+  void
+  append(const std::string& key, const std::string& result_json);
+
+  // Write buffered results to file at end of hw context lifetime
+  void
+  flush();
+
+private:
+  config m_config;
+  nlohmann::ordered_json m_results;
+  bool m_spilled = false;
+
+  // Write buffered JSON to file, log success, and clear the buffer
+  void
+  write_to_file();
 };
 
 } // xrt_core

--- a/src/runtime_src/core/common/buffer_dumper.h
+++ b/src/runtime_src/core/common/buffer_dumper.h
@@ -138,9 +138,9 @@ public:
  * dtrace_buffer_dumper - Coalesces per-run dtrace JSON results for a hw context.
  *
  * Accumulates JSON in memory up to max_bytes.
- * On overflow, the run that would exceed the cap is discarded, previously
- * buffered runs are spilled to disk, a warning is logged, and further appends
- * are disabled for this instance.
+ * On overflow, buffered runs are spilled to disk, the in-memory buffer is
+ * cleared, and appends continue into a fresh buffer (multiple spill files
+ * may be created over the lifetime of the hw context).
  */
 class dtrace_buffer_dumper
 {
@@ -163,8 +163,8 @@ public:
   dtrace_buffer_dumper& operator=(const dtrace_buffer_dumper&) = delete;
   dtrace_buffer_dumper& operator=(dtrace_buffer_dumper&&) = delete;
 
-  // Append run's JSON result under the given key
-  // Spill buffered results on overflow and disable further appends
+  // Append run's JSON result under the given key.
+  // Spill buffered results to disk on overflow, then continue buffering.
   void
   append(const std::string& key, const std::string& result_json);
 
@@ -176,7 +176,6 @@ private:
   config m_config;
   nlohmann::ordered_json m_results;
   size_t m_accumulated_bytes = 0;
-  bool m_spilled = false;
 
   // Write buffered JSON to file, log success, and clear the buffer
   void

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1180,6 +1180,21 @@ get_dtrace_output_json_format()
   return value;
 }
 
+inline bool
+get_dtrace_coalesce_result()
+{
+  static bool value = detail::get_bool_value("Debug.dtrace_coalesce_result", false);
+  return value;
+}
+
+inline unsigned int
+get_dtrace_coalesce_result_memory_mb()
+{
+  static constexpr unsigned int default_result_mb = 256U;
+  static unsigned int value = detail::get_uint_value("Debug.dtrace_coalesce_result_memory_mb", default_result_mb);
+  return value;
+}
+
 inline unsigned int
 get_run_buffer_pool_memory_mb()
 {

--- a/src/runtime_src/core/common/uc_log_schema.h
+++ b/src/runtime_src/core/common/uc_log_schema.h
@@ -66,7 +66,7 @@ uc_log_schema = {
     {11, "Exception!!\n\tESR: 0x%x EAR: 0x%x\n"},
     {12, "Error %d initializing XIOModule!"},
     {13, "Page-in to slot %u length 0x%x cur_save_level 0x%x\n"},
-    {14, "[preemption] job: %u\n"},
+    {14, "[yield] job: %u\n"},
     {15, "[block] job: %u\n"},
     {16, "[start] job: %u\n"},
     {17, "[launch] job: %u (%u)\n"},
@@ -181,7 +181,18 @@ uc_log_schema = {
     {126, "Skip %d cmds in runlist\n"},
     {127, "Leaving barrier: conditional job\n"},
     {128, "break early same page same job\n"},
-    {129, "\n"}
+    {129, "load pdi id %d at page index %d\n"},
+    {130, "load axi-mm elf id %d at page index %d\n"},
+    {131, "load cp elf id %d in page %d\n"},
+    {132, "out of order page-in page %d\n"},
+    {133, "in order page-in page %d\n"},
+    {134, "save level page-in page %d\n"},
+    {135, "load last pdi id %d at page index %d\n"},
+    {136, "host queue version read, major: %d minor: %d\n"},
+    {137, "npi error caught\n"},
+    {138, "restore L2 done & load_last_pdi start\n"},
+    {139, "restore done\n"},
+    {140, "\n"}
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Pull in 
https://github.com/Xilinx/aiebu/pull/295
- add/change API, and provide a buffer to save results of multiple runs (https://jira.xilinx.com/browse/AIESW-30744)

https://github.com/Xilinx/aiebu/pull/305; https://github.com/Xilinx/aiebu/pull/325
- avoid creating empty dtrace results when probe don't fire (https://jira.xilinx.com/browse/AIESW-37535)
- duplicate filename in dtrace parser, performance optimization and bug fixes (https://jira.xilinx.com/browse/AIESW-36216)

https://github.com/Xilinx/aiebu/pull/321
- action mask poll register (https://jira.xilinx.com/browse/AIESW-39037)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

This is a performance enhancement with dtrace JSON output support; eliminating per-run file I/O when opted in.
Every XRT `run.dump_dtrace_buffer()` performs file I/O to dump dtrace results — once per iteration. In multi-run scenarios (runlists or latency benchmarks with 1000+ iterations on the same run), this creates N files with N file system round-trips.
```
Mode                 | Latency                   | [Debug]
                     | run.dump_dtrace_buffer()  | dtrace_control_file_path=test.ct
---------------------|---------------------------|------------------------------------------
Python file I/O      | 3,048-3,389 us            | 
JSON file I/O        | 3,045-3,389 us            | dtrace_output_json_format=true
JSON buffered        | 607-718 us                | dtrace_output_json_format=true
                     |                           | dtrace_coalesce_result=true
```

```
End-to-end Performance Numbers
Mode                 | Latency         | Throughput
---------------------|-----------------|----------------------
Python file I/O      | 3,790 us        | 263 op/s
JSON file I/O        | 3,421 us        | 292 op/s
JSON buffered        | 1,992 us        | 501 op/s
```

#### How problem was solved, alternative solutions (if any) and why they were rejected

Accumulate dtrace JSON results in an in-memory nlohmann::ordered_json buffer. Each run.dump_dtrace_buffer() appends to this buffer. A single file is dumped when the hw context is destroyed.
Coalesce buffer remains opt-in via Debug.dtrace_coalesce_result=true and Debug.dtrace_output_json_format=true. Per-run file I/O (Python/JSON direct dump) is unchanged when coalesce is off.
Coalesce buffer holds up to `Debug.dtrace_coalesce_result_memory_mb` of JSON per hw context in host memory until flush or spill.

#### Risks (if any) associated the changes in the commit

Low, this applies only when dynamic tracing is enabled

#### What has been tested and how, request additional testing if necessary

Tested by dumping tracing json result on windows medusa board and the feature works as expected

#### Documentation impact (if any)

NA