### PR TITLE
Re-Integrate AIESW-3443 Initial ABI support for xrt-smi

### DIFF
--- a/src/runtime_src/core/common/smi/smi_alveo.cpp
+++ b/src/runtime_src/core/common/smi/smi_alveo.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "core/common/smi/smi_alveo.h"
 
@@ -41,7 +41,7 @@ create_validate_subcommand()
   validate_suboptions.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   validate_suboptions.emplace("format", std::make_shared<xrt_core::smi::option>("format", "f", "Report output format. Valid values are:\n"
                                 "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"));
+                                "\tJSON-2020.2 - JSON 2020.2 schema (legacy)", "common", "JSON", "string"));
   validate_suboptions.emplace("output", std::make_shared<xrt_core::smi::option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   validate_suboptions.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   validate_suboptions.emplace("run", std::make_shared<xrt_core::smi::listable_description_option>("run", "r", "Run a subset of the test suite. Valid options are:\n",
@@ -79,7 +79,7 @@ create_examine_subcommand()
   examine_suboptions.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   examine_suboptions.emplace("format", std::make_shared<xrt_core::smi::option>("format", "f", "Report output format. Valid values are:\n"
                                 "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"));
+                                "\tJSON-2020.2 - JSON 2020.2 schema (legacy)", "common", "JSON", "string"));
   examine_suboptions.emplace("output", std::make_shared<xrt_core::smi::option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   examine_suboptions.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   examine_suboptions.emplace("report", std::make_shared<xrt_core::smi::listable_description_option>("report", "r", "The type of report to be produced. Reports currently available are:\n", "common", "", "array", examine_report_desc));

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #define XRT_CORE_COMMON_SOURCE
 
@@ -63,7 +63,7 @@ config_gen_ryzen::create_validate_subcommand()
   validate_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   validate_suboptions.emplace("format", std::make_shared<option>("format", "f", "Report output format. Valid values are:\n"
                                 "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"));
+                                "\tJSON-2020.2 - JSON 2020.2 schema (legacy)", "common", "JSON", "string"));
   validate_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   validate_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   validate_suboptions.emplace("run", std::make_shared<listable_description_option>("run", "r", "Run a subset of the test suite. Valid options are:\n",
@@ -82,7 +82,7 @@ config_gen_ryzen::create_examine_subcommand()
   examine_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   examine_suboptions.emplace("format", std::make_shared<option>("format", "f", "Report output format. Valid values are:\n"
                                 "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"));
+                                "\tJSON-2020.2 - JSON 2020.2 schema (legacy)", "common", "JSON", "string"));
   examine_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   examine_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   examine_suboptions.emplace("watch", std::make_shared<option>("watch", "", "Refresh interval in seconds between examine updates. Exit with Ctrl+C.", "hidden", "0", "string"));
@@ -137,6 +137,42 @@ config_gen_npu3()
     {"sanity", "Run a small model and validate sanity of the device", "hidden"},
     {"preemption-overhead", "Measure preemption overhead at noop and memtile levels", "hidden"}
   };
+}
+
+subcommand
+config_gen_npu3::create_validate_subcommand()
+{
+  std::map<std::string, std::shared_ptr<option>> validate_suboptions;
+  validate_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  validate_suboptions.emplace("json", std::make_shared<option>("json", "", "JSON ABI version for file output. Valid values are:\n"
+                                "\tdefault - Latest JSON schema (default)", "common", "default", "string"));
+  validate_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
+  validate_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  validate_suboptions.emplace("run", std::make_shared<listable_description_option>("run", "r", "Run a subset of the test suite. Valid options are:\n",
+                              "common", "",  "array", get_validate_test_desc()));
+  validate_suboptions.emplace("param", std::make_shared<option>("param", "", "Extended parameter for a given test. Format: <test-name>:<key>:<value>", "param", "", "string"));
+  validate_suboptions.emplace("pmode", std::make_shared<option>("pmode", "", "Specify which power mode to run the benchmarks in. Note: Some tests might be unavailable for some modes", "hidden", "", "string"));
+  validate_suboptions.emplace("loop", std::make_shared<option>("loop", "", "Number of iterations to run the test", "hidden", "", "string"));
+
+  return {"validate", "Validates the given device by executing the platform's validate executable", "common", std::move(validate_suboptions)};
+}
+
+subcommand
+config_gen_npu3::create_examine_subcommand()
+{
+  std::map<std::string, std::shared_ptr<option>> examine_suboptions;
+  examine_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  examine_suboptions.emplace("json", std::make_shared<option>("json", "", "JSON ABI version for file output. Valid values are:\n"
+                                "\tdefault - Latest JSON schema (default)", "common", "default", "string"));
+  examine_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
+  examine_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  examine_suboptions.emplace("watch", std::make_shared<option>("watch", "", "Refresh interval in seconds between examine updates. Exit with Ctrl+C.", "hidden", "0", "string"));
+  examine_suboptions.emplace("report", std::make_shared<listable_description_option>("report", "r", "The type of report to be produced. Reports currently available are:\n", "common", "", "array", get_examine_report_desc()));
+  examine_suboptions.emplace("firmware-log", std::make_shared<option>("firmware-log", "", "Show status|watch firmware log data", "hidden", "", "string", true));
+  examine_suboptions.emplace("event-trace", std::make_shared<option>("event-trace", "", "Show status|watch event trace data", "hidden", "", "string", true));
+  examine_suboptions.emplace("context-health", std::make_shared<option>("context-health", "", "Show status|watch context health data", "hidden", "", "string", true));
+
+  return {"examine", "This command will 'examine' the state of the system/device and will generate a report of interest in a text or JSON format.", "common", std::move(examine_suboptions)};
 }
 
 static std::shared_ptr<config_gen_ryzen>

