### PR TITLE
AIESW-33855 [XRT-SMI] [AIE4] dipslay only relevant data in -telemetry and -preemption reports

### DIFF
--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -137,7 +137,7 @@ std::pair<unsigned int, unsigned int>
 get_terminal_size()
 {
   struct winsize ws{};
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) ioctl is the only portable way to query terminal size
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg) ioctl is the only portable way to query terminal size
   if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) != 0 || ws.ws_row == 0 || ws.ws_col == 0)
     throw xrt_core::error(errno, "Unable to determine terminal size");
 

--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
+// Local - Include Files
+#include "core/common/error.h"
+
 // 3rd Party Library - Include Files
 #include <boost/property_tree/ptree.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
 // System - Include Files
+#include <cerrno>
 #include <gnu/libc-version.h>
+#include <sys/ioctl.h>
 #include <sys/utsname.h>
 #include <thread>
+#include <unistd.h>
 
 #if defined(__aarch64__) || defined(__arm__) || defined(__mips__)
   #define MACHINE_NODE_PATH "/proc/device-tree/model"
@@ -125,6 +131,16 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("hostname", hn);
 
   pt.put("processor", processor_name());
+}
+
+std::pair<unsigned int, unsigned int>
+get_terminal_size()
+{
+  struct winsize ws{};
+  if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) != 0 || ws.ws_row == 0 || ws.ws_col == 0)
+    throw xrt_core::error(errno, "Unable to determine terminal size");
+
+  return {static_cast<unsigned int>(ws.ws_row), static_cast<unsigned int>(ws.ws_col)};
 }
 
 bool

--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
+++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
@@ -137,6 +137,7 @@ std::pair<unsigned int, unsigned int>
 get_terminal_size()
 {
   struct winsize ws{};
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) ioctl is the only portable way to query terminal size
   if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) != 0 || ws.ws_row == 0 || ws.ws_col == 0)
     throw xrt_core::error(errno, "Unable to determine terminal size");
 

--- a/src/runtime_src/core/common/detail/windows/sysinfo.h
+++ b/src/runtime_src/core/common/detail/windows/sysinfo.h
@@ -186,6 +186,25 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("processor", value);
 }
 
+std::pair<unsigned int, unsigned int>
+get_terminal_size()
+{
+  // Query the visible console window
+  const HANDLE hout = GetStdHandle(STD_OUTPUT_HANDLE);
+  CONSOLE_SCREEN_BUFFER_INFO csbi{};
+  if (hout == INVALID_HANDLE_VALUE || !GetConsoleScreenBufferInfo(hout, &csbi))
+    throw xrt_core::error("Unable to determine terminal size");
+
+  // srWindow describes the visible window; derive rows/cols from it (the
+  // buffer height/width can be much larger than what is on screen).
+  const auto cols = static_cast<unsigned int>(csbi.srWindow.Right - csbi.srWindow.Left + 1);
+  const auto rows = static_cast<unsigned int>(csbi.srWindow.Bottom - csbi.srWindow.Top + 1);
+  if (rows == 0 || cols == 0)
+    throw xrt_core::error("Unable to determine terminal size");
+
+  return {rows, cols};
+}
+
 bool
 is_advanced()
 {

--- a/src/runtime_src/core/common/sysinfo.cpp
+++ b/src/runtime_src/core/common/sysinfo.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "sysinfo.h"
 #include "detail/sysinfo.h"
@@ -53,6 +53,12 @@ is_advanced()
     return true;
 
   return xrt_core::sysinfo::detail::is_advanced();
+}
+
+std::pair<unsigned int, unsigned int>
+get_terminal_size()
+{
+  return xrt_core::sysinfo::detail::get_terminal_size();
 }
 
 } //xrt_core::sysinfo

--- a/src/runtime_src/core/common/sysinfo.h
+++ b/src/runtime_src/core/common/sysinfo.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #ifndef _xrt_core_common_sysinfo_h_
 #define _xrt_core_common_sysinfo_h_
 
@@ -9,7 +9,14 @@
 // 3rd Party Library - Include Files
 #include <boost/property_tree/ptree.hpp>
 
