### PR TITLE
Enable building of XRT HIP bindings by default.

### DIFF
--- a/src/CMake/settings.cmake
+++ b/src/CMake/settings.cmake
@@ -24,6 +24,9 @@ endif()
 # Option to enable/disable emulation libraries
 option(XRT_ENABLE_EMULATION "Enable Alveo emulation" ON)
 
+# Option to enable HIP bindings
+option(XRT_ENABLE_HIP "Enable hip bindings" ON)
+
 # Indicate that we are building XRT
 add_compile_definitions("XRT_BUILD")
 


### PR DESCRIPTION
#### Problem solved by the commit
Addresses the build part of SR-991005.

Add XRT_ENABLE_HIP cmake option and default to ON.
Building of HIP bindings is now enabled on all platforms. `build.sh -hip` has no effect and is hereby deprecated.