--- a/src/runtime_src/core/common/smi/smi_ryzen.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #pragma once
 
@@ -76,6 +76,12 @@ public:
   {
     return validate_test_desc;
   }
+
+  xrt_core::smi::subcommand
+  create_validate_subcommand() override;
+
+  xrt_core::smi::subcommand
+  create_examine_subcommand() override;
 };
 
 void

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -1,5 +1,7 @@
 /**
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,44 +19,99 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "Report.h"
-#include "core/common/time.h"
 
+#include "core/common/time.h"
 #include <boost/algorithm/string/predicate.hpp>
-#include <sstream>
 
 // Initialize our static mapping.
 const Report::SchemaDescriptionVector Report::m_schemaVersionVector = {
-  { SchemaVersion::unknown,       false, "",              "Unknown entry"},
-  { SchemaVersion::json_20202,    true,  "JSON",          "Latest JSON schema"}, // Note: to be updated to the latest schema version every release
-  { SchemaVersion::json_internal, false, "JSON-internal", "Internal JSON property tree"},
-  { SchemaVersion::json_20202,    true,  "JSON-2020.2",   "JSON 2020.2 schema"}
+  { SchemaVersion::unknown,       false, "",            "Unknown entry"},
+  { SchemaVersion::json_latest,   true,  "JSON",        "Latest JSON schema (default)"},
+  { SchemaVersion::json_latest,   false, "default",     "Latest JSON schema (default)"},
+  { SchemaVersion::json_internal, false, "",            "Internal JSON property tree"},
+  { SchemaVersion::json_20202,    true,  "JSON-2020.2", "JSON 2020.2 schema (legacy)"},
 };
 
-
 const Report::SchemaDescription &
-Report::getSchemaDescription(const std::string & _schemaVersionName) 
+Report::getSchemaDescription(const std::string & name)
 {
-  // Look for a match
   for (const auto & entry : m_schemaVersionVector) {
-    if (boost::iequals(entry.optionName, _schemaVersionName)) 
+    if (!entry.optionName.empty() && boost::iequals(entry.optionName, name))
       return entry;
   }
 
-  // Return back the unknown entry
-  return getSchemaDescription("");
+  return getSchemaDescription(SchemaVersion::unknown);
 }
 
-const Report::SchemaDescription & 
-Report::getSchemaDescription(SchemaVersion _schemaVersion)
+const Report::SchemaDescription &
+Report::getSchemaDescription(SchemaVersion version)
 {
-  // Look for a match
+  // A SchemaVersion may map to multiple registry rows (e.g. json_latest has both
+  // "JSON" and "default"). Prefer the --format row for canonical naming in errors.
+  const SchemaDescription* fallback = nullptr;
   for (const auto & entry : m_schemaVersionVector) {
-    if (entry.schemaVersion == _schemaVersion) 
+    if (entry.schemaVersion != version)
+      continue;
+    if (entry.isVisable)
       return entry;
+    fallback = &entry;
   }
 
-  // Return back the unknown entry
+  // No --format row (e.g. json_internal); return the sole --json or internal row.
+  if (fallback)
+    return *fallback;
+
   return getSchemaDescription(SchemaVersion::unknown);
+}
+
+Report::SchemaVersion
+Report::resolve_json_abi(bool json_platform, bool explicit_selector, const std::string& version)
+{
+  if (!explicit_selector)
+    return SchemaVersion::json_latest;
+
+  // json_platform selects isVisable=false (--json) vs isVisable=true (--format) entries.
+  // Each path rejects names that belong to the other flag.
+  const auto lookup_name = json_platform && version.empty() ? "default" : version;
+
+  for (const auto& entry : m_schemaVersionVector) {
+    if (entry.optionName.empty() || !boost::iequals(entry.optionName, lookup_name))
+      continue;
+    if (entry.isVisable == !json_platform)
+      return entry.schemaVersion;
+    return SchemaVersion::unknown;
+  }
+
+  return SchemaVersion::unknown;
+}
+
+bool
+Report::JsonAbi::valid_user_abi(SchemaVersion version)
+{
+  switch (version) {
+  case SchemaVersion::json_latest:
+  case SchemaVersion::json_20202:
+    return true;
+  default:
+    return false;
+  }
+}
+
+boost::property_tree::ptree
+Report::JsonAbi::make_json_header(const std::string& schema_label)
+{
+  boost::property_tree::ptree node;
+  node.put("schema", schema_label.empty() ? "unknown" : schema_label);
+  node.put("creation_date", xrt_core::timestamp());
+  return node;
+}
+
+// Shapes the internal report tree to match a frozen JSON ABI.
+boost::property_tree::ptree
+Report::JsonAbi::fit_abi_tree(SchemaVersion /*version*/,
+                              const boost::property_tree::ptree& tree)
+{
+  return tree;
 }
 
 Report::Report(const std::string & _reportName,
@@ -65,7 +122,6 @@ Report::Report(const std::string & _reportName,
   , m_isDeviceRequired(_isDeviceRequired)
   , m_isHidden(false)
 {
-  // Empty
 }
 
 Report::Report(const std::string & _reportName,
@@ -77,30 +133,31 @@ Report::Report(const std::string & _reportName,
   , m_isDeviceRequired(_isDeviceRequired)
   , m_isHidden(_isHidden)
 {
-  // Empty
 }
 
-void 
-Report::getFormattedReport( const xrt_core::device *pDevice, 
-                            SchemaVersion schemaVersion,
-                            const std::vector<std::string> & elementFilter,
-                            std::ostream & consoleStream,
-                            boost::property_tree::ptree & pt) const
+void
+Report::getFormattedReport(const xrt_core::device *pDevice,
+                           SchemaVersion schemaVersion,
+                           const std::vector<std::string> & elementFilter,
+                           std::ostream & consoleStream,
+                           boost::property_tree::ptree & pt) const
 {
-  // If an exception occurs while generating a report throw an error in the catch
   try {
     switch (schemaVersion) {
       case SchemaVersion::json_internal:
         getPropertyTreeInternal(pDevice, pt);
         break;
 
-      case SchemaVersion::json_20202:
-        getPropertyTree20202(pDevice, pt);
+      case SchemaVersion::json_latest:
+      case SchemaVersion::json_20202: {
+        boost::property_tree::ptree internal;
+        getPropertyTreeInternal(pDevice, internal);
+        pt = JsonAbi::fit_abi_tree(schemaVersion, internal);
         break;
+      }
 
       default:
         throw std::runtime_error("ERROR: Unknown schema version.");
-        break;
     }
 
     writeReport(pDevice, pt, elementFilter, consoleStream);

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __Report_h_
 #define __Report_h_
@@ -15,20 +15,18 @@
 
 class Report : public JSONConfigurable {
  public:
-  // Supported JSON schemas.
-  // 
-  // Remember to update the initialization of Report::m_schemaVersionMapping 
-  // if new enumeration values are added
+  // Numbered ABIs are for parser-breaking ptree changes.
+  // Alveo / AIE2 use --format, else use --json.
   enum class SchemaVersion  {
     unknown,
     json_internal,
-    json_20202,
+    json_latest,
+    json_20202,      // Legacy ABI (--format JSON-2020.2 only, identical to JSON)
   };
- 
-  // Helper mapping between string and enum
+
   struct SchemaDescription {
     SchemaVersion schemaVersion;
-    bool isVisable;
+    bool isVisable;                // Listed in --format help
     std::string optionName;
     std::string shortDescription;
   };
@@ -39,6 +37,25 @@ class Report : public JSONConfigurable {
   static const Report::SchemaDescription & getSchemaDescription(const std::string & _schemaVersionName);
   static const Report::SchemaDescription & getSchemaDescription(SchemaVersion _schemaVersion);
   static const SchemaDescriptionVector & getSchemaDescriptionVector() { return m_schemaVersionVector; };
+
+  /**
+   * Resolves the JSON ABI from CLI state.
+   * @param json_platform     true when --json is active (explicit or platform default)
+   * @param explicit_selector true when the user passed --json or --format
+   * @param version           --json or --format value depending on json_platform
+   */
+  static SchemaVersion resolve_json_abi(bool json_platform,
+                                        bool explicit_selector,
+                                        const std::string& version);
+
+  /** Helpers for JSON file output (header node, ABI-specific tree shaping). */
+  struct JsonAbi {
+    /** True for ABIs that write user-facing JSON to -o (excludes internal/unknown). */
+    static bool valid_user_abi(SchemaVersion version);
+    static boost::property_tree::ptree make_json_header(const std::string& schema_label);
+    static boost::property_tree::ptree fit_abi_tree(SchemaVersion version,
+                                                    const boost::property_tree::ptree& tree);
+  };
 
   // Supporting APIs
  public:
@@ -83,5 +100,3 @@ class Report : public JSONConfigurable {
 using ReportCollection = std::vector<std::shared_ptr<Report>>;
 
 #endif
-
-

--- a/src/runtime_src/core/tools/common/SmiDefault.cpp
+++ b/src/runtime_src/core/tools/common/SmiDefault.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // Local - Include Files
 
@@ -26,7 +26,7 @@ create_validate_subcommand()
   validate_suboptions.emplace("device", std::make_shared<xrt_core::smi::option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
   validate_suboptions.emplace("format", std::make_shared<xrt_core::smi::option>("format", "f", "Report output format. Valid values are:\n"
                                 "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema", "common", "JSON", "string"));
+                                "\tJSON-2020.2 - JSON 2020.2 schema (legacy)", "common", "JSON", "string"));
   validate_suboptions.emplace("output", std::make_shared<xrt_core::smi::option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   validate_suboptions.emplace("help", std::make_shared<xrt_core::smi::option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   validate_suboptions.emplace("run", std::make_shared<xrt_core::smi::option>("run", "r", "Run a subset of the test suite\n",

--- a/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdExamineInternal.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -122,7 +122,7 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  const auto validated_format = m_format.empty() ? "json" : m_format;
+  const auto validated_format = m_format.empty() ? "JSON" : m_format;
   Report::SchemaVersion schemaVersion = Report::getSchemaDescription(validated_format).schemaVersion;
   try{
     if (vm.count("output") && m_output.empty())
@@ -224,7 +224,9 @@ SubCmdExamineInternal::execute(const SubCmdOptions& _options) const
   // Create the report
   std::ostringstream oSchemaOutput;
   try {
-    XBU::produce_reports(device, reportsToProcess, schemaVersion, m_elementsFilter, std::cout, oSchemaOutput);
+    XBU::produce_reports(device, reportsToProcess, schemaVersion,
+                         Report::getSchemaDescription(validated_format).optionName,
+                         m_elementsFilter, std::cout, oSchemaOutput);
   } catch (const std::exception&) {
     // Exception is thrown at the end of this function to allow for report writing
     is_report_output_valid = false;

--- a/src/runtime_src/core/tools/common/SubCmdJsonObjects.cpp
+++ b/src/runtime_src/core/tools/common/SubCmdJsonObjects.cpp
@@ -192,6 +192,16 @@ JsonConfig::addProgramOptions(po::options_description& options
   subCommandIter->second.addProgramOptions(options, optionsType);
 }
 
+bool
+JsonConfig::has_option(const std::string& subCommand, const std::string& optionName) const
+{
+  const auto subCommandIter = m_subCommandMap.find(subCommand);
+  if (subCommandIter == m_subCommandMap.end())
+    return false;
+
+  return subCommandIter->second.getOptionMap().count(optionName) > 0;
+}
+
 void
 JsonConfig::printConfigurations() const
 {

--- a/src/runtime_src/core/tools/common/SubCmdJsonObjects.h
+++ b/src/runtime_src/core/tools/common/SubCmdJsonObjects.h
@@ -102,6 +102,12 @@ public:
   JsonConfig() = default;
 
   void addProgramOptions(po::options_description& options, const std::string& optionsType, const std::string& subCommand);
+
+  /**
+   * Returns true when subCommand defines optionName in its SMI configuration.
+   * Used to distinguish --json platforms from --format platforms at runtime.
+   */
+  bool has_option(const std::string& subCommand, const std::string& optionName) const;
   void printConfigurations() const;
 };
 } // namespace SubCmdJsonObjects

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -242,7 +242,8 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
 void 
 XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device, 
                               const ReportCollection & reportsToProcess, 
-                              const Report::SchemaVersion schemaVersion, 
+                              Report::SchemaVersion schema_version,
+                              const std::string& schema_label,
                               const std::vector<std::string> & elementFilter,
                               std::ostream & consoleStream,
                               std::ostream & schemaStream)
@@ -253,7 +254,7 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     return;
   }
 
-  if (schemaVersion == Report::SchemaVersion::unknown) {
+  if (schema_version == Report::SchemaVersion::unknown) {
     consoleStream << "Info: No action taken, 'UNKNOWN' schema value specified.\n";
     return;
   }
@@ -261,14 +262,7 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
   // Working property tree
   boost::property_tree::ptree ptRoot;
 
-  // Add schema version
-  {
-    boost::property_tree::ptree ptSchemaVersion;
-    ptSchemaVersion.put("schema", Report::getSchemaDescription(schemaVersion).optionName.c_str());
-    ptSchemaVersion.put("creation_date", xrt_core::timestamp());
-
-    ptRoot.add_child("schema_version", ptSchemaVersion);
-  }
+  ptRoot.add_child("schema_version", Report::JsonAbi::make_json_header(schema_label));
 
   bool is_report_output_valid = true;
 
@@ -280,14 +274,14 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
 
     boost::property_tree::ptree ptReport;
     try {
-      report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
+      report->getFormattedReport(nullptr, schema_version, elementFilter, consoleStream, ptReport);
     } catch (const std::exception&) {
       is_report_output_valid = false;
     }
 
     // Only support 1 node on the root
     if (ptReport.size() > 1)
-      throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schemaVersion).optionName).str());
+      throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schema_version).optionName).str());
 
     // We have 1 node, copy the child to the root property tree
     if (ptReport.size() == 1) {
@@ -377,14 +371,14 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
 
       boost::property_tree::ptree ptReport;
       try {
-        report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
+        report->getFormattedReport(device.get(), schema_version, elementFilter, consoleStream, ptReport);
       } catch (const std::exception&) {
         is_report_output_valid = false;
       }
 
       // Only support 1 node on the root
       if (ptReport.size() > 1)
-        throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schemaVersion).optionName).str());
+        throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schema_version).optionName).str());
 
       // We have 1 node, copy the child to the root property tree
       if (ptReport.size() == 1) {
@@ -400,16 +394,10 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     }
   }
 
