### PR TITLE
Add NPU3 f8, f9, f11, and f12 hardware types.

### DIFF
--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -173,7 +173,11 @@ smi_hardware_config()
     {{0x17f1, 0x13}, hardware_type::npu3_f5},
     {{0x17f1, 0x15}, hardware_type::npu3_f6},
     {{0x17f1, 0x11}, hardware_type::npu3_f7},
+    {{0x17f3, 0x11}, hardware_type::npu3_f8},
+    {{0x17f3, 0x12}, hardware_type::npu3_f9},
     {{0x17f1, 0x14}, hardware_type::npu3_f10},
+    {{0x17f3, 0x13}, hardware_type::npu3_f11},
+    {{0x17f3, 0x14}, hardware_type::npu3_f12},
     {{0x1B0A, 0x00}, hardware_type::npu3_B01},
     {{0x1B0B, 0x00}, hardware_type::npu3_B02},
     {{0x1B0C, 0x00}, hardware_type::npu3_B03},
@@ -212,7 +216,11 @@ get_family(hardware_type hw)
   case hardware_type::npu3_f5:
   case hardware_type::npu3_f6:
   case hardware_type::npu3_f7:
+  case hardware_type::npu3_f8:
+  case hardware_type::npu3_f9:
   case hardware_type::npu3_f10:
+  case hardware_type::npu3_f11:
+  case hardware_type::npu3_f12:
   case hardware_type::npu3_B01:
   case hardware_type::npu3_B02:
   case hardware_type::npu3_B03:

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -230,7 +230,11 @@ public:
     npu3_f5, // XXXXX
     npu3_f6, // XXXXX 
     npu3_f7, // XXXXX
+    npu3_f8, // XXXXX
+    npu3_f9, // XXXXX
     npu3_f10, // XXXXX
+    npu3_f11, // XXXXX
+    npu3_f12, // XXXXX
     npu3_B01, // XXXXX
     npu3_B02, // XXXXX
     npu3_B03, // XXXXX


### PR DESCRIPTION
Register new 0x17f3 PCIe device IDs and map them to the npu3 family for xrt-smi config and archive routing.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR adds some new npu3 device types to the list required for PF/VF related additions

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None. Found through internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via augmenting the list

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Not tested. David will test on a B0 board with VF setup

#### Documentation impact (if any)
None
