### PR TITLE
[SWDEV-577798] ASAN: scope MSVC CRT flags for /fsanitize=address builds

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -32,12 +32,24 @@ add_compile_definitions("BOOST_BIND_GLOBAL_PLACEHOLDERS")
 # the warning is bogus.  Remove defintion when fixed
 add_compile_definitions("_SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING")
 
+option(ENABLE_ASAN "Build with AddressSanitizer (/fsanitize=address). Requires MSVC v145 (VS 2026) for ARM64." OFF)
+
 if (MSVC)
-  # Static linking with the CRT
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  if (ENABLE_ASAN)
+    # Always use /MD (not /MDd): ASAN has its own heap tracking and does not
+    # integrate with the debug CRT. Avoids CMake 4.x try_compile rejection of
+    # MultiThreadedDLLDebug for the ARM64 cross-compiler.
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
 
   add_compile_options(
-    /MT$<$<CONFIG:Debug>:d>  # static linking with the CRT
+    # Explicit /MT only on the non-ASAN path. On the ASAN path CRT selection is
+    # driven by CMAKE_MSVC_RUNTIME_LIBRARY / the per-target MSVC_RUNTIME_LIBRARY
+    # property: an explicit /MD here would be mapped into <RuntimeLibrary> by the
+    # VS generator and override the per-target /MT that xclbinutil/xrt-smi need.
+    $<$<NOT:$<BOOL:${ENABLE_ASAN}>>:/MT$<$<CONFIG:Debug>:d>>
     /Zc:__cplusplus
     /Zi           # generate pdb files even in release mode
     /sdl          # enable security checks
@@ -50,9 +62,18 @@ if (MSVC)
     $<$<NOT:$<CONFIG:Debug>>:/d2CastGuardFailureMode:fastfail> # fastfail mode for cast guard
     $<$<NOT:$<CONFIG:Debug>>:/GL>  # enable whole program optimization
     )
