### PR TITLE
update aiebu submodule and uc log schema to latest

### DIFF
--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -755,11 +755,10 @@ class module_run_aie_gen2_plus : public module_run
     }
 
     // Get dump buffer data from config
-    if (m_config.dump_buf.size() == 0) {
-      xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
-                              "Dump section is empty in ELF");
-      return false;
-    }
+    // Dump map is required only for jprobe; pass empty string when ELF has no .dump section.
+    const std::string map_data = (m_config.dump_buf.size() == 0)
+      ? std::string{}
+      : m_config.dump_buf.to_string();
 
     // log level 0: error, 1: warning, 2: info
     auto log_level = static_cast<uint32_t>(xrt_core::config::get_dtrace_log_level());
@@ -768,7 +767,7 @@ class module_run_aie_gen2_plus : public module_run
     // output format 0: python, 1: json
     uint32_t output_fmt = xrt_core::config::get_dtrace_output_json_format() ? 1U : 0U;
 
-    m_dtrace = dtrace_util(path, m_config.dump_buf.to_string(), log_level, output_fmt);
+    m_dtrace = dtrace_util(path, map_data, log_level, output_fmt);
     if (!m_dtrace.dtrace_handle.get()) {
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
         "[dtrace] : Failed to get dtrace handle");
@@ -1175,8 +1174,11 @@ public:
 
         get_dtrace_result_file(m_dtrace.dtrace_handle.get(), result_file_name);
 
-        xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
-                                std::string{"[dtrace] : dtrace buffer dumped successfully to - "} + result_file_name);
+        // Check if file exists/created/probes fired and log the message
+        if (std::filesystem::exists((std::filesystem::current_path() / result_file_name).string()))
+          xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
+                                  std::string{"[dtrace] : dtrace buffer dumped successfully to - "}
+                                  + (std::filesystem::current_path() / result_file_name).string());
       }
     }
     catch (const std::exception& e) {

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1175,10 +1175,11 @@ public:
         get_dtrace_result_file(m_dtrace.dtrace_handle.get(), result_file_name);
 
         // Check if file exists/created/probes fired and log the message
-        if (std::filesystem::exists((std::filesystem::current_path() / result_file_name).string()))
+        const auto result_file_path = std::filesystem::current_path() / result_file_name;
+        if (std::filesystem::exists(result_file_path))
           xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module",
                                   std::string{"[dtrace] : dtrace buffer dumped successfully to - "}
-                                  + (std::filesystem::current_path() / result_file_name).string());
+                                  + result_file_path.string());
       }
     }
     catch (const std::exception& e) {

--- a/src/runtime_src/core/common/uc_log_schema.h
+++ b/src/runtime_src/core/common/uc_log_schema.h
@@ -192,7 +192,8 @@ uc_log_schema = {
     {137, "npi error caught\n"},
     {138, "restore L2 done & load_last_pdi start\n"},
     {139, "restore done\n"},
-    {140, "\n"}
+    {140, "assert\n"},
+    {141, "\n"}
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Update aiebu submodule to latest and align XRT dynamic tracing integration with recent changes, pull in
- https://github.com/Xilinx/aiebu/pull/335 (https://jira.xilinx.com/browse/AIESW-37536)
- https://github.com/Xilinx/aiebu/pull/338 (https://jira.xilinx.com/browse/AIESW-40230)

Update uc log schema to latest version

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

NA - these are capability and performance improvements, not regressions

#### How problem was solved, alternative solutions (if any) and why they were rejected

Empty .dump section blocking dtrace - dtrace init was rejected whenever the ELF had no .dump section, even for scripts using only begin/end/tracepoint probes that do not need the debug map. Updated XRT module integration to pass empty map data when .dump is absent

#### Risks (if any) associated the changes in the commit

Low, this applies only when dynamic tracing is enabled

#### What has been tested and how, request additional testing if necessary

Tested by dumping tracing json result on windows medusa board and the update works as expected

#### Documentation impact (if any)

NA
