### PR TITLE
AIESW-27796: Support dtrace script binding in profile.json

### DIFF
--- a/src/runtime_src/core/common/runner/profile.md
+++ b/src/runtime_src/core/common/runner/profile.md
@@ -25,7 +25,8 @@ There are two sections of profile json:
 
 1. [qos](#qos)
 2. [bindings](#bindings)
-3. [executions](#executions)
+3. [dtrace](#dtrace)
+4. [executions](#executions)
 
 The `bindings` section defines how external resources are created,
 initialized, and bound to a run-recipe.
@@ -244,6 +245,31 @@ instead of a file:
 
 The validate element will be enhanced to cover other validation
 specifics as needed.
+
+## Dtrace
+
+The `dtrace` section is optional.  It specifies dtrace control scripts to
+associate with specific run objects in the recipe.  Each element binds a
+script file to the recipe run identified by `"name"`.
+
+```
+  "dtrace": [
+    { "name": "run0", "file": "run0.ct" },
+    { "name": "run1", "file": "run1.ct" }
+  ],
+```
+
+- `name` identifies the run object in the recipe by its
+  `recipe.execution.runs[].name` field.
+- `file` is the path to the dtrace control script, resolved through the
+  artifacts repository in the same way as buffer initialization files.
+
+The script is applied by calling `xrt::run::set_dtrace_control_file()` before
+the first execution of the recipe.  Scripts are also applied to any cloned
+run objects created in `throughput` mode.
+
+Only NPU runs support dtrace; entries that match a CPU run are silently
+ignored.
 
 ## Executions
 

--- a/src/runtime_src/core/common/runner/recipe.md
+++ b/src/runtime_src/core/common/runner/recipe.md
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved. -->
+<!-- Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved. -->
 # Run recipe for XRT
 
 A run recipe defines a graph model that can be executed by XRT.
@@ -339,7 +339,17 @@ The `size` is currently specified in bytes.
 ## Execution
 
 The execution section is an ordered list of kernel or cpu instances
-with arguments from the resources section. 
+with arguments from the resources section.
+
+Each run entry has two identifying fields:
+
+- `kernel` — required, names the kernel or cpu resource (from the
+  `resources` section) from which the run object is created.
+- `name` — optional unique identifier for the run object itself.
+  Defaults to the value of `kernel` when not specified.  Use `name`
+  to distinguish between multiple runs that execute the same kernel
+  resource, and to reference the run from a [profile](profile.md)
+  (e.g. to bind a dtrace script to a specific run).
 
 Before the runner can execute the recipe in the execution section, all
 graph inputs and outputs must be bound to the recipe. As mentioned

--- a/src/runtime_src/core/common/runner/repo.cpp
+++ b/src/runtime_src/core/common/runner/repo.cpp
@@ -155,6 +155,9 @@ public:
 
   virtual span<char>
   get(const std::string& key, file_mode hint) const = 0;
+
+  virtual std::filesystem::path
+  get_path(const std::string& key) const = 0;
 };
 
 // class base_repo - Base implementation of repository_impl
@@ -281,6 +284,12 @@ public:
 
     return base_repo::get(key);       // get() resolves key as well
   }
+
+  std::filesystem::path
+  get_path(const std::string& key) const override
+  {
+    return std::filesystem::path{resolve_key(key)};
+  }
 };
 
 ////////////////////////////////////////////////////////////////
@@ -386,6 +395,13 @@ repository::
 get(const std::string& key, file_mode hint) const
 {
   return handle->get(key, hint);
+}
+
+std::filesystem::path
+repository::
+get_path(const std::string& key) const
+{
+  return handle->get_path(key);
 }
 
 }  // namespace xrt_core::artifacts

--- a/src/runtime_src/core/common/runner/repo.h
+++ b/src/runtime_src/core/common/runner/repo.h
@@ -173,6 +173,21 @@ public:
   XRT_API_EXPORT
   span<char>
   get(const std::string& key, file_mode hint) const;
+
+  /**
+   * get_path() - Resolve a key to its filesystem path
+   *
+   * @param key
+   *   Key identifying the artifact (filename, relative or absolute)
+   *
+   * Returns the resolved filesystem path for @a key.  For a
+   * file-based repository this is base_dir/key; for an in-memory
+   * repository the key is returned as-is.  Throws if the resolved
+   * path would escape the base directory.
+   */
+  XRT_API_EXPORT
+  std::filesystem::path
+  get_path(const std::string& key) const;
 };
 
 } // namespace xrt_core::artifacts

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -929,7 +929,8 @@ public:
         
       using run_type = std::variant<xrt::run, xrt_core::cpu::run>;
       using constant_type = std::variant<int, std::string>;
