### PR TITLE
Elf decompress

### DIFF
--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -43,6 +43,7 @@ namespace xrt {
 ////////////////////////////////////////////////////////////////
 struct buf
 {
+  template <typename T> using span = xrt_core::span<T>;
 private:
   // A view into ELFIO section data, possibly compressed.
   // For section-backed views, section and elf are non-null.
@@ -63,7 +64,7 @@ private:
   struct view_entry {
     const ELFIO::section* section = nullptr;   // section-backed view (may be compressed)
     const ELFIO::elfio* elf = nullptr;         // ELFIO owning the section (see lifetime note above)
-    std::string_view padding;                  // for zero-padding, points into m_padding_buffer
+    span<uint8_t> padding;                     // for zero-padding, points into m_padding_buffer
     std::size_t data_size = 0;                 // effective size (uncompressed if compressed)
   };
 
@@ -108,16 +109,15 @@ public:
   add_padding_to_size(size_t target_size)
   {
     size_t current = size();
-    if (target_size > current) {
-      size_t padding_size = target_size - current;
-      m_padding_buffer.resize(padding_size, 0);
-      view_entry entry;
-      entry.padding = std::string_view(
-          reinterpret_cast<const char*>(m_padding_buffer.data()),
-          padding_size);
-      entry.data_size = padding_size;
-      m_views.push_back(entry);
-    }
+    if (target_size <= current)
+      return;
+    
+    size_t padding_size = target_size - current;
+    m_padding_buffer.resize(padding_size, 0);
+    view_entry entry;
+    entry.padding = {m_padding_buffer.data(), m_padding_buffer.size()};
+    entry.data_size = padding_size;
+    m_views.push_back(entry);
   }
 
   // Get total size across all views.

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -39,8 +39,8 @@ namespace xrt {
 //
 // Stores non-owning pointers to ELFIO section objects.
 // Compression is fully abstracted — aiebu determines whether
-// decompression is needed via get_section_data_size() /
-// copy_section_data().
+// decompression is needed via get_section_uncompressed_size() /
+// copy_section_uncompressed_data().
 // Padding stored separately to avoid copying section data.
 ////////////////////////////////////////////////////////////////
 struct buf
@@ -79,7 +79,7 @@ public:
     view_entry entry;
     entry.section = sec;
     entry.elf = &elf;
-    entry.data_size = aiebu::get_section_data_size(sec, elf);
+    entry.data_size = aiebu::get_section_uncompressed_size(sec, elf);
     m_views.push_back(entry);
   }
 
@@ -134,7 +134,7 @@ public:
     auto* dst = dest.data();
     for (const auto& v : m_views) {
       if (v.section) {
-        aiebu::copy_section_data(v.section, *v.elf, dst, v.data_size);
+        aiebu::copy_section_uncompressed_data(v.section, *v.elf, dst, v.data_size);
       }
       else {
         std::memcpy(dst, v.padding.data(), v.data_size);
@@ -143,22 +143,17 @@ public:
     }
   }
 
-  // Get data pointer - only works for single uncompressed section view (zero-copy).
-  // Throws for compressed views — caller must use copy_to() instead.
+  // Get data pointer - only works for single view (zero-copy)
+  // Used by patcher that needs direct memory access
   const uint8_t*
   data() const
   {
     if (m_views.size() == 1 && m_views[0].section) {
-      if (m_views[0].data_size != m_views[0].section->get_size()) {
-        throw std::runtime_error(
-          "Cannot get direct pointer from compressed buffer. "
-          "Use copy_to() to decompress data instead."
-        );
-      }
       return reinterpret_cast<const uint8_t*>(m_views[0].section->get_data());
     }
 
-    // Multiple views or padding-only: cannot provide direct pointer
+    // Multiple views: cannot provide direct pointer
+    // Caller should use copy_to() instead
     throw std::runtime_error(
       "Cannot get direct pointer from buffer with multiple views. "
       "Use copy_to() to copy data instead."

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -7,6 +7,7 @@
 // It provides access to xrt::elf_impl class that is not
 // directly exposed to end users.
 #include "core/common/config.h"
+#include "core/common/span.h"
 #include "core/common/xclbin_parser.h"
 #include "core/include/xrt/experimental/xrt_elf.h"
 #include "core/include/xrt/xrt_bo.h"
@@ -14,7 +15,7 @@
 
 #include "ert.h"
 
-#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_assembler.h"
+#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_decompress.h"
 
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio.hpp>
@@ -36,21 +37,23 @@ namespace xrt {
 ////////////////////////////////////////////////////////////////
 // buf - wrapper for holding ELF section data
 //
-// Uses std::string_view for zero-copy non-owning view of
-// ELFIO section data.
+// Stores non-owning pointers to ELFIO section objects.
+// Compression is fully abstracted — aiebu determines whether
+// decompression is needed via get_section_data_size() /
+// copy_section_data().
 // Padding stored separately to avoid copying section data.
 ////////////////////////////////////////////////////////////////
 struct buf
 {
 private:
   // A view into ELFIO section data, possibly compressed.
-  // For compressed views, uncompressed_size > 0 and data points to the raw
-  // compressed bytes (including Elf_Chdr header).
-  // For uncompressed views, uncompressed_size == 0 and data is the raw bytes.
+  // For section-backed views, section and elf are non-null.
+  // For padding views, section is null and padding holds the zero buffer.
   struct view_entry {
-    std::string_view data;            // view into ELFIO data (compressed or uncompressed)
-    std::size_t uncompressed_size = 0; // 0 = not compressed; >0 = uncompressed size from Chdr
-    unsigned char elf_class = 0;       // ELFCLASS32/64 — needed for Chdr parsing when compressed
+    const ELFIO::section* section = nullptr;   // section-backed view (may be compressed)
+    const ELFIO::elfio* elf = nullptr;         // ELFIO object owning the section
+    std::string_view padding;                  // for zero-padding (section == nullptr)
+    std::size_t data_size = 0;                 // effective size (uncompressed if compressed)
   };
 
   // Non-owning views into ELFIO or external data
@@ -63,38 +66,29 @@ private:
 public:
   buf() = default;
 
-  // Append section data, detecting SHF_COMPRESSED sections.
-  // Compressed views store the uncompressed size from the Chdr header;
-  // decompression is deferred until copy_to().
+  // Append section data from an ELFIO section.
+  // Compression handling is delegated to aiebu — XRT does not inspect
+  // SHF_COMPRESSED or Chdr headers directly.  Decompression is deferred
+  // until copy_to().
   void
-  append_section_data(const ELFIO::section* sec, unsigned char elf_class = ELFIO::ELFCLASS32)
+  append_section_data(const ELFIO::section* sec, const ELFIO::elfio& elf)
   {
     if (!sec || sec->get_size() == 0)
       return;
 
     view_entry entry;
-    entry.data = std::string_view(sec->get_data(), sec->get_size());
-
-    if (sec->get_flags() & ELFIO::SHF_COMPRESSED) {
-      entry.elf_class = elf_class;
-      entry.uncompressed_size =
-          aiebu::aiebu_assembler::get_uncompressed_section_size(
-              sec->get_data(), sec->get_size(), elf_class);
-      if (entry.uncompressed_size == 0)
-        throw std::runtime_error(
-            "SHF_COMPRESSED section '" + sec->get_name()
-            + "' has invalid Chdr header");
-    }
-
+    entry.section = sec;
+    entry.elf = &elf;
+    entry.data_size = aiebu::get_section_data_size(sec, elf);
     m_views.push_back(entry);
   }
 
   // Overload for smart pointers (from ELFIO range-based for loops)
   void
   append_section_data(const std::unique_ptr<ELFIO::section>& sec,
-                      unsigned char elf_class = ELFIO::ELFCLASS32)
+                      const ELFIO::elfio& elf)
   {
-    append_section_data(sec.get(), elf_class);
+    append_section_data(sec.get(), elf);
   }
 
   // Add padding to reach target size (for AIE2PS/AIE4 page alignment)
@@ -107,64 +101,64 @@ public:
       size_t padding_size = target_size - current;
       m_padding_buffer.resize(padding_size, 0);
       view_entry entry;
-      entry.data = std::string_view(
+      entry.padding = std::string_view(
           reinterpret_cast<const char*>(m_padding_buffer.data()),
           padding_size);
+      entry.data_size = padding_size;
       m_views.push_back(entry);
     }
   }
 
   // Get total size across all views.
-  // For compressed views, returns the uncompressed size (what copy_to will produce).
+  // For compressed sections, returns the uncompressed size (what copy_to will produce).
   size_t
   size() const
   {
     size_t total = 0;
-    for (const auto& v : m_views) {
-      total += (v.uncompressed_size > 0) ? v.uncompressed_size : v.data.size();
-    }
+    for (const auto& v : m_views)
+      total += v.data_size;
     return total;
   }
 
   // Copy all views to destination buffer.
-  // Compressed views are decompressed directly into dest via zstd.
-  // Uncompressed views are memcpy'd as before.
+  // Compressed sections are decompressed directly into dest via aiebu.
+  // Uncompressed sections and padding are memcpy'd.
   void
-  copy_to(void* dest) const
+  copy_to(xrt_core::span<uint8_t> dest) const
   {
-    auto* dst = static_cast<uint8_t*>(dest);
+    if (dest.size() < size())
+      throw std::runtime_error(
+        "buf::copy_to: dest size (" + std::to_string(dest.size())
+        + ") < buf size (" + std::to_string(size()) + ")");
+
+    auto* dst = dest.data();
     for (const auto& v : m_views) {
-      if (v.uncompressed_size > 0) {
-        // Decompress directly into destination buffer
-        aiebu::aiebu_assembler::decompress_section_into(
-            v.data.data(), v.data.size(),
-            dst, v.uncompressed_size, v.elf_class);
-        dst += v.uncompressed_size;
+      if (v.section) {
+        aiebu::copy_section_data(v.section, *v.elf, dst, v.data_size);
       }
       else {
-        std::memcpy(dst, v.data.data(), v.data.size());
-        dst += v.data.size();
+        std::memcpy(dst, v.padding.data(), v.data_size);
       }
+      dst += v.data_size;
     }
   }
 
-  // Get data pointer - only works for single uncompressed view (zero-copy).
+  // Get data pointer - only works for single uncompressed section view (zero-copy).
   // Throws for compressed views — caller must use copy_to() instead.
   const uint8_t*
   data() const
   {
-    if (m_views.size() == 1 && m_views[0].uncompressed_size == 0) {
-      return reinterpret_cast<const uint8_t*>(m_views[0].data.data());
+    if (m_views.size() == 1 && m_views[0].section) {
+      if (m_views[0].data_size != m_views[0].section->get_size()) {
+        throw std::runtime_error(
+          "Cannot get direct pointer from compressed buffer. "
+          "Use copy_to() to decompress data instead."
+        );
+      }
+      return reinterpret_cast<const uint8_t*>(m_views[0].section->get_data());
     }
 
-    if (m_views.size() == 1 && m_views[0].uncompressed_size > 0) {
-      throw std::runtime_error(
-        "Cannot get direct pointer from compressed buffer. "
-        "Use copy_to() to decompress data instead."
-      );
-    }
-
-    // Multiple views: cannot provide direct pointer
+    // Multiple views or padding-only: cannot provide direct pointer
     throw std::runtime_error(
       "Cannot get direct pointer from buffer with multiple views. "
       "Use copy_to() to copy data instead."
@@ -178,7 +172,7 @@ public:
   {
     std::string result;
     result.resize(size());
-    copy_to(result.data());
+    copy_to({reinterpret_cast<uint8_t*>(result.data()), result.size()});
     return result;
   }
 
@@ -411,8 +405,8 @@ public:
 
   // Get raw ELFIO object reference.
   // Compressed sections (.ctrltext*, .ctrldata*, .ctrlpkt*) contain raw compressed
-  // bytes with SHF_COMPRESSED set. Callers that need section data must handle
-  // decompression — e.g. buf::copy_to() uses decompress_section_into() per-section
+  // bytes with SHF_COMPRESSED set. Callers that need section data should use
+  // buf::append_section_data() + copy_to() which delegate to aiebu for decompression.
   const ELFIO::elfio&
   get_elfio() const
   {

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -14,12 +14,17 @@
 
 #include "ert.h"
 
+#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_assembler.h"
+
+#include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio.hpp>
 
 #include <cstdint>
+#include <cstring>
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -38,8 +43,18 @@ namespace xrt {
 struct buf
 {
 private:
+  // A view into ELFIO section data, possibly compressed.
+  // For compressed views, uncompressed_size > 0 and data points to the raw
+  // compressed bytes (including Elf_Chdr header).
+  // For uncompressed views, uncompressed_size == 0 and data is the raw bytes.
+  struct view_entry {
+    std::string_view data;            // view into ELFIO data (compressed or uncompressed)
+    std::size_t uncompressed_size = 0; // 0 = not compressed; >0 = uncompressed size from Chdr
+    unsigned char elf_class = 0;       // ELFCLASS32/64 — needed for Chdr parsing when compressed
+  };
+
   // Non-owning views into ELFIO or external data
-  std::vector<std::string_view> m_views;
+  std::vector<view_entry> m_views;
 
   // Padding buffer - only allocated when AIE2PS/AIE4 needs page alignment
   // Stored separately to avoid copying section data
@@ -48,20 +63,38 @@ private:
 public:
   buf() = default;
 
-  // Append section data without copying (zero-copy from ELFIO)
+  // Append section data, detecting SHF_COMPRESSED sections.
+  // Compressed views store the uncompressed size from the Chdr header;
+  // decompression is deferred until copy_to().
   void
-  append_section_data(const ELFIO::section* sec)
+  append_section_data(const ELFIO::section* sec, unsigned char elf_class = ELFIO::ELFCLASS32)
   {
-    if (sec && sec->get_size() > 0) {
-      m_views.emplace_back(sec->get_data(), sec->get_size());
+    if (!sec || sec->get_size() == 0)
+      return;
+
+    view_entry entry;
+    entry.data = std::string_view(sec->get_data(), sec->get_size());
+
+    if (sec->get_flags() & ELFIO::SHF_COMPRESSED) {
+      entry.elf_class = elf_class;
+      entry.uncompressed_size =
+          aiebu::aiebu_assembler::get_uncompressed_section_size(
+              sec->get_data(), sec->get_size(), elf_class);
+      if (entry.uncompressed_size == 0)
+        throw std::runtime_error(
+            "SHF_COMPRESSED section '" + sec->get_name()
+            + "' has invalid Chdr header");
     }
+
+    m_views.push_back(entry);
   }
 
   // Overload for smart pointers (from ELFIO range-based for loops)
   void
-  append_section_data(const std::unique_ptr<ELFIO::section>& sec)
+  append_section_data(const std::unique_ptr<ELFIO::section>& sec,
+                      unsigned char elf_class = ELFIO::ELFCLASS32)
   {
-    append_section_data(sec.get());
+    append_section_data(sec.get(), elf_class);
   }
 
   // Add padding to reach target size (for AIE2PS/AIE4 page alignment)
@@ -73,62 +106,79 @@ public:
     if (target_size > current) {
       size_t padding_size = target_size - current;
       m_padding_buffer.resize(padding_size, 0);
-      m_views.emplace_back(
-        reinterpret_cast<const char*>(m_padding_buffer.data()),
-        padding_size
-      );
+      view_entry entry;
+      entry.data = std::string_view(
+          reinterpret_cast<const char*>(m_padding_buffer.data()),
+          padding_size);
+      m_views.push_back(entry);
     }
   }
 
-  // Get total size across all views
+  // Get total size across all views.
+  // For compressed views, returns the uncompressed size (what copy_to will produce).
   size_t
   size() const
   {
     size_t total = 0;
-    for (const auto& view : m_views) {
-      total += view.size();
+    for (const auto& v : m_views) {
+      total += (v.uncompressed_size > 0) ? v.uncompressed_size : v.data.size();
     }
     return total;
   }
 
-  // Copy all views to destination buffer
-  // Iterates views and copies directly - used for copying to device BOs
+  // Copy all views to destination buffer.
+  // Compressed views are decompressed directly into dest via zstd.
+  // Uncompressed views are memcpy'd as before.
   void
   copy_to(void* dest) const
   {
     auto* dst = static_cast<uint8_t*>(dest);
-    for (const auto& view : m_views) {
-      std::memcpy(dst, view.data(), view.size());
-      dst += view.size();
+    for (const auto& v : m_views) {
+      if (v.uncompressed_size > 0) {
+        // Decompress directly into destination buffer
+        aiebu::aiebu_assembler::decompress_section_into(
+            v.data.data(), v.data.size(),
+            dst, v.uncompressed_size, v.elf_class);
+        dst += v.uncompressed_size;
+      }
+      else {
+        std::memcpy(dst, v.data.data(), v.data.size());
+        dst += v.data.size();
+      }
     }
   }
 
-  // Get data pointer - only works for single view (zero-copy)
-  // Used by patcher that needs direct memory access
+  // Get data pointer - only works for single uncompressed view (zero-copy).
+  // Throws for compressed views — caller must use copy_to() instead.
   const uint8_t*
   data() const
   {
-    if (m_views.size() == 1) {
-      return reinterpret_cast<const uint8_t*>(m_views[0].data());
+    if (m_views.size() == 1 && m_views[0].uncompressed_size == 0) {
+      return reinterpret_cast<const uint8_t*>(m_views[0].data.data());
+    }
+
+    if (m_views.size() == 1 && m_views[0].uncompressed_size > 0) {
+      throw std::runtime_error(
+        "Cannot get direct pointer from compressed buffer. "
+        "Use copy_to() to decompress data instead."
+      );
     }
 
     // Multiple views: cannot provide direct pointer
-    // Caller should use copy_to() instead
     throw std::runtime_error(
       "Cannot get direct pointer from buffer with multiple views. "
       "Use copy_to() to copy data instead."
     );
   }
 
-  // Create std::string from views (for debug/trace)
+  // Create std::string from views (for debug/trace).
+  // Decompresses compressed views into the result string.
   std::string
   to_string() const
   {
     std::string result;
-    result.reserve(size());
-    for (const auto& view : m_views) {
-      result.append(view);
-    }
+    result.resize(size());
+    copy_to(result.data());
     return result;
   }
 
@@ -359,11 +409,37 @@ public:
   elf_impl& operator=(const elf_impl&) = delete;
   elf_impl& operator=(elf_impl&&) = delete;
 
-  // Get raw ELFIO object reference
+  // Get raw ELFIO object reference.
+  // Note: if the ELF was loaded without pre-decompression, compressed sections
+  // will contain raw compressed bytes.  For code that needs decompressed section
+  // data (e.g. AIEDebug), use get_decompressed_elfio() instead.
   const ELFIO::elfio&
   get_elfio() const
   {
     return m_elfio;
+  }
+
+  // Get a fully decompressed copy of the ELFIO object.
+  // This is expensive (serialize + decompress + reload) and should only be used
+  // in rare diagnostic paths (e.g. AIEDebug on health check failure).
+  ELFIO::elfio
+  get_decompressed_elfio() const
+  {
+    // Serialize current ELFIO (may have compressed sections) back to bytes
+    std::ostringstream oss;
+    const_cast<ELFIO::elfio&>(m_elfio).save(oss);
+    std::string elf_str = oss.str();
+
+    // Decompress using existing full-ELF API
+    std::vector<char> buf(elf_str.begin(), elf_str.end());
+    buf = aiebu::aiebu_assembler::decompress_elf(std::move(buf));
+
+    // Load into fresh ELFIO
+    ELFIO::elfio decompressed;
+    boost::interprocess::ibufferstream istr(buf.data(), buf.size());
+    if (!decompressed.load(istr))
+      throw std::runtime_error("failed to load decompressed ELF");
+    return decompressed;
   }
 
   // Get the filename this ELF was loaded from (empty if loaded from buffer/stream)

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -410,36 +410,13 @@ public:
   elf_impl& operator=(elf_impl&&) = delete;
 
   // Get raw ELFIO object reference.
-  // Note: if the ELF was loaded without pre-decompression, compressed sections
-  // will contain raw compressed bytes.  For code that needs decompressed section
-  // data (e.g. AIEDebug), use get_decompressed_elfio() instead.
+  // Compressed sections (.ctrltext*, .ctrldata*, .ctrlpkt*) contain raw compressed
+  // bytes with SHF_COMPRESSED set. Callers that need section data must handle
+  // decompression — e.g. buf::copy_to() uses decompress_section_into() per-section
   const ELFIO::elfio&
   get_elfio() const
   {
     return m_elfio;
-  }
-
-  // Get a fully decompressed copy of the ELFIO object.
-  // This is expensive (serialize + decompress + reload) and should only be used
-  // in rare diagnostic paths (e.g. AIEDebug on health check failure).
-  ELFIO::elfio
-  get_decompressed_elfio() const
-  {
-    // Serialize current ELFIO (may have compressed sections) back to bytes
-    std::ostringstream oss;
-    const_cast<ELFIO::elfio&>(m_elfio).save(oss);
-    std::string elf_str = oss.str();
-
-    // Decompress using existing full-ELF API
-    std::vector<char> buf(elf_str.begin(), elf_str.end());
-    buf = aiebu::aiebu_assembler::decompress_elf(std::move(buf));
-
-    // Load into fresh ELFIO
-    ELFIO::elfio decompressed;
-    boost::interprocess::ibufferstream istr(buf.data(), buf.size());
-    if (!decompressed.load(istr))
-      throw std::runtime_error("failed to load decompressed ELF");
-    return decompressed;
   }
 
   // Get the filename this ELF was loaded from (empty if loaded from buffer/stream)

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -17,7 +17,6 @@
 
 #include "core/common/aiebu/src/cpp/include/aiebu/aiebu_decompress.h"
 
-#include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio.hpp>
 
 #include <cstdint>
@@ -25,7 +24,6 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -49,10 +47,23 @@ private:
   // A view into ELFIO section data, possibly compressed.
   // For section-backed views, section and elf are non-null.
   // For padding views, section is null and padding holds the zero buffer.
+  //
+  // Lifetime of section/elf pointers:
+  //   section points into m_elfio's internal section array; elf points to
+  //   m_elfio itself (stored as &elf in append_section_data).  Both m_elfio
+  //   and the buf objects (m_instr_buf_map, m_ctrl_packet_map, etc.) are
+  //   members of the same elf_impl instance (m_elfio in the base class,
+  //   buf maps in the derived classes elf_aie_gen2 / elf_aie_gen2_plus).
+  //   This is why the raw pointers are safe: a buf cannot outlive its
+  //   owning elf_impl because it is a member of it, so m_elfio is
+  //   guaranteed to be alive whenever a view_entry in that buf is accessed.
+  //   At the broader scope, module_impl holds a shared_ptr<elf_impl>
+  //   ensuring elf_impl is not destroyed while the module is in use.
+  //
   struct view_entry {
     const ELFIO::section* section = nullptr;   // section-backed view (may be compressed)
-    const ELFIO::elfio* elf = nullptr;         // ELFIO object owning the section
-    std::string_view padding;                  // for zero-padding (section == nullptr)
+    const ELFIO::elfio* elf = nullptr;         // ELFIO owning the section (see lifetime note above)
+    std::string_view padding;                  // for zero-padding, points into m_padding_buffer
     std::size_t data_size = 0;                 // effective size (uncompressed if compressed)
   };
 
@@ -117,6 +128,7 @@ public:
     size_t total = 0;
     for (const auto& v : m_views)
       total += v.data_size;
+
     return total;
   }
 
@@ -133,22 +145,25 @@ public:
 
     auto* dst = dest.data();
     for (const auto& v : m_views) {
-      if (v.section) {
+      if (v.section)
         aiebu::copy_section_uncompressed_data(v.section, *v.elf, dst, v.data_size);
-      }
-      else {
+      else
         std::memcpy(dst, v.padding.data(), v.data_size);
-      }
+
       dst += v.data_size;
     }
   }
 
-  // Get data pointer - only works for single view (zero-copy)
-  // Used by patcher that needs direct memory access
+  // Get data pointer - only works for single uncompressed view (zero-copy).
+  // Throws if the section is SHF_COMPRESSED — compressed bytes are not valid
+  // instruction data. Use copy_to() for compression-safe access.
   const uint8_t*
   data() const
   {
     if (m_views.size() == 1 && m_views[0].section) {
+      if (m_views[0].section->get_flags() & ELFIO::SHF_COMPRESSED)
+        throw std::runtime_error(
+          "buf::data() called on compressed section — use copy_to() instead");
       return reinterpret_cast<const uint8_t*>(m_views[0].section->get_data());
     }
 
@@ -156,8 +171,7 @@ public:
     // Caller should use copy_to() instead
     throw std::runtime_error(
       "Cannot get direct pointer from buffer with multiple views. "
-      "Use copy_to() to copy data instead."
-    );
+      "Use copy_to() to copy data instead.");
   }
 
   // Create std::string from views (for debug/trace).

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -16,10 +16,14 @@
 #include "core/common/xclbin_parser.h"
 #include "core/common/runner/capture.h"
 
+#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_assembler.h"
+
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio.hpp>
 
 #include <cstdint>
+#include <fstream>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -199,42 +203,66 @@ construct_kernel_args(const std::string& signature)
 // of template to display specific error messages
 ///////////////////////////////////////////////////////////////
 
+// Load ELFIO from an owned buffer — no decompression.
+// Compressed sections (SHF_COMPRESSED) remain compressed in ELFIO; they are
+// decompressed on demand at xrt::run creation time by buf::copy_to().
+static ELFIO::elfio
+load_elfio_from_buffer(std::vector<char>& buf)
+{
+  ELFIO::elfio elfio;
+  boost::interprocess::ibufferstream istr(buf.data(), buf.size());
+  if (!elfio.load(istr))
+    throw std::runtime_error("not valid ELF data");
+  return elfio;
+}
+
 // Load ELFIO from file path
 static ELFIO::elfio
 load_elfio(const std::string& fnm)
 {
-  ELFIO::elfio elfio;
-  if (!elfio.load(fnm))
+  std::ifstream f(fnm, std::ios::binary);
+  if (!f)
     throw std::runtime_error(fnm + " is not found or is not a valid ELF file");
+
+  // Pre-size the buffer to avoid repeated reallocations on large ELF files.
+  f.seekg(0, std::ios::end);
+  const auto file_size = f.tellg();
+  f.seekg(0, std::ios::beg);
+
+  std::vector<char> buf;
+  if (file_size > 0)
+    buf.reserve(static_cast<std::size_t>(file_size));
+  buf.assign(std::istreambuf_iterator<char>(f), {});
+
+  if (f.bad())
+    throw std::runtime_error(fnm + ": I/O error while reading ELF file");
 
   if (xrt_core::config::get_xrt_debug()) {
     std::string message = "Loaded elf file " + fnm;
     xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_elf", message);
   }
-  return elfio;
+  return load_elfio_from_buffer(buf);
 }
 
 // Load ELFIO from stream
 static ELFIO::elfio
 load_elfio(std::istream& stream)
 {
-  ELFIO::elfio elfio;
-  if (!elfio.load(stream))
-    throw std::runtime_error("not a valid ELF stream");
-
-  return elfio;
+  std::vector<char> buf(std::istreambuf_iterator<char>(stream), {});
+  if (stream.bad())
+    throw std::runtime_error("I/O error while reading ELF stream");
+  return load_elfio_from_buffer(buf);
 }
 
 // Load ELFIO from buffer
 static ELFIO::elfio
 load_elfio(const void* data, size_t size)
 {
-  ELFIO::elfio elfio;
-  boost::interprocess::ibufferstream istr(static_cast<const char*>(data), size);
-  if (!elfio.load(istr))
-    throw std::runtime_error("not valid ELF data");
-
-  return elfio;
+  if (!data || size == 0)
+    throw std::runtime_error("not valid ELF data: null or empty buffer");
+  const char* bytes = static_cast<const char*>(data);
+  std::vector<char> buf(bytes, bytes + size);
+  return load_elfio_from_buffer(buf);
 }
 
 } // namespace
@@ -766,7 +794,7 @@ class elf_aie_gen2 : public elf_impl
       if (name.find(pm_pattern) == std::string::npos)
         continue;
 
-      m_ctrlpkt_pm_bufs[name].append_section_data(sec);
+      m_ctrlpkt_pm_bufs[name].append_section_data(sec, m_elfio.get_class());
     }
   }
 
@@ -1166,23 +1194,24 @@ class elf_aie_gen2_plus : public elf_impl
       m_ctrlcodes_map[id].resize(size);
       pad_offsets[id].resize(size);
       for (auto& [ucidx, elf_sects] : uc_sec) {
+        const auto elf_class = m_elfio.get_class();
         if (merged) {
           // Merged format: the single .ctrltext.<col> section already contains all
           // pages laid out at pageNum*PAGE_SIZE offsets with header+text+data+padding
           // embedded, meaning elf_sects contains only .ctrltext section
           const auto& page_sec = elf_sects.begin()->second;
           if (page_sec.ctrltext)
-            m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext);
+            m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, elf_class);
         }
         else {
           // Per-page format: each page has separate ctrltext + ctrldata sections;
           // pad each page up to page boundary.
           for (auto& [page, page_sec] : elf_sects) {
             if (page_sec.ctrltext)
-              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext);
+              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, elf_class);
 
             if (page_sec.ctrldata)
-              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrldata);
+              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrldata, elf_class);
 
             auto current_size = m_ctrlcodes_map[id][ucidx].size();
             auto target_size = (page + 1) * elf_page_size;
@@ -1219,7 +1248,7 @@ class elf_aie_gen2_plus : public elf_impl
         continue;
 
       buf ctrlpkt_buf;
-      ctrlpkt_buf.append_section_data(sec);
+      ctrlpkt_buf.append_section_data(sec, m_elfio.get_class());
       auto grp_idx = m_section_to_group_map[sec->get_index()];
       m_ctrlpkt_buf_map[grp_idx][name] = std::move(ctrlpkt_buf);
     }

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -16,14 +16,10 @@
 #include "core/common/xclbin_parser.h"
 #include "core/common/runner/capture.h"
 
-#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_assembler.h"
-
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio.hpp>
 
 #include <cstdint>
-#include <fstream>
-#include <iterator>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -203,66 +199,40 @@ construct_kernel_args(const std::string& signature)
 // of template to display specific error messages
 ///////////////////////////////////////////////////////////////
 
-// Load ELFIO from an owned buffer — no decompression.
-// Compressed sections (SHF_COMPRESSED) remain compressed in ELFIO; they are
-// decompressed on demand at xrt::run creation time by buf::copy_to().
-static ELFIO::elfio
-load_elfio_from_buffer(std::vector<char>& buf)
-{
-  ELFIO::elfio elfio;
-  boost::interprocess::ibufferstream istr(buf.data(), buf.size());
-  if (!elfio.load(istr))
-    throw std::runtime_error("not valid ELF data");
-  return elfio;
-}
-
 // Load ELFIO from file path
 static ELFIO::elfio
 load_elfio(const std::string& fnm)
 {
-  std::ifstream f(fnm, std::ios::binary);
-  if (!f)
+  ELFIO::elfio elfio;
+  if (!elfio.load(fnm))
     throw std::runtime_error(fnm + " is not found or is not a valid ELF file");
-
-  // Pre-size the buffer to avoid repeated reallocations on large ELF files.
-  f.seekg(0, std::ios::end);
-  const auto file_size = f.tellg();
-  f.seekg(0, std::ios::beg);
-
-  std::vector<char> buf;
-  if (file_size > 0)
-    buf.reserve(static_cast<std::size_t>(file_size));
-  buf.assign(std::istreambuf_iterator<char>(f), {});
-
-  if (f.bad())
-    throw std::runtime_error(fnm + ": I/O error while reading ELF file");
 
   if (xrt_core::config::get_xrt_debug()) {
     std::string message = "Loaded elf file " + fnm;
     xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_elf", message);
   }
-  return load_elfio_from_buffer(buf);
+  return elfio;
 }
 
 // Load ELFIO from stream
 static ELFIO::elfio
 load_elfio(std::istream& stream)
 {
-  std::vector<char> buf(std::istreambuf_iterator<char>(stream), {});
-  if (stream.bad())
-    throw std::runtime_error("I/O error while reading ELF stream");
-  return load_elfio_from_buffer(buf);
+  ELFIO::elfio elfio;
+  if (!elfio.load(stream))
+    throw std::runtime_error("not a valid ELF stream");
+  return elfio;
 }
 
 // Load ELFIO from buffer
 static ELFIO::elfio
 load_elfio(const void* data, size_t size)
 {
-  if (!data || size == 0)
-    throw std::runtime_error("not valid ELF data: null or empty buffer");
-  const char* bytes = static_cast<const char*>(data);
-  std::vector<char> buf(bytes, bytes + size);
-  return load_elfio_from_buffer(buf);
+  ELFIO::elfio elfio;
+  boost::interprocess::ibufferstream istr(static_cast<const char*>(data), size);
+  if (!elfio.load(istr))
+    throw std::runtime_error("not valid ELF data");
+  return elfio;
 }
 
 } // namespace

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -699,7 +699,7 @@ class elf_aie_gen2 : public elf_impl
         continue;
 
       auto grp_idx = m_section_to_group_map[sec->get_index()];
-      buf_map[grp_idx].append_section_data(sec);
+      buf_map[grp_idx].append_section_data(sec, m_elfio);
     }
   }
 
@@ -719,11 +719,11 @@ class elf_aie_gen2 : public elf_impl
         auto name = sec->get_name();
 
         if (name.find(save_pattern) != std::string::npos) {
-          m_save_buf_map[grp_id].append_section_data(sec);
+          m_save_buf_map[grp_id].append_section_data(sec, m_elfio);
           has_save = true;
         }
         else if (name.find(restore_pattern) != std::string::npos) {
-          m_restore_buf_map[grp_id].append_section_data(sec);
+          m_restore_buf_map[grp_id].append_section_data(sec, m_elfio);
           has_restore = true;
         }
       }
