### PR TITLE
Fix hw_context bitstream unlock on client exit

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
@@ -15,6 +15,7 @@
 #include "zocl_util.h"
 #include "zocl_xclbin.h"
 #include "zocl_kds.h"
+#include "zocl_aie.h"
 #include "kds_core.h"
 #include "kds_ert_table.h"
 #include "xclbin.h"
@@ -286,6 +287,51 @@ out:
 }
 
 /*
+ * Release hw contexts on client exit. Legacy apps use ctx_list for
+ * bitstream unlock; hw_context API apps need unlock here.
+ */
+static void zocl_fini_client_hw_ctxs(struct drm_zocl_dev *zdev,
+				     struct kds_client *client)
+{
+	struct kds_sched *kds = &zdev->kds;
+	struct kds_client_hw_ctx *hw_ctx, *next;
+	struct zocl_hw_graph_ctx *graph_ctx;
+	struct list_head *gptr, *gnext;
+	struct drm_zocl_slot *slot;
+	uuid_t *xclbin_id;
+	u32 s_id;
+	bool unlock = list_empty(&client->ctx_list);
+
+	list_for_each_entry_safe(hw_ctx, next, &client->hw_ctx_list, link)
+		kds_fini_hw_ctx_client(kds, client, hw_ctx);
+
+	mutex_lock(&client->lock);
+	list_for_each_entry_safe(hw_ctx, next, &client->hw_ctx_list, link) {
+		list_for_each_safe(gptr, gnext, &hw_ctx->graph_ctx_list) {
+			graph_ctx = list_entry(gptr, struct zocl_hw_graph_ctx, link);
+			list_del(gptr);
+			kfree(graph_ctx);
+		}
+
+		slot = zdev->pr_slot[hw_ctx->slot_idx];
+		s_id = hw_ctx->slot_idx;
+		xclbin_id = hw_ctx->xclbin_id;
+		if (kds_free_hw_ctx(client, hw_ctx) || !unlock)
+			continue;
+
+		if (slot && xclbin_id)
+			(void)zocl_unlock_bitstream(slot, xclbin_id);
+
+		if (slot && --slot->hwctx_ref_cnt == 0) {
+			if (s_id != 0)
+				zocl_destroy_aie(slot);
+			zdev->slot_mask &= ~(1 << s_id);
+		}
+	}
+	mutex_unlock(&client->lock);
+}
+
+/*
  * Destroy the given client and delete it from the KDS.
  *
  * @param	zdev:	zocl device structure
@@ -314,6 +360,7 @@ void zocl_destroy_client(void *client_hdl)
 	 * release xclbin_id and unlock bitstream if needed.
 	 */
 	zocl_aie_kds_del_graph_context_all(client);
+	zocl_fini_client_hw_ctxs(zdev, client);
 	kds_fini_client(kds, client);
 
 	/* Delete all the existing context associated to this device for this


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1276107 Legacy ctx_list cleanup did not cover xrt::hw_context apps. Add zocl_fini_client_hw_ctxs() in zocl_destroy_client().

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 When a host application using the xrt::hw_context API exits on a DFX platform, the hw_context / xclbin is not fully released. Slot 0 remains in-use, so a subsequent run without reboot fails with [drm:zocl_xclbin_read_axlf [zocl]] *ERROR* Current xclbin is in-use, can't change

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added zocl_fini_client_hw_ctxs() in zocl_kds.c and call it from zocl_destroy_client() before kds_fini_client(). On client exit this function:

1. Calls kds_fini_hw_ctx_client() for each entry in client->hw_ctx_list
2. Cleans up associated AIE graph contexts
3. Calls kds_free_hw_ctx() to release the hw_context
4. Unlocks the slot bitstream via zocl_unlock_bitstream() when appropriate
5. Decrements slot->hwctx_ref_cnt and tears down AIE state when the last reference is dropped

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on vck190 hw. 
#### Documentation impact (if any)
NA