### PR TITLE
[pyxrt] Expose controller transaction-result BO allocation

### DIFF
--- a/src/python/pybind11/pyxrt.pyi
+++ b/src/python/pybind11/pyxrt.pyi
@@ -1174,7 +1174,7 @@ class ext:
 
     @staticmethod
     def transaction_result_bo(hwctx: hw_context, size: SupportsInt) -> bo:
-        """Allocate controller transaction-result storage for one submission."""
+        """Allocate controller transaction-result storage for a hardware context."""
         ...
     
     # Type aliases for the ext submodule

--- a/src/python/pybind11/pyxrt.pyi
+++ b/src/python/pybind11/pyxrt.pyi
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 from __future__ import annotations
 import sys
 from enum import IntEnum
@@ -1171,6 +1171,11 @@ class _ext_kernel(kernel):
 
 class ext:
     """Extended XRT functionality."""
+
+    @staticmethod
+    def transaction_result_bo(hwctx: hw_context, size: SupportsInt) -> bo:
+        """Allocate controller transaction-result storage for one submission."""
+        ...
     
     # Type aliases for the ext submodule
     access_mode = _ext_access_mode

--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -710,7 +710,7 @@ PYBIND11_MODULE(pyxrt, m) {
             return xrt::ext::transaction_result_bo(hwctx, size);
         },
         py::arg("hwctx"), py::arg("size"),
-        "Allocate controller transaction-result storage for one submission.");
+        "Allocate controller transaction-result storage for a hardware context.");
     
     py::class_<xrt::ext::kernel, xrt::kernel> pyextkernel(ext, "kernel", "Extended kernel object for module-backed and shared workflows.");
 

--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -703,6 +703,14 @@ PYBIND11_MODULE(pyxrt, m) {
         }),
         py::arg("hwctx"), py::arg("pid"), py::arg("export_handle"),
         "Import an extended buffer into a hardware context from another process using an exported handle.");
+
+    ext.def("transaction_result_bo",
+        [](const xrt::hw_context& hwctx, size_t size) {
+            py::gil_scoped_release release;
+            return xrt::ext::transaction_result_bo(hwctx, size);
+        },
+        py::arg("hwctx"), py::arg("size"),
+        "Allocate controller transaction-result storage for one submission.");
     
     py::class_<xrt::ext::kernel, xrt::kernel> pyextkernel(ext, "kernel", "Extended kernel object for module-backed and shared workflows.");
 

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1731,6 +1731,12 @@ bo(const xrt::hw_context& hwctx, pid_type pid, xrt::bo::export_handle ehdl)
   : xrt::bo::bo{alloc_import_from_pid(device_type{hwctx}, pid, ehdl)}
 {}
 
+xrt::bo
+transaction_result_bo(const xrt::hw_context& hwctx, size_t size)
+{
+  return xrt_core::bo_int::create_bo(hwctx, size, xrt_core::bo_int::use_type::debug);
+}
+
 } // xrt::ext
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/include/xrt/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_ext.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef XRT_EXT_H_
 #define XRT_EXT_H_
 
@@ -18,6 +18,19 @@
 #endif
 
 #ifdef __cplusplus
+namespace xrt_core::bo_int {
+
+/// @cond
+// Existing coreutil entry point used by the header-only experimental wrapper.
+enum class use_type : int;
+
+XRT_API_EXPORT
+xrt::bo
+create_bo(const xrt::hw_context& hwctx, size_t size, use_type type);
+/// @endcond
+
+} // namespace xrt_core::bo_int
+
 namespace xrt::ext {
 
 /*!
@@ -231,6 +244,28 @@ public:
   /// @endcond
 };
 
+/**
+ * transaction_result_bo() - Allocate controller transaction-result storage
+ *
+ * @param hwctx
+ *  The hardware context that owns the buffer.
+ * @param size
+ *  Size of the result buffer in bytes.
+ *
+ * @return
+ *  A buffer object configured for controller transaction results.
+ *
+ * The controller writes ordered register-read results into this buffer. A new
+ * buffer must be allocated for each transaction submission that returns
+ * results.
+ */
+inline xrt::bo
+transaction_result_bo(const xrt::hw_context& hwctx, size_t size)
+{
+  return xrt_core::bo_int::create_bo(
+    hwctx, size,
+    static_cast<xrt_core::bo_int::use_type>(XRT_BO_USE_DEBUG));
+}
 
 class kernel : public xrt::kernel
 {

--- a/src/runtime_src/core/include/xrt/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_ext.h
@@ -18,19 +18,6 @@
 #endif
 
 #ifdef __cplusplus
-namespace xrt_core::bo_int {
-
-/// @cond
-// Existing coreutil entry point used by the header-only experimental wrapper.
-enum class use_type : int;
-
-XRT_API_EXPORT
-xrt::bo
-create_bo(const xrt::hw_context& hwctx, size_t size, use_type type);
-/// @endcond
-
-} // namespace xrt_core::bo_int
-
 namespace xrt::ext {
 
 /*!
@@ -255,17 +242,14 @@ public:
  * @return
  *  A buffer object configured for controller transaction results.
  *
- * The controller writes ordered register-read results into this buffer. A new
- * buffer must be allocated for each transaction submission that returns
- * results.
+ * The controller writes ordered register-read results into this buffer. The
+ * caller must keep the buffer alive until the associated submission completes
+ * and must not share it between in-flight submissions.
  */
-inline xrt::bo
-transaction_result_bo(const xrt::hw_context& hwctx, size_t size)
-{
-  return xrt_core::bo_int::create_bo(
-    hwctx, size,
-    static_cast<xrt_core::bo_int::use_type>(XRT_BO_USE_DEBUG));
-}
+XRT_API_EXPORT
+xrt::bo
+transaction_result_bo(const xrt::hw_context& hwctx, size_t size);
+
 
 class kernel : public xrt::kernel
 {


### PR DESCRIPTION
#### Problem solved by the commit

Controller transactions can return ordered register-read results through a hardware-context-owned result BO, but C++ and Python clients have no supported way to allocate that BO. This blocks host runtimes from consuming results such as AIE DMA Finish-on-TLAST counts.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

This is a missing API rather than a regression. It was found while adding host-visible Finish-on-TLAST completion counts to MLIR-AIE.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Add the experimental C++ API `xrt::ext::transaction_result_bo()`, declared in `xrt_ext.h` and implemented in `xrt_coreutil`. The implementation calls `xrt_core::bo_int::create_bo(..., use_type::debug)` internally. PyXRT exposes the same operation as `pyxrt.ext.transaction_result_bo()` by binding the public C++ API.

An earlier revision declared the internal allocator in the public header so a header-inline wrapper could remain compatible with the currently shipped Windows runtime. That approach was rejected because `bo_int` is private and subject to change. The revised implementation keeps the internal API entirely inside `xrt_coreutil`.

#### Risks (if any) associated the changes in the commit

This adds one experimental `xrt_coreutil` export. Existing API behavior and existing client compatibility are unchanged, but clients using the new function require an XRT runtime containing that export. Current Windows driver distributions do not contain it.

#### What has been tested and how, request additional testing if necessary

The public C++ header and a direct call to the new API compile against current XRT master. The modified `xrt_bo.cpp` compiles to an object, `pyxrt.cpp` passes syntax compilation, and a linked audit shared object exports `xrt::ext::transaction_result_bo()`. The Python type stub compiles.

The underlying result-BO allocation and Finish-on-TLAST path were exercised on Windows through the earlier compatibility prototype. This corrected version only changes how they are exposed.

#### Documentation impact (if any)

Adds API documentation in `xrt_ext.h` and the corresponding Python type stub.