### PR TITLE
SWSPLAT-30708 fix bo_cache bo_size regression from 9f49fda (#9895)

### DIFF
--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -32,7 +32,7 @@ public:
   template <typename CommandType>
   using cmd_bo = std::pair<std::unique_ptr<buffer_handle>, CommandType *const>;
   // Expose bo size in bytes to clients who use default bo_cache type
-  static constexpr size_t bo_size = BoSize * 1024u; // NOLINT
+  static constexpr size_t bo_size = BoSize;
 
 private:
   std::shared_ptr<device> m_device;


### PR DESCRIPTION
#### Problem solved by the commit
9f49fda (PR #9895) renamed m_bo_size to bo_size and accidentally introduced a * 1024u multiplier, inflating the exec BO allocation from 4 KB to 4 MB.

Remove the multiplier; BoSize has always been in bytes.

