### PR TITLE
AIESW-41370 handle xrt::bo subclasses as buffer arguments

### DIFF
--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -485,7 +485,7 @@ public:
    * See also ``operator()`` to set all arguments and start kernel.
    */
   template <typename ArgType>
-  std::enable_if_t<!std::is_base_of<xrt::bo, std::decay_t<ArgType>>::value>
+  std::enable_if_t<!std::is_base_of_v<xrt::bo, std::decay_t<ArgType>>>
   set_arg(int index, ArgType&& arg)
   {
     set_arg_at_index(index, &arg, sizeof(arg));
@@ -503,7 +503,7 @@ public:
    * treated as scalars by the generic template.
    */
   template <typename ArgType>
-  std::enable_if_t<std::is_base_of<xrt::bo, std::decay_t<ArgType>>::value>
+  std::enable_if_t<std::is_base_of_v<xrt::bo, std::decay_t<ArgType>>>
   set_arg(int index, ArgType&& boh)
   {
     set_arg_at_index(index, static_cast<const xrt::bo&>(boh));

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -23,6 +23,7 @@
 # include <cstdint>
 # include <functional>
 # include <memory>
+# include <type_traits>
 # include <vector>
 #endif
 
@@ -484,10 +485,28 @@ public:
    * See also ``operator()`` to set all arguments and start kernel.
    */
   template <typename ArgType>
-  void
+  std::enable_if_t<!std::is_base_of<xrt::bo, std::decay_t<ArgType>>::value>
   set_arg(int index, ArgType&& arg)
   {
     set_arg_at_index(index, &arg, sizeof(arg));
+  }
+
+  /**
+   * set_arg() - Set a specific kernel global argument for a run
+   *
+   * @param index
+   *  Index of kernel argument to set
+   * @param boh
+   *  Any xrt::bo or subclass (e.g. xrt::ext::bo) argument value to set.
+   *
+   * This overload catches xrt::bo subclasses that would otherwise be
+   * treated as scalars by the generic template.
+   */
+  template <typename ArgType>
+  std::enable_if_t<std::is_base_of<xrt::bo, std::decay_t<ArgType>>::value>
+  set_arg(int index, ArgType&& boh)
+  {
+    set_arg_at_index(index, static_cast<const xrt::bo&>(boh));
   }
 
   /**


### PR DESCRIPTION
#### Problem solved by the commit
Add a constrained template overload that matches any type derived from xrt::bo and dispatches to set_arg_at_index(int, const xrt::bo&). Without this, passing an xrt::ext::bo resolves to the unconstrained scalar template and is treated as a raw scalar value.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
AIESW-41370

#### How problem was solved, alternative solutions (if any) and why they were rejected
Test case per Jira.