-  // -- Write the formatted output 
-  switch (schemaVersion) {
-    case Report::SchemaVersion::json_20202:
-      boost::property_tree::json_parser::write_json(schemaStream, ptRoot, true /*Pretty Print*/);
-      schemaStream << std::endl;  
-      break;
-
-    default:
-      // Do nothing
-      break;
+  // -- Write the formatted output
+  if (Report::JsonAbi::valid_user_abi(schema_version)) {
+    boost::property_tree::json_parser::write_json(schemaStream, ptRoot, true /*Pretty Print*/);
+    schemaStream << std::endl;
   }
 
   // If any the data reports failed to generate with an exception throw an operation cancelled but output everything

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -38,9 +38,10 @@ namespace XBUtilities {
                                   ReportCollection & reportsToUse);
 
   void
-     produce_reports( const std::shared_ptr<xrt_core::device>& device, 
-                      const ReportCollection & reportsToProcess, 
-                      const Report::SchemaVersion schema, 
+     produce_reports( const std::shared_ptr<xrt_core::device>& device,
+                      const ReportCollection & reportsToProcess,
+                      Report::SchemaVersion schema_version,
+                      const std::string& schema_label,
                       const std::vector<std::string> & elementFilter,
                       std::ostream & consoleStream,
                       std::ostream & schemaStream);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -109,7 +109,8 @@ SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPrelimi
 void SubCmdExamine::fill_option_values(const po::variables_map& vm, SubCmdExamineOptions& options) const
 {
   options.m_device = vm.count("device") ? vm["device"].as<std::string>() : "";
-  options.m_format = vm.count("format") ? vm["format"].as<std::string>() : "JSON";
+  options.m_format = vm.find("format") != vm.end() ? vm["format"].as<std::string>() : "JSON";
+  options.m_json = vm.find("json") != vm.end() ? vm["json"].as<std::string>() : "default";
   options.m_output = vm.count("output") ? vm["output"].as<std::string>() : "";
   options.m_reportNames = vm.count("report") ? vm["report"].as<std::vector<std::string>>() : std::vector<std::string>();
   options.m_help = vm.count("help") ? vm["help"].as<bool>() : false;
@@ -128,7 +129,9 @@ SubCmdExamine::setOptionConfig(const boost::property_tree::ptree &config)
   try{
     m_jsonConfig.addProgramOptions(m_commonOptions, "common", getName());
     m_jsonConfig.addProgramOptions(m_hiddenOptions, "hidden", getName());
-  } 
+    m_json_abi_platform = m_jsonConfig.has_option(getName(), "json")
+                     && !m_jsonConfig.has_option(getName(), "format");
+  }
   catch (const std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;
   }
@@ -215,7 +218,11 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(options.m_format).schemaVersion;
+  Report::SchemaVersion schema_version = Report::SchemaVersion::unknown;
+  const bool json_platform = vm.count("json") || m_json_abi_platform;
+  const std::string schema_label = json_platform
+    ? (options.m_json.empty() ? "default" : options.m_json)
+    : options.m_format;
   try{
     if (vm.count("output") && options.m_output.empty())
       throw xrt_core::error("Output file not specified");
@@ -226,20 +233,20 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     if (vm.count("element") && options.m_elementsFilter.empty())
       throw xrt_core::error("No element filter given to be produced");
 
-    if (schemaVersion == Report::SchemaVersion::unknown) 
-      throw xrt_core::error((boost::format("Unknown output format: '%s'") % options.m_format).str());
+    schema_version = Report::resolve_json_abi(json_platform, vm.count("json") || vm.count("format"), schema_label);
+    if (schema_version == Report::SchemaVersion::unknown)
+      throw xrt_core::error((boost::format("Unknown JSON ABI version: '%s'") % schema_label).str());
 
-    // DRC check
-    // When json is specified, make sure an accompanying output file is also specified
-    if (vm.count("format") && options.m_output.empty())
+    // Either JSON output selector requires an accompanying output file
+    if ((vm.count("format") || vm.count("json")) && options.m_output.empty())
       throw xrt_core::error("Please specify an output file to redirect the json to");
 
     if (!options.m_output.empty() && std::filesystem::exists(options.m_output) && !XBU::getForce())
       throw xrt_core::error((boost::format("The output file '%s' already exists. Please either remove it or execute this command again with the '--force' option to overwrite it") % options.m_output).str());
 
     if (options.m_watchIntervalSec) {
-      if (vm.count("format"))
-        throw xrt_core::error("Watch mode cannot be used with --format; output is text only.");
+      if (vm.count("format") || vm.count("json"))
+        throw xrt_core::error("Watch mode cannot be additionally formatted; output is text only.");
       if (!options.m_output.empty())
         throw xrt_core::error("Watch mode cannot be used with --output.");
     }
@@ -251,12 +258,9 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     throw xrt_core::error(std::errc::operation_canceled);
   }
 
-  // Determine report level
   std::vector<std::string> reportsToRun(options.m_reportNames);
-  if (reportsToRun.empty()) {
-    // Default report with or without --advanced (advanced only unlocks hidden options/reports).
+  if (reportsToRun.empty())
     reportsToRun.emplace_back("host");
-  }
 
   if ((std::find(reportsToRun.begin(), reportsToRun.end(), "all") != reportsToRun.end()) && (reportsToRun.size() > 1)) {
     std::cerr << "ERROR: The 'all' value for the reports to run cannot be used with any other named reports.\n";
@@ -334,13 +338,13 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
       const auto examine_watch_snapshot =
           [&](const xrt_core::device*) {
             std::ostringstream console;
-            XBU::produce_reports(device, reportsToProcess, schemaVersion, {}, console, oSchemaOutput);
+            XBU::produce_reports(device, reportsToProcess, schema_version, schema_label, {}, console, oSchemaOutput);
             return console.str();
           };
       smi_watch_mode::run_watch_mode(device.get(), std::cout, examine_watch_snapshot,
           *options.m_watchIntervalSec);
     } else {
-      XBU::produce_reports(device, reportsToProcess, schemaVersion, {}, std::cout, oSchemaOutput);
+      XBU::produce_reports(device, reportsToProcess, schema_version, schema_label, {}, std::cout, oSchemaOutput);
     }
   } catch (const std::exception&) {
     // Exception is thrown at the end of this function to allow for report writing
@@ -358,7 +362,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
     fOutput << oSchemaOutput.str();
 
-    std::cout << boost::format("Successfully wrote the %s file: %s") % options.m_format % options.m_output << std::endl;
+    std::cout << boost::format("Successfully wrote the JSON file: %s") % options.m_output << std::endl;
   }
 
   if (!is_report_output_valid)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020 Xilinx, Inc
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdExamine_h_
 #define __SubCmdExamine_h_
@@ -25,6 +25,7 @@ struct SubCmdExamineOptions {
   std::vector<std::string>  m_reportNames;
   std::vector<std::string>  m_elementsFilter;
   std::string               m_format;
+  std::string               m_json;
   std::string               m_output;
   bool                      m_help;
   std::optional<unsigned>   m_watchIntervalSec;
@@ -32,6 +33,7 @@ struct SubCmdExamineOptions {
 class SubCmdExamine : public SubCmd {
   ReportCollection uniqueReportCollection;
   std::vector<std::shared_ptr<OptionOptions>> m_optionOptionsCollection;
+  bool m_json_abi_platform = false;
 
   void fill_option_values(const boost::program_options::variables_map& vm, SubCmdExamineOptions& options) const;
   std::vector<std::shared_ptr<Report>> getReportsList(const xrt_core::smi::tuple_vector&) const;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -338,31 +338,34 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   return status;
 }
 
+static boost::property_tree::ptree
+build_validate_json_output(Report::SchemaVersion schema_version,
+                           const std::string& schema_label,
+                           const boost::property_tree::ptree& ptDeviceTested)
+{
+  boost::property_tree::ptree ptRoot;
+  ptRoot.add_child("schema_version", Report::JsonAbi::make_json_header(schema_label));
+  ptRoot.add_child("logical_devices",
+                   Report::JsonAbi::fit_abi_tree(schema_version, ptDeviceTested));
+  return ptRoot;
+}
+
 static bool
 run_tests_on_devices( std::shared_ptr<xrt_core::device> &device,
-                      Report::SchemaVersion schemaVersion,
+                      Report::SchemaVersion schema_version,
+                      const std::string& schema_label,
                       std::vector<std::shared_ptr<TestRunner>>& testObjectsToRun,
                       std::ostream & output,
                       unsigned int iter_count)
 {
-  // -- Root property tree
-  boost::property_tree::ptree ptDevCollectionTestSuite;
-
   // -- Run the various tests and collect the test data
   boost::property_tree::ptree ptDeviceTested;
-  auto has_failures = (run_test_suite_device(device, schemaVersion, testObjectsToRun, ptDeviceTested, iter_count) == test_status::failed);
+  auto has_failures = (run_test_suite_device(device, schema_version, testObjectsToRun, ptDeviceTested, iter_count) == test_status::failed);
 
-  ptDevCollectionTestSuite.put_child("logical_devices", ptDeviceTested);
-
-  // -- Write the formatted output
-  switch (schemaVersion) {
-    case Report::SchemaVersion::json_20202:
-      boost::property_tree::json_parser::write_json(output, ptDevCollectionTestSuite, true /*Pretty Print*/);
-      output << std::endl;
-      break;
-    default:
-      // Do nothing
-      break;
+  if (Report::JsonAbi::valid_user_abi(schema_version)) {
+    const auto ptRoot = build_validate_json_output(schema_version, schema_label, ptDeviceTested);
+    boost::property_tree::json_parser::write_json(output, ptRoot, true /*Pretty Print*/);
+    output << std::endl;
   }
 
   return has_failures;
@@ -417,8 +420,8 @@ SubCmdValidate::handle_errors_and_validate_tests(const boost::program_options::v
   if (vm.count("pmode") && options.m_pmode.empty())
     throw xrt_core::error("Power mode not specified");
 
-  // When json is specified, make sure an accompanying output file is also specified
-   if (vm.count("format") && options.m_output.empty())
+  // Either JSON output selector requires an accompanying output file
+  if ((vm.count("format") || vm.count("json")) && options.m_output.empty())
     throw xrt_core::error("Please specify an output file to redirect the json to");
 
   if (!options.m_output.empty() && !XBU::getForce() && std::filesystem::exists(options.m_output))
@@ -499,7 +502,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   XBU::setElf(options.m_elf);
 
   // -- Process the options --------------------------------------------
-  Report::SchemaVersion schemaVersion = Report::SchemaVersion::unknown;    // Output schema version
+  Report::SchemaVersion schema_version = Report::SchemaVersion::unknown;
   std::vector<std::string> param;
   std::vector<std::string> validatedTests;
   std::string validateXclbinPath = options.m_xclbin_path;
@@ -518,11 +521,15 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   auto tests = xrt_core::device_query<xq::xrt_smi_lists>(device, xq::xrt_smi_lists::type::validate_tests);
   auto testOptions = getTestList(tests);
 
+  const bool json_platform = vm.count("json") || m_json_abi_platform;
+  const std::string schema_label = json_platform
+    ? (options.m_json.empty() ? "default" : options.m_json)
+    : options.m_format;
   try {
-    // Output Format
-    schemaVersion = Report::getSchemaDescription(options.m_format).schemaVersion;
-    if (schemaVersion == Report::SchemaVersion::unknown)
-      throw xrt_core::error((boost::format("Unknown output format: '%s'") % options.m_format).str());
+    schema_version = Report::resolve_json_abi(json_platform, vm.count("json") || vm.count("format"), schema_label);
+    if (schema_version == Report::SchemaVersion::unknown)
+      throw xrt_core::error((boost::format("Unknown JSON ABI version: '%s'") % schema_label).str());
+
     // All Error Handling for xrt-smi validate should go here
     handle_errors_and_validate_tests(vm, options, testOptions, validatedTests, param);
 
@@ -632,7 +639,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   }
   // -- Run the tests --------------------------------------------------
   std::ostringstream oSchemaOutput;
-  bool has_failures = run_tests_on_devices(device, schemaVersion, testObjectsToRun, oSchemaOutput, options.m_loop);
+  bool has_failures = run_tests_on_devices(device, schema_version, schema_label, testObjectsToRun, oSchemaOutput, options.m_loop);
 
   try {
     //reset pmode
@@ -655,7 +662,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
 
     fOutput << oSchemaOutput.str();
 
-    std::cout << boost::format("Successfully wrote the %s file: %s") % options.m_format % options.m_output << std::endl;
+    std::cout << boost::format("Successfully wrote the JSON file: %s") % options.m_output << std::endl;
   }
 
   if (has_failures == true)
@@ -665,7 +672,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
 void SubCmdValidate::fill_option_values(const po::variables_map& vm, SubCmdValidateOptions& options) const
 {
   options.m_device = vm.count("device") ? vm["device"].as<std::string>() : "";
-  options.m_format = vm.count("format") ? vm["format"].as<std::string>() : "JSON";
+  options.m_format = vm.find("format") != vm.end() ? vm["format"].as<std::string>() : "JSON";
+  options.m_json = vm.find("json") != vm.end() ? vm["json"].as<std::string>() : "default";
   options.m_output = vm.count("output") ? vm["output"].as<std::string>() : "";
   options.m_param = vm.count("param") ? vm["param"].as<std::string>() : "";
   options.m_xclbin_path = vm.count("path") ? vm["path"].as<std::string>() : "";
@@ -683,6 +691,8 @@ SubCmdValidate::setOptionConfig(const boost::property_tree::ptree &config)
   try{
     m_jsonConfig.addProgramOptions(m_commonOptions, "common", getName());
     m_jsonConfig.addProgramOptions(m_hiddenOptions, "hidden", getName());
+    m_json_abi_platform = m_jsonConfig.has_option(getName(), "json")
+                     && !m_jsonConfig.has_option(getName(), "format");
   } 
   catch (const std::exception& e) {
     std::cerr << "Error: " << e.what() << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2020 Xilinx, Inc
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __SubCmdValidate_h_
 #define __SubCmdValidate_h_
@@ -16,6 +16,7 @@
 struct SubCmdValidateOptions {
   std::string m_device;
   std::string m_format;
+  std::string m_json;
   std::string m_output;
   std::string m_param;
   std::string m_xclbin_path;
@@ -35,6 +36,7 @@ class SubCmdValidate : public SubCmd {
   SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  private:
+  bool m_json_abi_platform = false;
 
   void fill_option_values(const boost::program_options::variables_map& vm, SubCmdValidateOptions& options) const;
   void handle_errors_and_validate_tests(const boost::program_options::variables_map&, 

--- a/src/runtime_src/doc/toc/xrt-smi.rst
+++ b/src/runtime_src/doc/toc/xrt-smi.rst
@@ -108,7 +108,7 @@ The command ``xrt-smi validate`` validates the installed card by running precomp
 - The ``--format`` (or ``-f``) specifies the report format. Note that ``--format`` also needs an ``--output`` to dump the report in json format. If ``--output`` is missing text format will be shown in stdout
 
     - ``JSON``: The report is shown in latest JSON schema
-    - ``JSON-2020.2``: The report is shown in JSON 2020.2 schema
+    - ``JSON-2020.2``: The report is shown in JSON 2020.2 schema (legacy option that is identical to ``JSON``)
 
 - The ``--output`` (or ``-o``) specifies the output file to direct the output
 


### PR DESCRIPTION
Reverts Xilinx/XRT#9951, which reverted Xilinx/XRT#9930

https://jira.xilinx.com/browse/AIESW-3443

Additional testcases-ve2 changes have been merged earlier today to resolve the earlier pipeline issue in MCDM. Will not merge until decided flag day.