@@ -750,7 +750,7 @@ class elf_aie_gen2 : public elf_impl
       if (name.find(pdi_pattern) == std::string::npos)
         continue;
 
-      m_pdi_buf_map[name].append_section_data(sec);
+      m_pdi_buf_map[name].append_section_data(sec, m_elfio);
     }
   }
 
@@ -764,7 +764,7 @@ class elf_aie_gen2 : public elf_impl
       if (name.find(pm_pattern) == std::string::npos)
         continue;
 
-      m_ctrlpkt_pm_bufs[name].append_section_data(sec, m_elfio.get_class());
+      m_ctrlpkt_pm_bufs[name].append_section_data(sec, m_elfio);
     }
   }
 
@@ -1164,24 +1164,23 @@ class elf_aie_gen2_plus : public elf_impl
       m_ctrlcodes_map[id].resize(size);
       pad_offsets[id].resize(size);
       for (auto& [ucidx, elf_sects] : uc_sec) {
-        const auto elf_class = m_elfio.get_class();
         if (merged) {
           // Merged format: the single .ctrltext.<col> section already contains all
           // pages laid out at pageNum*PAGE_SIZE offsets with header+text+data+padding
           // embedded, meaning elf_sects contains only .ctrltext section
           const auto& page_sec = elf_sects.begin()->second;
           if (page_sec.ctrltext)
-            m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, elf_class);
+            m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, m_elfio);
         }
         else {
           // Per-page format: each page has separate ctrltext + ctrldata sections;
           // pad each page up to page boundary.
           for (auto& [page, page_sec] : elf_sects) {
             if (page_sec.ctrltext)
-              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, elf_class);
+              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, m_elfio);
 
             if (page_sec.ctrldata)
