### PR TITLE
[Windows] Fix AIEBU linker crash from IPO

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -36,6 +36,16 @@ if (MSVC)
   # Static linking with the CRT
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+  # Use target-initialized IPO so compiler and linker settings stay paired
+  # when a subdirectory overrides the policy.
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
+
+  # CastGuard requires /GL; key it to each target's IPO property rather than
+  # the build configuration alone.
+  set(_xrt_msvc_cast_guard_enabled
+    "$<AND:$<NOT:$<CONFIG:Debug>>,$<BOOL:$<TARGET_PROPERTY:INTERPROCEDURAL_OPTIMIZATION>>>")
+
   add_compile_options(
     /MT$<$<CONFIG:Debug>:d>  # static linking with the CRT
     /Zc:__cplusplus
@@ -46,17 +56,14 @@ if (MSVC)
     /ZH:SHA_256   # enable secure source code hashing
     /guard:cf     # enable compiler control guard feature (CFG) to prevent attackers from redirecting execution to unsafe locations
     /GF           # eliminate duplicate strings
-    $<$<NOT:$<CONFIG:Debug>>:/guard:cast> # enable cast guard to prevent type confusion
-    $<$<NOT:$<CONFIG:Debug>>:/d2CastGuardFailureMode:fastfail> # fastfail mode for cast guard
-    $<$<NOT:$<CONFIG:Debug>>:/GL>  # enable whole program optimization
+    "$<${_xrt_msvc_cast_guard_enabled}:/guard:cast>" # enable cast guard to prevent type confusion
+    "$<${_xrt_msvc_cast_guard_enabled}:/d2CastGuardFailureMode:fastfail>" # fastfail mode for cast guard
     )
   add_link_options(
     /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
     /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
     $<$<CONFIG:Debug>:/INCREMENTAL>            # enable incremental linking for debug builds
-    $<$<CONFIG:Debug>:/LTCG:OFF>               # disable link time code generation for debug builds
     $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>  # disable incremental linking for release builds
-    $<$<NOT:$<CONFIG:Debug>>:/LTCG>            # enable link time code generation for release builds
     $<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>         # enable COMDAT folding
     $<$<NOT:$<CONFIG:Debug>>:/OPT:REF>         # eliminates functions and data that are never referenced
     /DEBUG           # instruct linker to create debugging info
@@ -66,6 +73,7 @@ if (MSVC)
     /LARGEADDRESSAWARE # enable large address awareness
     /experimental:deterministic # deterministic build
     )
+  unset(_xrt_msvc_cast_guard_enabled)
   if (NOT ${CMAKE_CXX_COMPILER} MATCHES "(arm64|ARM64)")
     add_link_options(
       /CETCOMPAT  # enable Control-flow Enforcement Technology (CET) Shadow Stack mitigation

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -21,7 +21,21 @@ else()
   # AIEBU should use XRT's version of ELFIO
   set(AIEBU_ELFIO_SRC_DIR ${XRT_SOURCE_DIR}/runtime_src/core/common/elf)
 
+  # link.exe overflows its stack when aiebu-asm inherits IPO. Disable IPO only
+  # while AIEBU targets are created.
+  if(MSVC)
+    set(_xrt_interprocedural_optimization
+      "${CMAKE_INTERPROCEDURAL_OPTIMIZATION}")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+  endif()
+
   xrt_add_subdirectory(aiebu)
+
+  if(MSVC)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
+      "${_xrt_interprocedural_optimization}")
+    unset(_xrt_interprocedural_optimization)
+  endif()
 endif()
 
 add_library(core_common_library_objects OBJECT


### PR DESCRIPTION
#### Problem solved by the commit

The x64 Windows Release build fails while linking `aiebu-asm`. MSVC `link.exe` exits with `0xC00000FD` (`STATUS_STACK_OVERFLOW`) during LTCG code generation.

The Windows build enables `/GL` and `/LTCG` through directory-wide options, so AIEBU inherits IPO even though its standalone Windows build does not enable it.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Technically, PR #9500 introduced the failure by enabling `/GL` and `/LTCG` for non-Debug targets under `nativeWin.cmake`, but this was not a problem until recent AIEBU revisions.

The issue was found during a full x64 Windows Release build with Visual Studio 18 Community and MSVC 14.51.36231.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Replace the manual `/GL`, `/LTCG`, and `/LTCG:OFF` pairing with CMake's `INTERPROCEDURAL_OPTIMIZATION`.

IPO is still enabled for non-Debug targets. It is only disabled while AIEBU targets are created, then restored for subsequent targets.

CastGuard follows each target's IPO property because `/guard:cast` requires `/GL`. This removes MSVC warning D9007 from AIEBU targets while preserving CastGuard where IPO remains enabled.

Alternatives considered:

* Disabling IPO for all Windows targets was rejected because only AIEBU triggers the linker failure.
* Disabling IPO only for `aiebu_asm_objects` was tested and still produced the same linker stack overflow.
* Removing and restoring literal `/GL` and `/LTCG` flags around AIEBU was rejected because it depends on their exact spelling and placement.

#### Risks (if any) associated the changes in the commit

Low.

Non-Debug targets retain IPO and CastGuard. AIEBU retains its normal Release optimization settings, including `/O2` and `/Ot`. It simply no longer inherits IPO or CastGuard. The impact of this should be almost unnoticeable. 

**The change is limited to MSVC builds.**

#### What has been tested and how, request additional testing if necessary

* Completed a full x64 Windows Release `ALL_BUILD` with Visual Studio 18 Community and MSVC 14.51.36231.
* Build result: 0 errors and 0 warnings.
* Confirmed that AIEBU targets do not receive `/GL`, `/LTCG`, `/LTCGOUT`, `/guard:cast`, or `/d2CastGuardFailureMode:fastfail`.
* Confirmed that subsequent Release targets retain IPO and CastGuard.

#### Documentation impact (if any)

None.