### PR TITLE
build: improve CMake3/CMake detection across build scripts

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -7,19 +7,23 @@ VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 MAJOR=${VERSION%.*}
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
-CMAKE=cmake
-CMAKE_MAJOR_VERSION=`cmake --version | head -n 1 | awk '{print $3}' |awk -F. '{print $1}'`
-CPU=`uname -m`
-
-if [[ $CMAKE_MAJOR_VERSION != 3 ]]; then
-    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]] || [[ $OSDIST == "mariner" ]] || [[ $OSDIST == "almalinux" ]] || [[ $OSDIST == "rocky" ]]; then
-        CMAKE=cmake3
-        if [[ ! -x "$(command -v $CMAKE)" ]]; then
-            echo "$CMAKE is not installed, please run xrtdeps.sh"
-            exit 1
-        fi
+CMAKE=""
+if command -v cmake >/dev/null 2>&1; then
+    CMAKE_MAJOR_VERSION=$(cmake --version | head -n 1 | awk '{print $3}' | cut -d. -f1)
+    if [[ "$CMAKE_MAJOR_VERSION" -ge 3 ]]; then
+        CMAKE=cmake
     fi
 fi
+
+if [[ -z "$CMAKE" ]]; then
+    if command -v cmake3 >/dev/null 2>&1; then
+        CMAKE=cmake3
+    else
+        echo "CMake >= 3 is required, please run xrtdeps.sh"
+        exit 1
+    fi
+fi
+CPU=`uname -m`
 
 if [[ $CPU == "aarch64" ]] && [[ $OSDIST == "ubuntu" ]]; then
     # On ARM64 Ubuntu use GCC version 8+, GCC version 7 has

--- a/build/xocl_petalinux_compile/build.sh
+++ b/build/xocl_petalinux_compile/build.sh
@@ -27,9 +27,25 @@ usage_and_exit()
 }
 
 PROGRAM=`basename $0`
-OSDIST=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
-CMAKE=cmake
+CMAKE=""
+if command -v cmake >/dev/null 2>&1; then
+    CMAKE_MAJOR_VERSION=$(cmake --version | head -n 1 | awk '{print $3}' | cut -d. -f1)
+    if [[ "$CMAKE_MAJOR_VERSION" -ge 3 ]]; then
+        CMAKE=cmake
+    fi
+fi
+
+if [[ -z "$CMAKE" ]]; then
+    if command -v cmake3 >/dev/null 2>&1; then
+        CMAKE=cmake3
+    else
+        echo "CMake >= 3 is required, please install cmake3 by running following commands..."
+        echo "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+        echo "sudo yum install -y cmake3"
+        exit 1
+    fi
+fi
 CORE=`grep -c ^processor /proc/cpuinfo`
 jcore=$CORE
 CONFIG_FILE=""
@@ -40,16 +56,6 @@ clean=0
 SSTATE_CACHE=""
 SETTINGS_FILE="petalinux.build"
 
-
-if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]]; then
-    CMAKE=cmake3
-    if [[ ! -x "$(command -v $CMAKE)" ]]; then
-        echo "$CMAKE is not installed, please install cmake3 by running following commands..."
-        echo "sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-        echo "sudo yum install -y cmake3"
-        exit 1
-    fi
-fi
 
 release_dir="cmake_files"
 

--- a/tests/build/build.sh
+++ b/tests/build/build.sh
@@ -13,19 +13,23 @@ VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 MAJOR=${VERSION%.*}
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
-CMAKE=cmake
-CMAKE_MAJOR_VERSION=`cmake --version | head -n 1 | awk '{print $3}' |awk -F. '{print $1}'`
-CPU=`uname -m`
-
-if [[ $CMAKE_MAJOR_VERSION != 3 ]]; then
-    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]] || [[ $OSDIST == "mariner" ]] || [[ $OSDIST == "almalinux" ]] || [[ $OSDIST == "rocky" ]]; then
-        CMAKE=cmake3
-        if [[ ! -x "$(command -v $CMAKE)" ]]; then
-            echo "$CMAKE is not installed, please run xrtdeps.sh"
-            exit 1
-        fi
+CMAKE=""
+if command -v cmake >/dev/null 2>&1; then
+    CMAKE_MAJOR_VERSION=$(cmake --version | head -n 1 | awk '{print $3}' | cut -d. -f1)
+    if [[ "$CMAKE_MAJOR_VERSION" -ge 3 ]]; then
+        CMAKE=cmake
     fi
 fi
+
+if [[ -z "$CMAKE" ]]; then
+    if command -v cmake3 >/dev/null 2>&1; then
+        CMAKE=cmake3
+    else
+        echo "CMake >= 3 is required, please run xrtdeps.sh"
+        exit 1
+    fi
+fi
+CPU=`uname -m`
 
 
 if [[ $CPU == "aarch64" ]] && [[ $OSDIST == "ubuntu" ]]; then


### PR DESCRIPTION
#### Problem solved by the commit

Build failed on fedora 44 as fedora44 ships with cmake 4 and command recognized is `cmake` rather than older `cmake3`.

CMake detection was implemented differently across the affected build scripts,. The existing logic could select `cmake3` based on the distribution even when a suitable `cmake` executable was already available.

This change makes CMake detection consistent and ensures that a CMake 3 or newer installation is used regardless of whether it is provided as `cmake` or `cmake3`.

Also faced similar issue on [xdna-driver](https://github.com/amd/xdna-driver) which was fixed by [PR](https://github.com/amd/xdna-driver/pull/1560)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

No specific regression or previously introduced PR is being fixed.

The change addresses inconsistent CMake executable detection observed while reviewing the build scripts. The previous implementation relied on distribution-specific handling of `cmake3` rather than consistently checking for an available CMake 3+ executable.

#### How problem was solved, alternative solutions (if any) and why they were rejected

The CMake detection logic was updated in:

* `build/build.sh`
* `test/build.sh`
* `build/xocl_petalinux_compile`

The new logic:

1. Checks whether `cmake` is available.
2. Verifies that its major version is at least 3.
3. Uses `cmake` when the requirement is satisfied.
4. Falls back to `cmake3` when `cmake` is unavailable or unsuitable.
5. Reports an error if neither executable provides the required CMake version.

An alternative would be to retain the existing distribution-specific selection of `cmake3`. This was not used because it unnecessarily couples CMake executable selection to the operating system distribution and does not handle environments where `cmake` already provides CMake 3+.


#### What has been tested and how, request additional testing if necessary

The modified scripts were reviewed to ensure that the CMake detection logic is consistent across all three affected files.

Testing should cover the following environments where applicable:

* `cmake` available with CMake 3+
* `cmake` unavailable and `cmake3` available with CMake 3+
* Both `cmake` and `cmake3` unavailable
* `cmake` available with a version older than 3 and `cmake3` available

Additional testing on distributions that package CMake as `cmake3` would be useful.