-              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrldata, elf_class);
+              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrldata, m_elfio);
 
             auto current_size = m_ctrlcodes_map[id][ucidx].size();
             auto target_size = (page + 1) * elf_page_size;
@@ -1201,7 +1200,7 @@ class elf_aie_gen2_plus : public elf_impl
         if (name.find(pad_pattern) == std::string::npos)
           continue;
         auto [col, page] = get_column_and_page(name, is_merged_format());
-        m_ctrlcodes_map[id][col].append_section_data(sec);
+        m_ctrlcodes_map[id][col].append_section_data(sec, m_elfio);
       }
     }
   }
@@ -1218,7 +1217,7 @@ class elf_aie_gen2_plus : public elf_impl
         continue;
 
       buf ctrlpkt_buf;
-      ctrlpkt_buf.append_section_data(sec, m_elfio.get_class());
+      ctrlpkt_buf.append_section_data(sec, m_elfio);
       auto grp_idx = m_section_to_group_map[sec->get_index()];
       m_ctrlpkt_buf_map[grp_idx][name] = std::move(ctrlpkt_buf);
     }
@@ -1236,7 +1235,7 @@ class elf_aie_gen2_plus : public elf_impl
         continue;
 
       auto ctrl_id = m_section_to_group_map[sec->get_index()];