-      std::string m_kernel;
+      std::string m_kernel; // name of kernel from which run is created
+      std::string m_name;   // identifier for this run
       run_type m_run;
       std::map<std::string, argument> m_args;
       std::map<int, constant_type> m_constants;
@@ -1045,11 +1046,15 @@ public:
       static xrt::run
       create_kernel_run(const resources& resources, const json& j)
       {
-        auto name = j.contains("kernel")
+        // The recipe should specify "kernel" name for the run, but
+        // legacy was to use "name" for the kernel.  "kernel" takes
+        // precedence, but if missing, then "name" is the identifier
+        // for the kernel
+        auto kname = j.contains("kernel")
           ? j.at("kernel").get<std::string>()
-          : j.at("name").get<std::string>();  // deprecated
+          : j.at("name").get<std::string>();  // deprecated, required w/o "kernel"
 
-        return xrt::run{resources.get_xrt_kernel_or_error(name)};
+        return xrt::run{resources.get_xrt_kernel_or_error(kname)};
       }
 
       static run_type
@@ -1073,6 +1078,7 @@ public:
         : m_kernel{j.contains("kernel")
                    ? j.at("kernel").get<std::string>()
                    : j.at("name").get<std::string>()} // deprecated
+        , m_name{j.value("name", m_kernel)}
         , m_run{create_run(resources, j)}
         , m_args{create_and_set_args(resources, m_run, j.at("arguments"))}
         , m_constants{create_and_set_constant_args(m_run, j.value("constants", json::object()))}
@@ -1087,6 +1093,7 @@ public:
       // other run are independent in regards to argument data.
       run(const resources& resources, const run& other)
         : m_kernel{other.m_kernel}
+        , m_name{other.m_name}
         , m_run{create_run(resources, other)}
         , m_args{create_and_set_args(resources, m_run, other.m_args)}
         , m_constants{create_and_set_constant_args(m_run, other.m_constants)}

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -929,7 +929,7 @@ public:
         
       using run_type = std::variant<xrt::run, xrt_core::cpu::run>;
       using constant_type = std::variant<int, std::string>;
-      std::string m_name;
+      std::string m_kernel;
       run_type m_run;
       std::map<std::string, argument> m_args;
       std::map<int, constant_type> m_constants;
@@ -944,13 +944,13 @@ public:
       };
 
       struct copy_visitor {
-        const std::string& m_name;
+        const std::string& m_kernel;
         const resources& m_res;
-        copy_visitor(const std::string& nm, const resources& res) : m_name{nm}, m_res{res} {}
+        copy_visitor(const std::string& nm, const resources& res) : m_kernel{nm}, m_res{res} {}
         run_type operator() (const xrt::run&)
-        { return xrt::run{m_res.get_xrt_kernel_or_error(m_name)}; };
+        { return xrt::run{m_res.get_xrt_kernel_or_error(m_kernel)}; };
         run_type operator() (const xrt_core::cpu::run&)
-        { return xrt_core::cpu::run{m_res.get_cpu_function_or_error(m_name)}; };
+        { return xrt_core::cpu::run{m_res.get_cpu_function_or_error(m_kernel)}; };
       };
 
       static std::map<std::string, argument>
@@ -1065,19 +1065,19 @@ public:
       static run_type
       create_run(const resources& resources, const run& other)
       {
-        return std::visit(copy_visitor{other.m_name, resources}, other.m_run);
+        return std::visit(copy_visitor{other.m_kernel, resources}, other.m_run);
       }
 
     public:
       run(const resources& resources, const json& j)
