### PR TITLE
Fix xilinx_xrt() root discovery on Debian multiarch installs

### DIFF
--- a/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
+++ b/src/runtime_src/core/common/detail/linux/xilinx_xrt.h
@@ -24,9 +24,21 @@
 # error "XRT_VERSION_STRING is undefined"
 #endif
 
+// XRT_LIB_DIR (CMAKE_INSTALL_LIBDIR) is supplied as a compile definition on
+// module_loader.cpp, the only translation unit that includes this header.
+// This header is not meant to be compiled stand-alone, so error out if it is
+// missing rather than guessing a default.
+#ifndef XRT_LIB_DIR
+# error "XRT_LIB_DIR is undefined"
+#endif
+
 namespace xrt_core::detail {
 
 namespace sfs = std::filesystem;
+
+// The code below also tolerates an empty value (coreutil then sits directly in
+// the XRT root).
+constexpr const char* xrt_lib_dir = XRT_LIB_DIR;
 
 // Get XRT install path from DSO location or compile time constant.
 //
@@ -58,9 +70,22 @@ xilinx_xrt()
   if (::dladdr(reinterpret_cast<const void*>(&xilinx_xrt), &info) != 0
       && info.dli_fname && *info.dli_fname) {
     // info.dli_fname is the full path to libxrt_coreutil.so, e.g.
-    // /opt/xilinx/xrt/lib/libxrt_coreutil.so.2 — go up two levels to
-    // get the XRT root that callers expect (e.g. /opt/xilinx/xrt).
-    sfs::path xrt_root = sfs::path(info.dli_fname).parent_path().parent_path();
+    // /opt/xilinx/xrt/lib/libxrt_coreutil.so.2 or, on a Debian
+    // multiarch install, /opt/amdgpu/lib/x86_64-linux-gnu/libxrt_coreutil.so.2.
+    // The library lives in <xrt_root>/<XRT_LIB_DIR>, so strip the
+    // XRT_LIB_DIR suffix from the directory dladdr() reported to recover
+    // the XRT root that callers expect (e.g. /opt/xilinx/xrt). XRT_LIB_DIR
+    // may be one or more path components ("lib", "lib64", or
+    // "lib/x86_64-linux-gnu"), so remove one component per component in it
+    // rather than hardcoding a fixed number of levels. Skip empty and root
+    // components so an absolute XRT_LIB_DIR (e.g. "/usr/lib") does not
+    // over-strip past the XRT root.
+    sfs::path xrt_root = sfs::path(info.dli_fname).parent_path();
+    for (const auto& comp : sfs::path(xrt_lib_dir)) {
+      if (comp.empty() || comp == comp.root_directory())
+        continue;
+      xrt_root = xrt_root.parent_path();
+    }
     if (!xrt_root.empty())
       return xrt_root;
   }


### PR DESCRIPTION
xilinx_xrt() derived the XRT root by taking two parent_path() levels up from the libxrt_coreutil.so path reported by dladdr(). This assumes coreutil lives directly in <root>/lib, which only holds when CMAKE_INSTALL_LIBDIR is a single path component (lib, lib64). On a Debian multiarch install CMAKE_INSTALL_LIBDIR is lib/x86_64-linux-gnu, so coreutil is one level deeper and the two-level strip returns <root>/lib instead of <root>. shim_path() then re-appends XRT_LIB_DIR, producing a doubled path such as
'/opt/amdgpu/lib/lib/x86_64-linux-gnu/libxrt_core.so.2' and the load fails with "No such library".

Strip exactly as many trailing components as XRT_LIB_DIR contains instead of a hardcoded two levels, so the root is recovered correctly for lib, lib64, and lib/x86_64-linux-gnu layouts alike. Single-component layouts (standard, lib64, single-arch Yocto) are unaffected. Also default XRT_LIB_DIR to "lib" so the header stays self-contained; the loop additionally tolerates an empty value.

Regression from 11169ba50 (SWSPLAT-24084) which switched XRT root discovery from XILINX_XRT to dladdr().

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