-      m_dump_buf_map[ctrl_id].append_section_data(sec);
+      m_dump_buf_map[ctrl_id].append_section_data(sec, m_elfio);
     }
   }
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -5195,11 +5195,10 @@ aie_error_message_v1(const ert_packet* epkt, const std::string& msg,
           << "\n";
 
       // Decode the opcode at (uc_idx, page_idx, offset) directly from the ELF binary.
-      // get_decompressed_elfio() is needed because compressed sections contain raw
-      // compressed bytes that AIEDebug cannot parse directly.
+      // AIEDebug handles SHF_COMPRESSED sections internally — only the specific
+      // .ctrltext section is decompressed on demand, not the entire ELF.
       if (elf_impl_ptr) {
-        auto decompressed_elfio = elf_impl_ptr->get_decompressed_elfio();
-        aiebu::AIEDebug dbg(decompressed_elfio);
+        aiebu::AIEDebug dbg(elf_impl_ptr->get_elfio());
         auto info = dbg.get_opcode_information(
           kernel_instance,
           ctx_health->aie4.uc_info[i].uc_idx,

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1834,9 +1834,11 @@ private:
     if (ctrl_packet.size() == 0)
       return nullptr;
 
-    // Create mutable copy for buffer cache
-    std::vector<uint8_t> ctrlpkt_data(ctrl_packet.data(),
-                                      ctrl_packet.data() + ctrl_packet.size());
+    // Create mutable copy for buffer cache.
+    // copy_to() handles compressed sections transparently; for uncompressed
+    // ELFs this is a plain memcpy.
+    std::vector<uint8_t> ctrlpkt_data(ctrl_packet.size());
+    ctrl_packet.copy_to({ctrlpkt_data.data(), ctrlpkt_data.size()});
     auto ctrlpkt_buf_size = ctrlpkt_data.size();
 
     constexpr size_t bytes_per_mb = 1024ULL * 1024ULL;

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -5194,9 +5194,12 @@ aie_error_message_v1(const ert_packet* epkt, const std::string& msg,
           << ctx_health->aie4.uc_info[i].uc_esr
           << "\n";
 
-      // Decode the opcode at (uc_idx, page_idx, offset) directly from the ELF binary
+      // Decode the opcode at (uc_idx, page_idx, offset) directly from the ELF binary.
+      // get_decompressed_elfio() is needed because compressed sections contain raw
+      // compressed bytes that AIEDebug cannot parse directly.
       if (elf_impl_ptr) {
-        aiebu::AIEDebug dbg(elf_impl_ptr->get_elfio());
+        auto decompressed_elfio = elf_impl_ptr->get_decompressed_elfio();
+        aiebu::AIEDebug dbg(decompressed_elfio);
         auto info = dbg.get_opcode_information(
           kernel_instance,
           ctx_health->aie4.uc_info[i].uc_idx,

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -259,8 +259,8 @@ protected:
   static void
   fill_bo_with_data(xrt::bo& bo, const xrt::buf& buf, bool sync = true)
   {
-    auto ptr = bo.map<char*>();
-    buf.copy_to(ptr);
+    auto ptr = bo.map<uint8_t*>();
+    buf.copy_to({ptr, bo.size()});
     if (sync)
       bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
   }
@@ -876,10 +876,12 @@ class module_run_aie_gen2_plus : public module_run
     const auto& col_data = m_config.ctrlcodes;
 
     // Copy all column control codes to instruction buffer
-    auto ptr = m_buffer.map<char*>();
+    auto ptr = m_buffer.map<uint8_t*>();
+    auto remaining = m_buffer.size();
     for (const auto& ctrlcode : col_data) {
-      ctrlcode.copy_to(ptr);
+      ctrlcode.copy_to({ptr, remaining});
       ptr += ctrlcode.size();
+      remaining -= ctrlcode.size();
     }
 
     // Dump pre-patched instruction buffer

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -1418,7 +1418,7 @@ patch(const xrt::module& module, uint8_t* ibuf, size_t sz,
 
   if (sz < inst->size())
     throw std::runtime_error{"Control code buffer passed in is too small"};
-  inst->copy_to(ibuf);
+  inst->copy_to({ibuf, sz});
 
   // If no args to patch, we're done
   if (!args || args->empty())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
ELF compression support in XRT — deferred per-section decompression
#### How problem was solved, alternative solutions (if any) and why they were rejected
Adds transparent support for zstd-compressed ELF binaries (SHF_COMPRESSED) produced by the updated aiebu.
ELFIO loads compressed sections as-is. Decompression is deferred to BO-fill time — buf::copy_to() decompresses each section directly into the device BO via aiebu::copy_section_uncompressed_data() with no intermediate heap copy. All compression/decompression logic stays in aiebu; XRT only includes aiebu_decompress.h.

AIEDebug: passes get_elfio() directly to aiebu::AIEDebug; decode_opcode() decompresses only the single .ctrltext.<uc_idx> section needed instead of decompressing the full ELF 
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
In progress. Tested with compressed/uncompressed ELFs, context health timeout report in ERT_CMD_STATE_TIMEOUT case.
#### Documentation impact (if any)
Yes. Anyone using compressed ELFs for their host applications should use XRT version that include this PR changes 