### PR TITLE
CodeQL Fix OOB reads in SectionFlash

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -182,9 +182,9 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                              "  mpo_md5_value (0x%lx): '%s'\n")
                % pHdr->m_flash_type % getFlashTypeAsString((FLASH_TYPE)pHdr->m_flash_type)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
-               % pHdr->mpo_version % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->mpo_md5_value % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_md5_value));
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize)
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize)
+               % pHdr->mpo_md5_value % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize));
 
   // Get the JSON metadata
   _istream.seekg(0, _istream.end);             // Go to the beginning
@@ -235,7 +235,7 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(flash) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptFlash.get<std::string>("name", sDefault);
     flashHdr.mpo_name = sizeof(flash) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -245,7 +245,7 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_version
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(flash) + pHdr->mpo_version;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize);
     auto sValue = ptFlash.get<std::string>("version", sDefault);
     flashHdr.mpo_version = sizeof(flash) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -254,7 +254,7 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_md5_value
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(flash) + pHdr->mpo_md5_value;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize);
     auto sValue = ptFlash.get<std::string>("md5", sDefault);
     flashHdr.mpo_md5_value = sizeof(flash) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -277,7 +277,12 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("flash m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -413,6 +418,12 @@ SectionFlash::writeObjImage(std::ostream& _oStream) const
   // No look at the data
   auto pHdr = reinterpret_cast<flash*>(m_pBuffer);
 
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("flash m_image_offset/m_image_size out of bounds");
+  }
+
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);
 }
@@ -441,9 +452,9 @@ SectionFlash::writeMetadata(std::ostream& _oStream) const
                              "  mpo_md5_value (0x%lx): '%s'\n")
                % pHdr->m_flash_type % getFlashTypeAsString((FLASH_TYPE)pHdr->m_flash_type)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
-               % pHdr->mpo_version % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->mpo_md5_value % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_md5_value));
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize)
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, m_bufferSize)
+               % pHdr->mpo_md5_value % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, m_bufferSize));
 
   // Convert the data from the binary format to JSON
   boost::property_tree::ptree ptFlash;


### PR DESCRIPTION
#### Problem solved by the commit
Five CWE-125 heap OOB reads in SectionFlash.cxx where attacker- controlled flash mpo_* and image offset/size fields were used without bounds checking:

- AIESW-41121/41120/41119: mpo_name, mpo_version, mpo_md5_value used as raw pointer offsets in the TRACE block of copyBufferUpdateMetadata() without going through bounded_mpo_cstr(), unlike the equivalent paths in SectionAIEResourcesBin which were fixed in bb1791f6.

- AIESW-41117/41118: m_image_offset and m_image_size used to read image data at line 281 with no bounds check against _origSectionSize.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Jira:
- AIESW-41117
- AIESW-41118
- AIESW-41119
- AIESW-41120
- AIESW-41121

CodeQL alerts #143-#147 (amd-psirt/xclbin-parser-oob, HIGH severity). Missed by bb1791f6 (SWSPLAT-30717) which fixed other mpo_* reads but left the TRACE paths and image copy in SectionFlash unguarded.

#### How problem was solved, alternative solutions (if any) and why they were rejected
TRACE paths: replaced raw `pHdr + mpo_field` with
bounded_mpo_cstr(pHdr, mpo_field, size) in both
copyBufferUpdateMetadata() and writeMetadata().

sDefault fallback strings: replaced raw `pHdr + sizeof(flash) + field` with bounded_mpo_cstr(pHdr, field, _origSectionSize), also fixing the same double-offset bug as found in SectionAIEResourcesBin where sizeof(flash) was incorrectly added on top of already-absolute mpo offsets.

Image copy: added overflow-safe uint64_t bounds check before the _buffer.write() in copyBufferUpdateMetadata() and writeObjImage().

#### Risks (if any) associated the changes in the commit
Low. Only rejects malformed xclbins; behavior for well-formed inputs is unchanged.

#### What has been tested and how, request additional testing if necessary
Built xclbinutil successfully.

#### Documentation impact (if any)
None
