### PR TITLE
CodeQL Fix OOB reads in SectionVenderMetadata

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -75,7 +75,7 @@ SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                               "Original: \n"
                               "  mpo_name (0x%lx): '%s'\n"
                               "  m_image_offset: 0x%lx, m_image_size: 0x%lx\n")
-                          % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
+                          % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize)
                           % pHdr->m_image_offset % pHdr->m_image_size));
 
   // Get the JSON metadata
@@ -106,7 +106,7 @@ SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   // Update and record the variables
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(vender_metadata) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_name", sDefault);
 
     if (sValue.compare(getSectionIndexName()) != 0) {
@@ -136,7 +136,12 @@ SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("vender_metadata m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -230,6 +235,12 @@ SectionVenderMetadata::writeObjImage(std::ostream& _oStream) const
 
   // Now look at the data
   auto pHdr = reinterpret_cast<vender_metadata*>(m_pBuffer);
+
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("vender_metadata m_image_offset/m_image_size out of bounds");
+  }
 
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);


### PR DESCRIPTION
#### Problem solved by the commit
Three CWE-125 heap OOB reads in SectionVenderMetadata.cxx where attacker-controlled vender_metadata mpo_name and image offset/size fields were used without bounds checking:

- AIESW-41110: mpo_name used as raw pointer offset in the TRACE block of copyBufferUpdateMetadata() without going through bounded_mpo_cstr(), unlike writeMetadata() which already used it correctly.

- AIESW-41108/41109: m_image_offset and m_image_size used to read image data at line 140 with no bounds check against _origSectionSize.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Jira:
- AIESW-41108
- AIESW-41109
- AIESW-41110

CodeQL alerts #154-#156 (amd-psirt/xclbin-parser-oob, HIGH severity). Missed by bb1791f6 (SWSPLAT-30717) which fixed writeMetadata() but left the TRACE path and image copy in copyBufferUpdateMetadata() unguarded, and writeObjImage() without image bounds checking.

#### How problem was solved, alternative solutions (if any) and why they were rejected
TRACE path: replaced raw `pHdr + mpo_name` with
bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize).

sDefault fallback string: replaced raw `pHdr + sizeof(vender_metadata)
+ mpo_name` with bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize), also fixing the same double-offset bug found in all other Section* files where sizeof(struct) was incorrectly added on top of already-absolute mpo offsets.

Image copy: added overflow-safe uint64_t bounds check before the _buffer.write() in copyBufferUpdateMetadata() and writeObjImage().

#### Risks (if any) associated the changes in the commit
Low. Only rejects malformed xclbins; behavior for well-formed inputs is unchanged.

#### What has been tested and how, request additional testing if necessary
Built xclbinutil successfully.

#### Documentation impact (if any)
None
