### PR TITLE
AIESW-39741 xrt-smi validate pmode warning not showing up

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -590,6 +590,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   //get current performance mode
   const auto og_pmode = xrt_core::device_query_default<xq::performance_mode>(device, 0);
   const auto parsed_og_pmode = xq::performance_mode::parse_status(og_pmode);
+  // Tracks whether we successfully changed the pmode; only then should we reset it.
+  bool pmode_changed = false;
   //--pmode
   try {
     if (!options.m_pmode.empty()) {
@@ -613,10 +615,12 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       else {
         throw xrt_core::error(boost::str(boost::format("Invalid pmode value: '%s'\n") % options.m_pmode));
       }
+      pmode_changed = true;
       XBU::verbose(boost::str(boost::format("Setting power mode to `%s` \n") % options.m_pmode));
     }
     else if(!boost::iequals(parsed_og_pmode, "PERFORMANCE")) {
       xrt_core::device_update<xq::performance_mode>(device.get(), xq::performance_mode::power_type::performance);
+      pmode_changed = true;
       XBU::verbose("Setting power mode to `performance`\n");
     } 
   } catch (const xq::no_such_key&) {
@@ -625,9 +629,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     std::cerr << boost::format("\nERROR: %s\n") % e.what();
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
-  } catch (const std::exception & ex) { //check if permission was denied, i.e., no sudo access
-    if(boost::icontains(ex.what(), "Permission denied"))
-      std::cout << boost::format("WARNING: User doesn't have admin permissions to set performance mode. Running validate in %s mode") 
+  } catch (const std::exception&) {
+    std::cout << boost::format("WARNING: User doesn't have admin permissions to set performance mode. Running validate in %s mode") 
                                     % parsed_og_pmode << std::endl;
   }
   // -- Run the tests --------------------------------------------------
@@ -635,15 +638,14 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   bool has_failures = run_tests_on_devices(device, schemaVersion, testObjectsToRun, oSchemaOutput, options.m_loop);
 
   try {
-    //reset pmode
-    xrt_core::device_update<xq::performance_mode>(device.get(), static_cast<xq::performance_mode::power_type>(og_pmode));
+    //reset pmode only if we actually changed it; skip if the set failed
+    if (pmode_changed)
+      xrt_core::device_update<xq::performance_mode>(device.get(), static_cast<xq::performance_mode::power_type>(og_pmode));
   } catch (const xq::no_such_key&) {
     // Do nothing, as performance mode setting is not supported
-  } catch (const std::exception & ex) { //check if permission was denied, i.e., no sudo access
-    if(!boost::icontains(ex.what(), "Permission denied")) {
-      std::cerr << boost::format("\nERROR: %s\n") % ex.what();
-      throw xrt_core::error(std::errc::operation_canceled);
-    }
+  } catch (const std::exception & ex) {
+    std::cerr << boost::format("\nERROR: %s\n") % ex.what();
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // -- Write output file ----------------------------------------------

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -587,9 +587,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     }
   }
 
-  //get current performance mode
+  //get current performance mode so it can be restored after the run
   const auto og_pmode = xrt_core::device_query_default<xq::performance_mode>(device, 0);
-  const auto parsed_og_pmode = xq::performance_mode::parse_status(og_pmode);
   // Tracks whether we successfully changed the pmode; only then should we reset it.
   bool pmode_changed = false;
   //--pmode
@@ -615,14 +614,13 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       else {
         throw xrt_core::error(boost::str(boost::format("Invalid pmode value: '%s'\n") % options.m_pmode));
       }
-      pmode_changed = true;
       XBU::verbose(boost::str(boost::format("Setting power mode to `%s` \n") % options.m_pmode));
     }
     else if(!boost::iequals(parsed_og_pmode, "PERFORMANCE")) {
       xrt_core::device_update<xq::performance_mode>(device.get(), xq::performance_mode::power_type::performance);
-      pmode_changed = true;
       XBU::verbose("Setting power mode to `performance`\n");
-    } 
+    }
+    pmode_changed = true;
   } catch (const xq::no_such_key&) {
     // Do nothing, as performance mode setting is not supported
   } catch(const xrt_core::error& e) {
@@ -630,8 +628,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     printHelp();
     throw xrt_core::error(std::errc::operation_canceled);
   } catch (const std::exception&) {
-    std::cout << boost::format("WARNING: User doesn't have admin permissions to set performance mode. Running validate in %s mode") 
-                                    % parsed_og_pmode << std::endl;
+    // Setting performance mode may require privileges the user does not have.
+    // Silently continue running in the current mode.
   }
   // -- Run the tests --------------------------------------------------
   std::ostringstream oSchemaOutput;
@@ -644,8 +642,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   } catch (const xq::no_such_key&) {
     // Do nothing, as performance mode setting is not supported
   } catch (const std::exception & ex) {
-    std::cerr << boost::format("\nERROR: %s\n") % ex.what();
-    throw xrt_core::error(std::errc::operation_canceled);
+    std::cerr << boost::format("\nWARNING: %s\n") % ex.what();
   }
 
   // -- Write output file ----------------------------------------------


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[AIESW-39741](https://jira.xilinx.com/browse/AIESW-39741) xrt-smi validate pmode warning not showing up

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Driver behavior changed a couple weeks back, that's when it was discovered.

#### How problem was solved, alternative solutions (if any) and why they were rejected
remove searching for "permission denied" string as it is not platform agnostic and is unreliable

#### Risks (if any) associated the changes in the commit
N/A. 

#### What has been tested and how, request additional testing if necessary
Tested on windows

```
>xrt-smi validate -r latency
WARNING: User doesn't have admin permissions to set performance mode. Running validate in default mode
Validate Device           : [00c5:00:01.1]
    Platform              : NPU Medusa B0
    Power Mode            : default
-------------------------------------------------------------------------------
Test 1 [00c5:00:01.1]     : latency
    Details               : Average latency: 73.0 us
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed

>echo %errorlevel%
0

```

#### Documentation impact (if any)
N/A