+// System - Include Files
+#include <utility>
+
 namespace xrt_core::sysinfo {
+
+XRT_CORE_COMMON_EXPORT
+std::pair<unsigned int, unsigned int>
+get_terminal_size();
 
 XRT_CORE_COMMON_EXPORT
 void

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __Report_h_
 #define __Report_h_
@@ -49,6 +49,8 @@ class Report : public JSONConfigurable {
   bool isDeviceRequired() const { return m_isDeviceRequired; };
   bool isHidden() const { return m_isHidden; };
   bool getConfigHidden() const {return isHidden();};
+
+  virtual bool clearScreenBeforeReports() const { return false; }
 
   void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
-// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -22,6 +22,7 @@ namespace po = boost::program_options;
 #include <algorithm>
 #include <iostream>
 #include <numeric>
+#include <sstream>
 
 // ------ N A M E S P A C E ---------------------------------------------------
 using namespace XBUtilities;
@@ -348,6 +349,26 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
       // proceed even if the platform name is not available
       platform = "<not defined>";
     }
+
+    const bool clear_screen = std::any_of(reportsToProcess.begin(), reportsToProcess.end(),
+      [](const std::shared_ptr<Report>& r) {
+        return r->isDeviceRequired() && r->clearScreenBeforeReports();
+      });
+
+    // When more than one device report is printed together, truncate the "live"
+    // reports against the fixed default terminal size instead of the measured
+    // size, so the combined layout is stable regardless of window size.
+    const auto device_report_count = std::count_if(reportsToProcess.begin(), reportsToProcess.end(),
+      [](const std::shared_ptr<Report>& r) { return r->isDeviceRequired(); });
+    const bool multiple_reports = device_report_count > 1;
+
+    if (clear_screen && !XBUtilities::is_escape_codes_disabled()) {
+      // 2J: clear the visible screen, H: home the cursor. Scrollback is
+      // intentionally preserved (no 3J), so prior terminal history stays
+      // available by scrolling up.
+      consoleStream << "\033[2J\033[H";
+    }
+
     // Bound the device description on top and bottom with '-' characters
     const std::string dev_desc = (boost::format("[%s] : %s\n") % ptDevice.get<std::string>("device_id") % platform).str();
     consoleStream << std::endl;
@@ -369,18 +390,24 @@ XBUtilities::produce_reports( const std::shared_ptr<xrt_core::device>& device,
     // 1. Is in factory mode and is not in recovery mode
     // 2. Is not ready and is not in recovery mode
     if ((is_mfg || !is_ready) && !is_recovery)
-      std::cout << "Warning: Device is not ready - Limited functionality available with XRT tools.\n";
+      consoleStream << "Warning: Device is not ready - Limited functionality available with XRT tools.\n";
 
     for (auto &report : reportsToProcess) {
       if (!report->isDeviceRequired())
         continue;
 
+      std::ostringstream report_buffer;
       boost::property_tree::ptree ptReport;
       try {
-        report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
+        report->getFormattedReport(device.get(), schemaVersion, elementFilter, report_buffer, ptReport);
       } catch (const std::exception&) {
         is_report_output_valid = false;
       }
+
+      if (report->clearScreenBeforeReports())
+        consoleStream << XBUtilities::truncate_to_terminal(report_buffer.str(), multiple_reports, multiple_reports);
+      else
+        consoleStream << report_buffer.str();
 
       // Only support 1 node on the root
       if (ptReport.size() > 1)

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2020-2022 Xilinx, Inc
 // Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
-// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.cpp
@@ -8,6 +8,7 @@
 #include "XBUtilitiesCore.h"
 
 #include "core/common/error.h"
+#include "core/common/sysinfo.h"
 #include "core/common/unistd.h"
 
 // 3rd Party Library - Include Files
@@ -17,6 +18,8 @@
 
 // System - Include Files
 #include <regex>
+#include <sstream>
+#include <vector>
 
 
 // ------ N A M E S P A C E ---------------------------------------------------
@@ -138,6 +141,76 @@ XBUtilities::disable_escape_codes(bool _disable)
 bool
 XBUtilities::is_escape_codes_disabled() {
   return m_disableEscapeCodes;
+}
+
+std::pair<unsigned int, unsigned int>
+XBUtilities::get_terminal_size()
+{
+  // Conservative fallback used when the size cannot be determined (e.g. the
+  // output stream is not attached to a real console, or the current system
+  // shim does not implement the query).
+  constexpr unsigned int default_rows = 24;
+  constexpr unsigned int default_cols = 80;
+
+  try {
+    const auto [rows, cols] = xrt_core::sysinfo::get_terminal_size();
+    if (rows > 0 && cols > 0)
+      return {rows, cols};
+  }
+  catch (const std::exception&) {
+    // Not implemented / not a terminal; fall back to the default below.
+  }
+
+  return {default_rows, default_cols};
+}
+
+std::string
+XBUtilities::truncate_to_terminal(const std::string& content, bool use_default_terminal_size, bool show_truncation_notice)
+{
+  // Batch mode / redirected output: return the full content untouched so that
+  // scripted output stays complete.
+  if (is_escape_codes_disabled())
+    return content;
+
+  // Split the content into individual lines.
+  std::vector<std::string> lines;
+  std::string::size_type start = 0;
+  while (start <= content.size()) {
+    const auto pos = content.find('\n', start);
+    if (pos == std::string::npos) {
+      if (start < content.size())
+        lines.push_back(content.substr(start));
+      break;
+    }
+    lines.push_back(content.substr(start, pos - start));
+    start = pos + 1;
+  }
+
+  // get_terminal_size() returns {rows, cols}; only the row count is needed here.
+  // When multiple reports are printed together, use the fixed default row count
+  // for a stable layout instead of measuring the current terminal.
+  constexpr unsigned int default_rows = 24;
+  const unsigned int term_rows = use_default_terminal_size ? default_rows : get_terminal_size().first;
+  // Reserve rows for the shell prompt, and (when the notice is shown) an extra
+  // two rows for the notice and a trailing blank separator line.
+  const unsigned int reserved_rows = show_truncation_notice ? 3 : 1;
+  const unsigned int visible_rows = (term_rows > reserved_rows) ? (term_rows - reserved_rows) : 1;
+
+  if (lines.size() <= visible_rows)
+    return content;
+
+  std::ostringstream out;
+  for (unsigned int i = 0; i < visible_rows; ++i)
+    out << lines[i] << "\n";
+
+  // When requested, note that content was dropped and how to see the full
+  // report, followed by a blank line separating this report from the next.
+  if (show_truncation_notice) {
+    out << "INFO:  additional entries not shown - use --batch or redirect to a file to see the full report\n";
+    out << "\n";
+  }
+
+  return out.str();
 }
 
 

--- a/src/runtime_src/core/tools/common/XBUtilitiesCore.h
+++ b/src/runtime_src/core/tools/common/XBUtilitiesCore.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <map>
 #include <iostream>
+#include <utility>
 #include <vector>
 
 #include <boost/format.hpp>
@@ -53,6 +54,19 @@ namespace XBUtilities {
 
   void disable_escape_codes( bool _disable );
   bool is_escape_codes_disabled();  
+
+  /**
+   * Query the visible size of the current terminal window as a {rows, cols}
+   * pair (rows = height, cols = width).
+   */
+  std::pair<unsigned int, unsigned int> get_terminal_size();
+
+  /**
+   * Truncate report text to the rows that fit in the terminal, returning the
+   * (possibly shortened) string. Does not clear the screen; the caller is
+   * responsible for any screen clearing/header printing.
+   */
+  std::string truncate_to_terminal(const std::string& content, bool use_default_terminal_size = false, bool show_truncation_notice = true);
 
   void message_(MessageType _eMT, const std::string& _msg, bool _endl = true, std::ostream & _ostream = std::cout);
 

--- a/src/runtime_src/core/tools/common/reports/ReportPreemption.h
+++ b/src/runtime_src/core/tools/common/reports/ReportPreemption.h
@@ -18,7 +18,7 @@ class ReportPreemption : public Report {
   virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream& _output) const;
 
   // Full-screen "live" report: clear once, print header once, share it across reports.
-  virtual bool clearScreenBeforeReports() const override { return true; }
+  bool clearScreenBeforeReports() const override { return true; }
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/reports/ReportPreemption.h
+++ b/src/runtime_src/core/tools/common/reports/ReportPreemption.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __ReportPreemption_h_
 #define __ReportPreemption_h_
@@ -16,6 +16,9 @@ class ReportPreemption : public Report {
   virtual void getPropertyTreeInternal(const xrt_core::device* dev, boost::property_tree::ptree& pt) const;
   virtual void getPropertyTree20202(const xrt_core::device* deve, boost::property_tree::ptree& pt) const;
   virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream& _output) const;
+
+  // Full-screen "live" report: clear once, print header once, share it across reports.
+  virtual bool clearScreenBeforeReports() const override { return true; }
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/reports/ReportTelemetry.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportTelemetry.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "ReportTelemetry.h"
 
@@ -214,14 +214,14 @@ ReportTelemetry::writeReport(const xrt_core::device* /*_pDevice*/,
                              const std::vector<std::string>& /*_elementsFilter*/,
                              std::ostream& _output) const
 {
-  _output << "Telemetry\n";
-
   boost::property_tree::ptree telemetry_pt = pt.get_child("telemetry", empty_ptree);
   if (telemetry_pt.empty()) {
+    _output << "Telemetry\n";
     _output << "  No telemetry information available\n\n";
     return;
   }
 
+  _output << "Telemetry\n";
   _output << generate_misc_string(telemetry_pt);
   _output << generate_rtos_string(telemetry_pt);
   _output << generate_rtos_dtlb_string(telemetry_pt);

--- a/src/runtime_src/core/tools/common/reports/ReportTelemetry.h
+++ b/src/runtime_src/core/tools/common/reports/ReportTelemetry.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #ifndef __ReportTelemetry_h_
 #define __ReportTelemetry_h_
@@ -16,6 +16,9 @@ class ReportTelemetry : public Report {
   virtual void getPropertyTreeInternal(const xrt_core::device* dev, boost::property_tree::ptree& pt) const;
   virtual void getPropertyTree20202(const xrt_core::device* deve, boost::property_tree::ptree& pt) const;
   virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream& _output) const;
+
+  // Full-screen "live" report: clear once, print header once, share it across reports.
+  virtual bool clearScreenBeforeReports() const override { return true; }
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/reports/ReportTelemetry.h
+++ b/src/runtime_src/core/tools/common/reports/ReportTelemetry.h
@@ -18,7 +18,7 @@ class ReportTelemetry : public Report {
   virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream& _output) const;
 
   // Full-screen "live" report: clear once, print header once, share it across reports.
-  virtual bool clearScreenBeforeReports() const override { return true; }
+  bool clearScreenBeforeReports() const override { return true; }
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbflash2/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(${XBFLASH_NAME} ${XBFLASH_QSPI_SRC})
 set(Boost_USE_STATIC_LIBS ON)
 target_link_libraries(${XBFLASH_NAME}
       PRIVATE
+      xrt_coreutil
       boost_program_options
       )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[AIESW-33855](https://jira.xilinx.com/browse/AIESW-33855) [XRT-SMI] [AIE4] dipslay only relevant data in -telemetry and -preemption reports

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
When driver exposed the new virtual contexts, xrt-smi started displaying long reports

#### How problem was solved, alternative solutions (if any) and why they were rejected
When a single report is run interactively (preemption or telemetry), it clears the current screen and prints the rows that fit on the terminal.
1.	**When the new behavior is triggered**
All of the following must be true:
- _A VT-capable terminal is available_ — i.e. ANSI/VT escape sequences can be used. If escape codes are unavailable/disabled, the behavior is off.
- _No --batch_ - With --batch, escape codes are disabled and the whole report is printed. This precedence was set by watch mode, and I'm following it for consistency.
- _Exactly one report is queried_ — a single -r telemetry or -r preemption. The fit-to-terminal trimming applies to the single-report case only.

2.	**Behavior when triggered (interactive, no --batch)**
•	The visible screen is cleared. This preserves scrollback. 
•	We query the terminal size (rows) — GetConsoleScreenBufferInfo on Windows, ioctl(TIOCGWINSZ) on Linux — with a conservative 24×80 fallback if it can't be determined.
•	The report is trimmed to the rows that fit.

3.	Behavior when NOT triggered
There are three cases, with two distinct outcomes:
- (a) No VT terminal, or (b) --batch → escape codes are disabled, so the full, unmodified report is emitted: no screen clear, no truncation. This keeps redirected/scripted output complete (the watch-mode precedence).
- (c) Multiple reports queried (e.g. -r telemetry preemption, interactive) → the screen is cleared once and a single shared device header is printed; each telemetry/preemption report is then capped at the fixed default 24-row layout (not the measured terminal size, so combined output stays stable) and followed by a truncation notice. Other reports in the same run (e.g. platform) print in full.

Behavior:
```
xrt-smi examine -r platform  #unchanged
xrt-smi examine -r preemption #table fits terminal size
xrt-smi examine -r telemetry #table fits terminal size
xrt-smi examine -r platform telemetry preemption aie-partitions #prints all reports, telemetry and preemption reports show 16 entries followed by a note that the report is truncated"
xrt-smi examine -r telemetry --batch #prints full report
xrt-smi examine -r preemption --batch #prints full report
```


#### Risks (if any) associated the changes in the commit
It touches `Report.h` and `XBUtilities`, so it can affect examine reports. However, I have done thorough manual testing. 

#### What has been tested and how, request additional testing if necessary
Tested on windows
Linux testing TBD


#### Documentation impact (if any)
Update xrt-smi User Guide