### PR TITLE
CodeQL: xclbinutil fixes

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
@@ -200,7 +200,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("name", sDefault);
 
     if (sValue.compare(getSectionIndexName()) != 0) {
@@ -215,7 +215,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_version
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->mpo_version;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize);
     auto sValue = ptSK.get<std::string>("version", sDefault);
     aieResourcesBinHdr.mpo_version = sizeof(aie_resources_bin) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -224,7 +224,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // m_start_column
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->m_start_column;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->m_start_column, _origSectionSize);
     auto sValue = ptSK.get<std::string>("start_column", sDefault);
     aieResourcesBinHdr.m_start_column = sizeof(aie_resources_bin) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -233,7 +233,7 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // m_num_columns
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(aie_resources_bin) + pHdr->m_num_columns;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->m_num_columns, _origSectionSize);
     auto sValue = ptSK.get<std::string>("num_columns", sDefault);
     aieResourcesBinHdr.m_num_columns = sizeof(aie_resources_bin) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -257,7 +257,12 @@ SectionAIEResourcesBin::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("aie_resources_bin m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -382,6 +387,12 @@ SectionAIEResourcesBin::writeObjImage(std::ostream& _oStream) const
 
   // No look at the data
   auto pHdr = reinterpret_cast<aie_resources_bin*>(m_pBuffer);
+
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("aie_resources_bin m_image_offset/m_image_size out of bounds");
+  }
 
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);

--- a/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
@@ -158,11 +158,9 @@ SectionBMC::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                % pHdr->m_version
                % pHdr->m_md5value);
 
-  uint64_t expectedSize = pHdr->m_offset + pHdr->m_size;
-
-  // Check to see if array size
-  if (expectedSize > _origSectionSize) {
-    auto errMsg = boost::format("ERROR: bmc section size (0x%lx) exceeds the given segment size (0x%lx).") % expectedSize % _origSectionSize;
+  // Guard against uint64_t overflow before comparing against section size
+  if (pHdr->m_size > _origSectionSize || pHdr->m_offset > _origSectionSize - pHdr->m_size) {
+    auto errMsg = boost::format("ERROR: bmc m_offset (0x%lx) + m_size (0x%lx) exceeds the given segment size (0x%lx).") % pHdr->m_offset % pHdr->m_size % _origSectionSize;
     throw std::runtime_error(errMsg.str());
   }
 

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -182,9 +182,9 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                              "  mpo_md5_value (0x%lx): '%s'\n")
                % pHdr->m_flash_type % getFlashTypeAsString((FLASH_TYPE)pHdr->m_flash_type)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
-               % pHdr->mpo_version % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->mpo_md5_value % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_md5_value));
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize)
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize)
+               % pHdr->mpo_md5_value % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize));
 
   // Get the JSON metadata
   _istream.seekg(0, _istream.end);             // Go to the beginning
@@ -235,7 +235,7 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(flash) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptFlash.get<std::string>("name", sDefault);
     flashHdr.mpo_name = sizeof(flash) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -245,7 +245,7 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_version
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(flash) + pHdr->mpo_version;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize);
     auto sValue = ptFlash.get<std::string>("version", sDefault);
     flashHdr.mpo_version = sizeof(flash) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -254,7 +254,7 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_md5_value
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(flash) + pHdr->mpo_md5_value;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize);
     auto sValue = ptFlash.get<std::string>("md5", sDefault);
     flashHdr.mpo_md5_value = sizeof(flash) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -277,7 +277,12 @@ SectionFlash::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("flash m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -413,6 +418,12 @@ SectionFlash::writeObjImage(std::ostream& _oStream) const
   // No look at the data
   auto pHdr = reinterpret_cast<flash*>(m_pBuffer);
 
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("flash m_image_offset/m_image_size out of bounds");
+  }
+
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);
 }
@@ -441,9 +452,9 @@ SectionFlash::writeMetadata(std::ostream& _oStream) const
                              "  mpo_md5_value (0x%lx): '%s'\n")
                % pHdr->m_flash_type % getFlashTypeAsString((FLASH_TYPE)pHdr->m_flash_type)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
-               % pHdr->mpo_version % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->mpo_md5_value % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_md5_value));
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, m_bufferSize)
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, m_bufferSize)
+               % pHdr->mpo_md5_value % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, m_bufferSize));
 
   // Convert the data from the binary format to JSON
   boost::property_tree::ptree ptFlash;

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -155,11 +155,11 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                              "  mpo_md5_value (0x%lx): '%s'\n"
                              "  mpo_symbol_name (0x%lx): '%s'\n"
                              "  m_num_instances: %d")