-        : m_name{j.contains("kernel")
-                 ? j.at("kernel").get<std::string>()
-                 : j.at("name").get<std::string>()} // deprecated
+        : m_kernel{j.contains("kernel")
+                   ? j.at("kernel").get<std::string>()
+                   : j.at("name").get<std::string>()} // deprecated
         , m_run{create_run(resources, j)}
         , m_args{create_and_set_args(resources, m_run, j.at("arguments"))}
         , m_constants{create_and_set_constant_args(m_run, j.value("constants", json::object()))}
       {
-        XRT_DEBUGF("recipe::execution::run(%s)\n", m_name.c_str());
+        XRT_DEBUGF("recipe::execution::run(%s)\n", m_kernel.c_str());
       }
 
       // Create a run from another run using argument resources
@@ -1086,12 +1086,12 @@ public:
       // to the runs are copied, so this run along with the argument
       // other run are independent in regards to argument data.
       run(const resources& resources, const run& other)
-        : m_name{other.m_name}
+        : m_kernel{other.m_kernel}
         , m_run{create_run(resources, other)}
         , m_args{create_and_set_args(resources, m_run, other.m_args)}
         , m_constants{create_and_set_constant_args(m_run, other.m_constants)}
       {
-        XRT_DEBUGF("recipe::execution::run(other) name(%s)\n", m_name.c_str());
+        XRT_DEBUGF("recipe::execution::run(other) name(%s)\n", m_kernel.c_str());
       }
 
       bool

--- a/src/runtime_src/core/common/runner/runner.cpp
+++ b/src/runtime_src/core/common/runner/runner.cpp
@@ -1148,6 +1148,19 @@ public:
         arg.bind(bo);
         std::visit(set_arg_visitor{arg.m_argidx, arg.get_xrt_bo()}, m_run);
       }
+
+      const std::string&
+      get_name() const
+      {
+        return m_name;
+      }
+
+      void
+      set_dtrace(const std::string& path)
+      {
+        if (std::holds_alternative<xrt::run>(m_run))
+          std::get<xrt::run>(m_run).set_dtrace_control_file(path);
+      }
     }; // class recipe::execution::run
 
     // struct runlist - a list of runs to execute
@@ -1426,7 +1439,14 @@ public:
         run.bind(name, bo);
     }
 
-    
+    void
+    set_dtrace(const std::string& name, const std::string& path)
+    {
+      for (auto& run : m_runs)
+        if (run.get_name() == name)
+          run.set_dtrace(path);
+    }
+
     // execute_runlist() - execute a runlist synchronously
     // The lambda function is executed asynchronously by an
     // xrt::queue object. The wait is necessary for an NPU runlist,
@@ -1998,6 +2018,47 @@ class profile
     }
   }; // class profile::bindings
 
+  // class dtrace - dtrace script binding section of the profile
+  //
+  // "dtrace": [
+  //   { "name": "run0", "file": "run0.ct" },
+  //   { "name": "run1", "file": "run1.ct" }
+  // ]
+  //
+  // Each element binds a dtrace control script to the recipe run
+  // identified by "name".  The "file" is resolved through the
+  // artifacts repository, consistent with buffer binding files.
+  class dtrace
+  {
+    using name_t = std::string;
+    using path_t = std::filesystem::path;
+    std::map<name_t, path_t> m_scripts;  // run name → resolved script path
+
+    static std::map<name_t, path_t>
+    init_scripts(const json& j, const xartifacts::repo& repo)
+    {
+      std::map<name_t, path_t> scripts;
+      for (const auto& node : j)
+        scripts.emplace(node.at("name").get<std::string>(),
+                        repo.get_path(node.at("file").get<std::string>()));
+      return scripts;
+    }
+
+  public:
+    dtrace() = default;
+
+    dtrace(const json& j, const xartifacts::repo& repo)
+      : m_scripts{init_scripts(j, repo)}
+    {}
+
+    void
+    apply(recipe::execution& re) const
+    {
+      for (const auto& [name, path] : m_scripts)
+        re.set_dtrace(name, path.string());
+    }
+  }; // class profile::dtrace
+
   // class execution - represents the execution section of a profile json
   //
   // {
