### PR TITLE
CodeQL Fix OOB reads in SectionAIEResourcesBin

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
@@ -200,7 +200,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("name", sDefault);
 
     if (sValue.compare(getSectionIndexName()) != 0) {
@@ -215,7 +215,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_version
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->mpo_version;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize);
     auto sValue = ptSK.get<std::string>("version", sDefault);
     aieResourcesBinHdr.mpo_version = sizeof(aie_resources_bin) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -224,7 +224,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // m_start_column
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->m_start_column;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->m_start_column, _origSectionSize);
     auto sValue = ptSK.get<std::string>("start_column", sDefault);
     aieResourcesBinHdr.m_start_column = sizeof(aie_resources_bin) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -233,7 +233,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // m_num_columns
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->m_num_columns;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->m_num_columns, _origSectionSize);
     auto sValue = ptSK.get<std::string>("num_columns", sDefault);
     aieResourcesBinHdr.m_num_columns = sizeof(aie_resources_bin) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -257,7 +257,12 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("aie_resources_bin m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -382,6 +387,12 @@ SectionAIEResourcesBin::writeObjImage(std::ostream& _oStream) const
 
   // No look at the data
   auto pHdr = reinterpret_cast<aie_resources_bin*>(m_pBuffer);
+
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("aie_resources_bin m_image_offset/m_image_size out of bounds");
+  }
 
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);


### PR DESCRIPTION
#### Problem solved by the commit
Four CWE-125 heap OOB reads in copyBufferUpdateMetadata() where aie_resources_bin mpo_* fields (mpo_name, mpo_version, m_start_column, m_num_columns) were used as raw pointer offsets without bounds checking when computing sDefault fallback strings, bypassing the bounded_mpo_cstr() guard added in bb1791f6.

Two additional CWE-125 OOB reads where m_image_offset and m_image_size were used without bounds checking in both copyBufferUpdateMetadata() and writeObjImage() before reading image data.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Jira tickets:
- AIESW-41124
- AIESW-41125
- AIESW-41126
- AIESW-41127
- AIESW-41128
- AIESW-41129

CodeQL alerts #135-#140 (amd-psirt/xclbin-parser-oob, HIGH severity). The sDefault reads were missed by bb1791f6 (SWSPLAT-30717), which protected the TRACE() and writeMetadata() paths but not the fallback default value paths in copyBufferUpdateMetadata(). The image offset/size checks were never added to writeObjImage().

#### How problem was solved, alternative solutions (if any) and why they were rejected
Replaced the four raw sDefault pointer calculations with bounded_mpo_cstr(pHdr, pHdr->field, _origSectionSize). This also fixes a pre-existing double-offset bug in the original code: the sDefault expressions incorrectly added sizeof(aie_resources_bin) on top of the mpo_* field value, but mpo_* fields already store absolute offsets from pHdr (sizeof is baked in at write time), so the fallback pointer was pointing past the actual string.

Added explicit uint64_t overflow-safe bounds checks for m_image_offset + m_image_size against section size in both copyBufferUpdateMetadata() and writeObjImage().

#### Risks (if any) associated the changes in the commit
Low. The sDefault path is only taken when the JSON metadata stream omits a key; the double-offset bug meant the fallback was producing wrong values anyway. The image bounds checks only reject malformed xclbins.

#### What has been tested and how, request additional testing if necessary
Built xclbinutil successfully. Recommend testing xclbinutil --input with a crafted xclbin containing OOB mpo offsets and verifying it throws rather than reading past the buffer.

#### Documentation impact (if any)
None