-               % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
+               % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize)
                % pHdr->m_image_offset % pHdr->m_image_size
-               % pHdr->mpo_version % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_version)
-               % pHdr->mpo_md5_value % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_md5_value)
-               % pHdr->mpo_symbol_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_symbol_name)
+               % pHdr->mpo_version % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize)
+               % pHdr->mpo_md5_value % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize)
+               % pHdr->mpo_symbol_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_symbol_name, _origSectionSize)
                % pHdr->m_num_instances);
 
   // Get the JSON metadata
@@ -190,7 +190,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_name", sDefault);
 
     if (sValue.compare(getSectionIndexName()) != 0) {
@@ -205,7 +205,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_version
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_version;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_version, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_version", sDefault);
     softKernelHdr.mpo_version = sizeof(soft_kernel) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -214,7 +214,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_md5_value
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_md5_value;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_md5_value, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_md5_value", sDefault);
     softKernelHdr.mpo_md5_value = sizeof(soft_kernel) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -223,7 +223,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
 
   // mpo_symbol_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(soft_kernel) + pHdr->mpo_symbol_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_symbol_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_symbol_name", sDefault);
     softKernelHdr.mpo_symbol_name = sizeof(soft_kernel) + stringBlock.tellp();
     stringBlock << sValue << '\0';
@@ -269,7 +269,12 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("soft_kernel m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -394,6 +399,12 @@ SectionSoftKernel::writeObjImage(std::ostream& _oStream) const
 
   // No look at the data
   auto pHdr = reinterpret_cast<soft_kernel*>(m_pBuffer);
+
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("soft_kernel m_image_offset/m_image_size out of bounds");
+  }
 
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -75,7 +75,7 @@ SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
                               "Original: \n"
                               "  mpo_name (0x%lx): '%s'\n"
                               "  m_image_offset: 0x%lx, m_image_size: 0x%lx\n")
-                          % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
+                          % pHdr->mpo_name % XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize)
                           % pHdr->m_image_offset % pHdr->m_image_size));
 
   // Get the JSON metadata
@@ -106,7 +106,7 @@ SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   // Update and record the variables
   // mpo_name
   {
-    auto sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(vender_metadata) + pHdr->mpo_name;
+    auto sDefault = XUtil::bounded_mpo_cstr(pHdr, pHdr->mpo_name, _origSectionSize);
     auto sValue = ptSK.get<std::string>("mpo_name", sDefault);
 
     if (sValue.compare(getSectionIndexName()) != 0) {
@@ -136,7 +136,12 @@ SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
   std::string sStringBlock = stringBlock.str();
   _buffer.write(sStringBlock.c_str(), sStringBlock.size());
 
-  // Image
+  // Image — validate offset+size against the original section before reading
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > _origSectionSize)
+      throw std::runtime_error("vender_metadata m_image_offset/m_image_size out of bounds");
+  }
   _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
 }
 
@@ -230,6 +235,12 @@ SectionVenderMetadata::writeObjImage(std::ostream& _oStream) const
 
   // Now look at the data
   auto pHdr = reinterpret_cast<vender_metadata*>(m_pBuffer);
+
+  {
+    uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
+    if (img_end > m_bufferSize)
+      throw std::runtime_error("vender_metadata m_image_offset/m_image_size out of bounds");
+  }
 
   auto pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
   _oStream.write(pFWBuffer, pHdr->m_image_size);


### PR DESCRIPTION
#### Problem solved by the commit

CodeQL rule `amd-psirt/xclbin-parser-oob` flagged 20 HIGH-severity (CWE-125) heap out-of-bounds read vulnerabilities across five xclbinutil section files. In each case, wire-format fields from an attacker-controlled xclbin file were used as pointer offsets or copy lengths without checking that the resulting access lies within the section buffer. A crafted xclbin can set any of these fields to an arbitrary value, causing xclbinutil to read and potentially expose adjacent heap memory, or crash.

The affected fields and files are:

| File | Fields | Tickets |
|---|---|---|
| SectionAIEResourcesBin.cxx | `mpo_name`, `mpo_version`, `m_start_column`, `m_num_columns`, `m_image_offset`, `m_image_size` | AIESW-41124 – 41129 |
| SectionFlash.cxx | `mpo_name`, `mpo_version`, `mpo_md5_value`, `m_image_offset`, `m_image_size` | AIESW-41117 – 41121 |
| SectionSoftKernel.cxx | `mpo_name`, `mpo_version`, `mpo_md5_value`, `mpo_symbol_name`, `m_image_offset`, `m_image_size` | AIESW-41111 – 41116 |
| SectionVenderMetadata.cxx | `mpo_name`, `m_image_offset`, `m_image_size` | AIESW-41108 – 41110 |
| SectionBMC.cxx | `m_offset`, `m_size` (overflow in bounds check) | (hardening, no ticket) |

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

CodeQL alerts #136–#156 (rule `amd-psirt/xclbin-parser-oob`, severity HIGH).

The vulnerabilities were missed by PR bb1791f6 (SWSPLAT-30717), which fixed `mpo_*` reads in `writeMetadata()` paths by introducing XclBinUtilities::bounded_mpo_cstr()`, but left three categories of reads unguarded:

1. **TRACE logging paths** in `copyBufferUpdateMetadata()` — used raw  `pHdr + mpo_field` arithmetic instead of `bounded_mpo_cstr()`.

2. **`sDefault` fallback strings** in `copyBufferUpdateMetadata()` — used  raw `pHdr + sizeof(struct) + mpo_field`, which also had a pre-existing  double-offset bug: `mpo_*` fields already store absolute offsets from  `pHdr` (with `sizeof(struct)` baked in at write time), so adding  `sizeof(struct)` again produced a pointer past the actual string.

3. **Image copy paths** — `m_image_offset` and `m_image_size` were used  for `_buffer.write()` and `_oStream.write()` in both  `copyBufferUpdateMetadata()` and `writeObjImage()` without checking that  `m_image_offset + m_image_size <= section_size`.

Additionally, `SectionBMC::copyBufferUpdateMetadata()` computed `m_offset + m_size` as a plain `uint64_t` addition before comparing against `_origSectionSize`, which silently wraps on crafted inputs. This was not flagged by CodeQL but was discovered during triage of AIESW-41122/41123 (which are false positives — see below).

**False positives:** AIESW-41122 and AIESW-41123 flag `SectionBMC::writeFWImage()` for using `bmc::m_offset` and `bmc::m_size` without bounds checking. These are false positives: `writeFWImage()` only reads from `m_pBuffer`, which is populated either by `createDefaultImage()` (trusted internal values) or by `copyBufferUpdateMetadata()` (which validates `m_offset + m_size <= _origSectionSize` before accepting the data). CodeQL cannot trace data flow across the load/store boundary into`m_pBuffer`.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Three classes of fix, applied consistently across all four section files:

**1. TRACE paths and `sDefault` fallbacks** — replaced all raw `pHdr + mpo_field` and `pHdr + sizeof(struct) + mpo_field` expressions with `XclBinUtilities::bounded_mpo_cstr(pHdr, mpo_field, _origSectionSize)`. This validates that the offset lies within the buffer and that a null terminator exists before returning the pointer. The existing helper from bb1791f6 was already correct for `writeMetadata()`; it just needed to be applied to the missed paths.

**2. Image copy bounds checks** — added overflow-safe `uint64_t` checks before each image read:
```cpp
uint64_t img_end = static_cast<uint64_t>(pHdr->m_image_offset) + pHdr->m_image_size;
if (img_end > section_size)
    throw std::runtime_error("... out of bounds");
```
Applied in both `copyBufferUpdateMetadata()` and `writeObjImage()` for all four section types.

**3. SectionBMC overflow hardening** — replaced the overflowable addition `uint64_t expectedSize = pHdr->m_offset + pHdr->m_size` with:
```cpp
if (pHdr->m_size > _origSectionSize || pHdr->m_offset > _origSectionSize - pHdr->m_size)
    throw ...
```

#### Risks (if any) associated the changes in the commit

Low. All changes are input validation only at xclbin load time. Behavior for well-formed xclbin files is unchanged. Malformed files that previously caused silent heap reads now throw `std::runtime_error`, which xclbinutil
already handles at its top level.

#### What has been tested and how, request additional testing if necessary

Code review and `xclbinutil` build verification. Recommend testing with crafted xclbin files containing out-of-bounds `mpo_*` offsets (e.g. `mpo_name = 0x7FFFFFFF`) and verifying that xclbinutil throws rather than leaking heap data or crashing. AddressSanitizer fuzzing of the sectionparsing paths would provide stronger coverage.

#### Documentation impact (if any)

None.