@@ -2103,13 +2164,16 @@ class profile
         }
       }
 
-      // Bind buffers to recipe and to recipe::execution copies.
+      // Bind buffers and apply dtrace scripts to recipe and copies.
       void
       bind()
       {
         m_profile->bind(*m_base);
-        for (auto& exec : m_copies)
+        m_profile->apply_dtrace(*m_base);
+        for (auto& exec : m_copies) {
           m_profile->bind(exec);
+          m_profile->apply_dtrace(exec);
+        }
       }
 
       // Re-bind buffers to recipe and to recipe::execution copies.
@@ -2327,6 +2391,7 @@ private:
   size_t m_runlist_threshold;
   recipe m_recipe;
   bindings m_bindings;
+  dtrace m_dtrace;
   execution m_execution;
   std::vector<std::unique_ptr<execution>> m_executions;
 
@@ -2334,6 +2399,12 @@ private:
   bind(recipe::execution& exec)
   {
     m_bindings.bind(exec);
+  }
+
+  void
+  apply_dtrace(recipe::execution& exec)
+  {
+    m_dtrace.apply(exec);
   }
 
   void
@@ -2421,6 +2492,7 @@ public:
     , m_runlist_threshold{init_runlist_threshold(m_profile_json)}
     , m_recipe{device, load_json(recipe), m_qos, m_runlist_threshold, m_repo}
     , m_bindings{device, m_profile_json.value("bindings", json::object()), m_repo}
+    , m_dtrace{m_profile_json.value("dtrace", json::array()), m_repo}
     , m_execution(this, &m_recipe, m_profile_json.value("execution", json::object()), true)
     , m_executions(create_executions(this, &m_recipe, m_profile_json.value("executions", json::object())))
   {}


### PR DESCRIPTION
#### Problem solved by the commit

profile.json had no way to associate a dtrace control script with a specific xrt::run object created from a recipe.

#### How problem was solved

Added a top-level "dtrace" section to profile.json that maps run names (recipe.execution.runs[].name) to script files, mirroring how "bindings" maps buffer names to xrt::bo objects.

- repo: add get_path() to resolve an artifact key to its filesystem path, reusing the existing path-traversal-safe resolve_key() logic
- runner: add recipe::execution::run::get_name() and set_dtrace()
- runner: add recipe::execution::set_dtrace(name, path) to locate a run by name and call set_dtrace_control_file() on its xrt::run
- runner: add profile::dtrace class constructed from "dtrace" JSON array; apply() calls recipe::execution::set_dtrace for each entry
- runner: call apply_dtrace() from executor::bind() alongside bind(), including on cloned executions created in throughput mode
- docs: document "dtrace" section in [profile.md](https://github.com/stsoe/XRT/blob/6d55e13c5ba51c080fe7cb405d71179aba60ef40/src/runtime_src/core/common/runner/profile.md) and kernel/name fields in [recipe.md](https://github.com/stsoe/XRT/blob/6d55e13c5ba51c080fe7cb405d71179aba60ef40/src/runtime_src/core/common/runner/recipe.md)

Supporting changes:

> [Rename recipe::execution::run::m_name to m_kernel](https://github.com/Xilinx/XRT/commit/c2e460735b1a562e630dad893341ea75cec47546)
> A recipe run object is created from a kernel.  The recipe runspecifies the name of the kernel from which the run is created.
> 
> Legacy recipe.json files use recipe.execution.runs[].name whereas new syntax is recipe.execution.runs[].kernel.  Both are supported, if "kernel" is missing, then "name" is required.  If both "kernel" and "name" are present, then "name" is an identifier for the particular execution run that can be referenced in profile.json.


> [Add name identifier to execution::runs[] objects](https://github.com/Xilinx/XRT/commit/f55ea13182cdd22c4125c9db6c4b73335bb9d5df) 
> The name is an identifier for the execution run.  This identifier can be used in the profile.json to identify the particular run.


#### Risks

None; "dtrace" section is optional and defaults to an empty array.

#### What has been tested and how

Compiled on Linux.

