### PR TITLE
CodeQL Fix OOB reads in SectionSoftKernel

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -155,11 +155,11 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                              "  mpo_md5_value (0x%lx): '%s'\n"
                              "  mpo_symbol_name (0x%lx): '%s'\n"
                              "  m_num_instances: %d")
-               % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_version % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->mpo_md5_value % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_md5_value)
-               % pHdr->mpo_symbol_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_symbol_name)
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize)
+               % pHdr->mpo_md5_value % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize)
+               % pHdr->mpo_symbol_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_symbol_name, _origSectionSize)
                % pHdr->m_num_instances);
 
   // Get the JSON metadata
@@ -190,7 +190,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_name", sDefault);
 
     if (sValue.compare(getSectionIndexName()) != 0) {
@@ -205,7 +205,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_version
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_version;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_version", sDefault);
     softKernelHdr.mpo_version = sizeof(soft_kernel) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -214,7 +214,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_md5_value
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_md5_value;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_md5_value", sDefault);
     softKernelHdr.mpo_md5_value = sizeof(soft_kernel) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -223,7 +223,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_symbol_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_symbol_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_symbol_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_symbol_name", sDefault);
     softKernelHdr.mpo_symbol_name = sizeof(soft_kernel) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -269,7 +269,12 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("soft_kernel m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -394,6 +399,12 @@ SectionSoftKernel::writeObjImage(std::ostream& _oStream) const
 
   // No look at the data
   auto pHdr = reinterpret_cast<soft_kernel*>(m_pBuffer);
+
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("soft_kernel m_image_offset/m_image_size out of bounds");
+  }
 
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);


### PR DESCRIPTION
#### Problem solved by the commit
Six CWE-125 heap OOB reads in SectionSoftKernel.cxx where attacker- controlled soft_kernel mpo_* and image offset/size fields were used without bounds checking:

- AIESW-41116/41115/41114/41113: mpo_name, mpo_version, mpo_md5_value, mpo_symbol_name used as raw pointer offsets in the TRACE block of copyBufferUpdateMetadata() without going through bounded_mpo_cstr(), unlike writeMetadata() which already used it correctly.

- AIESW-41111/41112: m_image_offset and m_image_size used to read image data at line 273 with no bounds check against _origSectionSize.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Jira:
- AIESW-41111
- AIESW-41112
- AIESW-41113
- AIESW-41114
- AIESW-41115
- AIESW-41116

CodeQL alerts #148-#153 (amd-psirt/xclbin-parser-oob, HIGH severity). Missed by bb1791f6 (SWSPLAT-30717) which fixed writeMetadata() but left the TRACE paths and image copy in copyBufferUpdateMetadata() unguarded, and writeObjImage() without image bounds checking.

#### How problem was solved, alternative solutions (if any) and why they were rejected
TRACE paths: replaced raw `pHdr + mpo_field` arithmetic with bounded_mpo_cstr(pHdr, mpo_field, _origSectionSize).

sDefault fallback strings: replaced raw `pHdr + sizeof(soft_kernel) + field` with bounded_mpo_cstr(pHdr, field, _origSectionSize), also fixing the same double-offset bug as found in SectionAIEResourcesBin and SectionFlash where sizeof(soft_kernel) was incorrectly added on top of already-absolute mpo offsets.

Image copy: added overflow-safe uint64_t bounds check before the _buffer.write() in copyBufferUpdateMetadata() and writeObjImage().

#### Risks (if any) associated the changes in the commit
Low. Only rejects malformed xclbins; behavior for well-formed inputs is unchanged.

#### What has been tested and how, request additional testing if necessary
Built xclbinutil successfully.

