### PR TITLE
AIESW-40532 xrt-smi runlist-throughput test fails with error memory manager

### DIFF
--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -32,7 +32,7 @@ public:
   template <typename CommandType>
   using cmd_bo = std::pair<std::unique_ptr<buffer_handle>, CommandType *const>;
   // Expose bo size in bytes to clients who use default bo_cache type
-  static constexpr size_t bo_size = BoSize * 1024u; // NOLINT
+  static constexpr size_t bo_size = BoSize; // NOLINT
 
 private:
   std::shared_ptr<device> m_device;


### PR DESCRIPTION
#### Problem solved by the commit
Restores execbuf command BOs to their correct byte size, fixing runlist-throughput failing with WDDM 0xc01e0200 (video memory manager could not page-in all required allocations) on NPU.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixes a 1024x execbuf BO over-allocation introduced by #9895 (SWSPLAT-30708); discovered via xrt-smi validate -r runlist-throughput failing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Dropped the erroneous KiB multiplier so bo_size = BoSize (byte-denominated, as before); rejected re-denominating to KiB (bo_cache_t<4>) as it would need every instantiation and execbuf_size changed for no benefit.

#### Risks (if any) associated the changes in the commit
Low — one-line revert of a sizing regression; #9895's arg offset/size bounds checks, payload_size() and m_payload_size are untouched, so the CWE-787 OOB-write fix is fully preserved.

#### What has been tested and how, request additional testing if necessary
Verified bo_cache_t<4096>=4KB and bo_cache_t<execbuf_size>=execbuf_size bytes, and payload_size() ceiling back to ~4KB; tested by running runlist-throughput + full xrt-smi validate to confirm.

#### Documentation impact (if any)
None.