### PR TITLE
Fix uint64_t overflow in SectionBMC bounds check

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
@@ -158,11 +158,9 @@ SectionBMC::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                % pHdr->m_version
                % pHdr->m_md5value);
 
-  uint64_t expectedSize = pHdr->m_offset + pHdr->m_size;
-
-  // Check to see if array size
-  if (expectedSize > _origSectionSize) {
-    auto errMsg = boost::format("ERROR: bmc section size (0x%lx) exceeds the given segment size (0x%lx).") % expectedSize % _origSectionSize;
+  // Guard against uint64_t overflow before comparing against section size
+  if (pHdr->m_size > _origSectionSize || pHdr->m_offset > _origSectionSize - pHdr->m_size) {
+    auto errMsg = boost::format("ERROR: bmc m_offset (0x%lx) + m_size (0x%lx) exceeds the given segment size (0x%lx).") % pHdr->m_offset % pHdr->m_size % _origSectionSize;
     throw std::runtime_error(errMsg.str());
   }
 


### PR DESCRIPTION
#### Problem solved by the commit
copyBufferUpdateMetadata() computed `pHdr->m_offset + pHdr->m_size` as a uint64_t addition before comparing against _origSectionSize. If both fields are near UINT64_MAX the addition wraps silently, causing the bounds check to pass on a malformed section.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered Found during triage of AIESW-41122/41123 (false positives). The overflow was latent in the original check predating bb1791f6.

#### How problem was solved, alternative solutions (if any) and why they were rejected Replaced the addition with an overflow-safe two-part check:
  m_size > _origSectionSize || m_offset > _origSectionSize - m_size

#### Risks (if any) associated the changes in the commit Low. Semantically equivalent for all non-overflow inputs; only rejects crafted inputs that previously slipped past the check.

#### What has been tested and how, request additional testing if necessary Built xclbinutil successfully.

#### Documentation impact (if any)
None