+  if (NOT ENABLE_ASAN)
+    # Hybrid CRT is skipped under ASAN. On x64 the static ASan malloc thunk
+    # (asan_malloc_win_thunk) defines malloc/free; forcing the dynamic ucrt.lib
+    # import re-defines them -> LNK2005/LNK1169 in the /MT tool targets
+    # (xclbinutil, xrt-smi). Keeping the standard static ucrt default for /MT lets
+    # ASan intercept the allocator cleanly. No-op for /MD targets and ARM64.
+    add_link_options(
+      /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
+      /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
+      )
+  endif()
   add_link_options(
-    /NODEFAULTLIB:libucrt$<$<CONFIG:Debug>:d>.lib  # Hybrid CRT
-    /DEFAULTLIB:ucrt$<$<CONFIG:Debug>:d>.lib       # Hybrid CRT
     $<$<CONFIG:Debug>:/INCREMENTAL>            # enable incremental linking for debug builds
     $<$<CONFIG:Debug>:/LTCG:OFF>               # disable link time code generation for debug builds
     $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>  # disable incremental linking for release builds
@@ -70,6 +91,22 @@ if (MSVC)
     add_link_options(
       /CETCOMPAT  # enable Control-flow Enforcement Technology (CET) Shadow Stack mitigation
       )
+  endif()
+  if (ENABLE_ASAN)
+    # Derive ASAN lib dir from compiler path:
+    # .../MSVC/<ver>/bin/Hostx64/<arch>/cl.exe -> .../MSVC/<ver>/lib/<arch>/
+    get_filename_component(_asan_lib_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+    get_filename_component(_asan_lib_dir "${_asan_lib_dir}" DIRECTORY)
+    get_filename_component(_asan_lib_dir "${_asan_lib_dir}" DIRECTORY)
+    get_filename_component(_asan_lib_dir "${_asan_lib_dir}" DIRECTORY)
+    if (${CMAKE_CXX_COMPILER} MATCHES "(arm64|ARM64)")
+      set(_asan_lib_dir "${_asan_lib_dir}/lib/arm64")
+    else()
+      set(_asan_lib_dir "${_asan_lib_dir}/lib/x64")
+    endif()
+    link_directories("${_asan_lib_dir}")
+    add_compile_options(/fsanitize=address)
+    add_link_options(/INCREMENTAL:NO)
   endif()
 endif()
 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -68,8 +68,16 @@ else()
   set(XRT_HELPER_SCRIPTS "xrt-smi")
 endif()
 
+
 xrt_configure_version_file(${XBUTIL2_NAME} APP)
 add_executable(${XBUTIL2_NAME} ${XBUTIL2_NAME}-version.rc ${XBUTIL_V2_SRCS})
+
+if (ENABLE_ASAN)
+  # xrt-smi links static Boost (/MT). Override the global MultiThreadedDLL
+  # set by ASAN so the object files match the Boost libraries' CRT metadata.
+  set_target_properties(${XBUTIL2_NAME} PROPERTIES
+    MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 # Determine what functionality should be added
 if (NOT XRT_EDGE OR DEFINED XDNA_VE2)

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -101,8 +101,16 @@ file(GLOB XCLBINUTIL_MAIN_FILE
 )
 set(XCLBINUTIL_SRCS ${XCLBINUTIL_MAIN_FILE} ${XCLBINUTIL_FILES_SRCS})
 
+
 xrt_configure_version_file(${XCLBINUTIL_NAME} APP)
 add_executable(${XCLBINUTIL_NAME} ${XCLBINUTIL_NAME}-version.rc ${XCLBINUTIL_SRCS})
+
+if (ENABLE_ASAN)
+  # xclbinutil links static Boost (/MT). Override the global MultiThreadedDLL
+  # set by ASAN so the object files match the Boost libraries' CRT metadata.
+  set_target_properties(${XCLBINUTIL_NAME} PROPERTIES
+    MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 # Signing xclbin images currently is not support on windows
 if(NOT WIN32)


### PR DESCRIPTION
Problem solved by the commit

  -asan (/fsanitize=address) builds of XRT failed on Windows/MSVC for both x64 and ARM64 due to C runtime (CRT) and
  ASan-runtime library mismatches. AddressSanitizer requires the dynamic CRT (/MD), but the XRT Windows build hard-codes
   the static CRT (/MT) for static-Boost tool targets, producing LNK2038/LNK1319 runtime-library-mismatch link failures.
   This commit makes ENABLE_ASAN builds link and run cleanly while leaving the default (non-ASAN) build completely
  unchanged.

  Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

  Not a regression fix — no prior PR introduced a defect. This is enablement work: the existing Windows CMake hardening
  (static /MT CRT, Hybrid-CRT ucrt swap) was simply never reconciled with /fsanitize=address, which mandates the dynamic
   CRT. Discovered when attempting to produce an ASAN-instrumented XRT build (Jira SWDEV-577798): the VS generator maps
  an explicit /MT into per-object <RuntimeLibrary>, overriding the per-target MSVC_RUNTIME_LIBRARY property, so
  instrumented /MD objects collided with /MT at link time.

  How problem was solved, alternative solutions (if any) and why they were rejected

  All changes are strictly scoped behind ENABLE_ASAN and are no-ops on the default build:
  - nativeWin.cmake: on the ASAN path select the dynamic CRT via CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL, and emit
  the explicit /MT only when NOT ENABLE_ASAN. Skip the Hybrid-CRT ucrt swap under ASAN so the static ASan malloc thunk
  can intercept the allocator cleanly. Derive the ASan lib dir from the compiler path (lib/x64 or lib/arm64), add
  /fsanitize=address and /INCREMENTAL:NO.
  - xclbinutil / xbutil2 (xrt-smi) CMakeLists: keep these /MT static-Boost tool targets building without ASAN
  instrumentation, so they are not dropped from build output — the driver INF requires xclbinutil.exe / xrt-smi.exe.
  - aiebu submodule bump for the matching ASAN CRT scoping.

  Alternatives rejected: (1) Instrumenting xclbinutil/xrt-smi too — rejected because they link prebuilt non-instrumented
   static Boost, forcing /MD there yields container-overflow annotation mismatches (LNK2038
  annotate_string/annotate_vector). (2) Forcing /MD globally via an explicit compile flag — rejected because the VS
  generator overrides the per-target property, re-breaking the /MT tool targets. Using CMAKE_MSVC_RUNTIME_LIBRARY +
  guarding explicit flags is the only combination that lets per-target overrides survive.

  Risks (if any) associated the changes in the commit

  Low. Every change is gated on ENABLE_ASAN (default OFF), so the shipping/default build path is bit-for-bit unaffected.
   Residual risk is confined to the opt-in ASAN configuration: the ASan lib-dir derivation assumes the standard MSVC
  bin/Hostx64/<arch> → lib/<arch> layout, and ARM64 ASAN requires MSVC v145 (VS 2026).

  What has been tested and how, request additional testing if necessary

  Both x64 and ARM64 -asan builds were run to completion — GREEN. Verified xclbinutil.exe and xrt-smi.exe are present in
   the build output (INF requirement). Default (non-ASAN) build path unchanged by construction (all edits behind NOT
  ENABLE_ASAN / ENABLE_ASAN guards). Requested additional testing: runtime execution of an ASAN-instrumented XRT load to
   confirm the interceptor initializes and no CRT double-allocation occurs at process start.

  Documentation impact (if any)

  None. No public API, CLI, or user-facing behavior change; ENABLE_ASAN is an internal opt-in developer build flag. A
  short note in the Windows build README on enabling ASAN (and the ARM64 VS 2026 / v145 requirement) would be a
  nice-to-have but is not required by this commit.
