### PR TITLE
tools: drop external grep from the Windows check in tool wrappers

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -8,11 +8,13 @@
 #
 
 # -- Detect a Windows environment and automatically switch to the .bat file
-if [ "$(uname | grep -E '^(windows32|CYGWIN)')" ]; then
-    trap "" INT
-    "$0.bat" "$@"
-    exit $?
-fi
+case "$(uname)" in
+    windows32*|CYGWIN*)
+        trap "" INT
+        "$0.bat" "$@"
+        exit $?
+        ;;
+esac
 
 # Working variables
 XRT_PROG=xbmgmt

--- a/src/runtime_src/core/tools/xbutil2/xrt-smi
+++ b/src/runtime_src/core/tools/xbutil2/xrt-smi
@@ -7,11 +7,13 @@
 #
 
 # -- Detect a Windows environment and automatically switch to the .bat file
-if [ "$(uname | grep -E '^(windows32|CYGWIN)')" ]; then
-    trap "" INT
-    "$0.bat" "$@"
-    exit $?
-fi
+case "$(uname)" in
+    windows32*|CYGWIN*)
+        trap "" INT
+        "$0.bat" "$@"
+        exit $?
+        ;;
+esac
 
 # Working variables
 XRT_PROG=xrt-smi

--- a/src/runtime_src/tools/xclbinutil/xclbinutil
+++ b/src/runtime_src/tools/xclbinutil/xclbinutil
@@ -3,11 +3,13 @@
 # Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 
 # -- Detect a Windows environment and automatically switch to the .bat file
-if [ "$(uname | grep -E '^(windows32|CYGWIN)')" ]; then
-  trap "" INT
-  "$0.bat" "$@"
-  exit $?
-fi
+case "$(uname)" in
+  windows32*|CYGWIN*)
+    trap "" INT
+    "$0.bat" "$@"
+    exit $?
+    ;;
+esac
 
 # Working variables
 XRT_PROG=xclbinutil


### PR DESCRIPTION
Avoids shelling out to `grep`, which threw warnings due to a modified `LD_LIBRARY_PATH` in environments like https://binarybuilder.org/. This way should be more portable anyways by not requiring `grep` to be installed on the system