### PR TITLE
xrt-smi: enumerate PF and VF devices for SR-IOV

### DIFF
--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -158,30 +158,63 @@ instance()
 smi_hardware_config::
 smi_hardware_config()
 {
-  // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers) 
+  // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+  // PCI ID map aligned with NPU product table (device_id, revision_id) -> hardware_type.
   hardware_map = {
+    // npu1
     {{0x1502, 0x00}, hardware_type::phx},
+
+    // npu2
     {{0x17f0, 0x00}, hardware_type::stxA0},
+
+    // npu4
     {{0x17f0, 0x10}, hardware_type::stxB0},
+
+    // npu5
     {{0x17f0, 0x11}, hardware_type::stxH},
+
+    // npu6
     {{0x17f0, 0x20}, hardware_type::krk1},
-    {{0x17f1, 0x00}, hardware_type::npu3_f0}, //deprecated
-    {{0x17f1, 0x10}, hardware_type::npu3_f1}, 
-    {{0x17f2, 0x10}, hardware_type::npu3_f2}, 
-    {{0x17f3, 0x10}, hardware_type::npu3_f3},
-    {{0x17f1, 0x12}, hardware_type::npu3_f4},
-    {{0x17f1, 0x13}, hardware_type::npu3_f5},
-    {{0x17f1, 0x15}, hardware_type::npu3_f6},
-    {{0x17f1, 0x11}, hardware_type::npu3_f7},
-    {{0x17f3, 0x11}, hardware_type::npu3_f8},
-    {{0x17f3, 0x12}, hardware_type::npu3_f9},
-    {{0x17f1, 0x14}, hardware_type::npu3_f10},
-    {{0x17f3, 0x13}, hardware_type::npu3_f11},
-    {{0x17f3, 0x14}, hardware_type::npu3_f12},
+
+    // npu3 classic (17f1:10 / 1B0A:00)
+    {{0x17f1, 0x00}, hardware_type::npu3_f0}, // deprecated
+    {{0x17f1, 0x10}, hardware_type::npu3_f1},
     {{0x1B0A, 0x00}, hardware_type::npu3_B01},
-    {{0x1B0B, 0x00}, hardware_type::npu3_B02},
-    {{0x1B0C, 0x00}, hardware_type::npu3_B03},
-    {{0xb052, 0x01}, hardware_type::aie2ps}
+
+    // npu3a VF (17f3:10 / 1B0C:00)
+    {{0x17f3, 0x10}, hardware_type::npu3a_vf},
+    {{0x1B0C, 0x00}, hardware_type::npu3_B03_vf},
+
+    // npu3a PF (17f2:10 / 1B0B:00)
+    {{0x17f2, 0x10}, hardware_type::npu3a_pf},
+    {{0x1B0B, 0x00}, hardware_type::npu3_B02_pf},
+
+    // npu7
+    {{0x17f1, 0x11}, hardware_type::npu7},
+    {{0x17f2, 0x11}, hardware_type::npu7_pf},
+    {{0x17f3, 0x11}, hardware_type::npu7_vf},
+
+    // npu8
+    {{0x17f1, 0x12}, hardware_type::npu8},
+    {{0x17f2, 0x12}, hardware_type::npu8_pf},
+    {{0x17f3, 0x12}, hardware_type::npu8_vf},
+
+    // npu9
+    {{0x17f1, 0x13}, hardware_type::npu9},
+    {{0x17f2, 0x13}, hardware_type::npu9_pf},
+    {{0x17f3, 0x13}, hardware_type::npu9_vf},
+
+    // npu10
+    {{0x17f1, 0x14}, hardware_type::npu10},
+    {{0x17f2, 0x14}, hardware_type::npu10_pf},
+    {{0x17f3, 0x14}, hardware_type::npu10_vf},
+
+    // npu11
+    {{0x17f1, 0x15}, hardware_type::npu11},
+    {{0x17f2, 0x15}, hardware_type::npu11_pf},
+    {{0x17f3, 0x15}, hardware_type::npu11_vf},
+
+    {{0xb052, 0x01}, hardware_type::aie2ps},
   };
   // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 }
@@ -191,9 +224,9 @@ smi_hardware_config::
 get_hardware_type(const xq::pcie_id::data& dev) const 
 {
   auto it = hardware_map.find(dev);
-  return (it != hardware_map.end()) 
-      ? it->second 
-      : hardware_type::unknown;
+  return (it != hardware_map.end())
+    ? it->second
+    : hardware_type::unknown;
 }
 
 smi_hardware_config::hardware_family
@@ -210,20 +243,26 @@ get_family(hardware_type hw)
     return hardware_family::strix;
   case hardware_type::npu3_f0:
   case hardware_type::npu3_f1:
-  case hardware_type::npu3_f2:
-  case hardware_type::npu3_f3:
-  case hardware_type::npu3_f4:
-  case hardware_type::npu3_f5:
-  case hardware_type::npu3_f6:
-  case hardware_type::npu3_f7:
-  case hardware_type::npu3_f8:
-  case hardware_type::npu3_f9:
-  case hardware_type::npu3_f10:
-  case hardware_type::npu3_f11:
-  case hardware_type::npu3_f12:
   case hardware_type::npu3_B01:
-  case hardware_type::npu3_B02:
-  case hardware_type::npu3_B03:
+  case hardware_type::npu3a_pf:
+  case hardware_type::npu3a_vf:
+  case hardware_type::npu3_B02_pf:
+  case hardware_type::npu3_B03_vf:
+  case hardware_type::npu7:
+  case hardware_type::npu7_pf:
+  case hardware_type::npu7_vf:
+  case hardware_type::npu8:
+  case hardware_type::npu8_pf:
+  case hardware_type::npu8_vf:
+  case hardware_type::npu9:
+  case hardware_type::npu9_pf:
+  case hardware_type::npu9_vf:
+  case hardware_type::npu10:
+  case hardware_type::npu10_pf:
+  case hardware_type::npu10_vf:
+  case hardware_type::npu11:
+  case hardware_type::npu11_pf:
+  case hardware_type::npu11_vf:
     return hardware_family::npu3;
   case hardware_type::aie2ps:
     return hardware_family::aie2ps;

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -217,28 +217,34 @@ public:
 class smi_hardware_config {
 public:
   enum class hardware_type {
-    phx, // Phoenix
-    stxA0, // StrixA0
-    stxB0, // Strix B0
-    stxH, // Strix Halo
-    krk1, // Krackan
+    phx,
+    stxA0,
+    stxB0,
+    stxH,
+    krk1,
     npu3_f0, // deprecated
-    npu3_f1, // XXXXX
-    npu3_f2, // XXXXX
-    npu3_f3, // XXXXX
-    npu3_f4, // XXXXX
-    npu3_f5, // XXXXX
-    npu3_f6, // XXXXX 
-    npu3_f7, // XXXXX
-    npu3_f8, // XXXXX
-    npu3_f9, // XXXXX
-    npu3_f10, // XXXXX
-    npu3_f11, // XXXXX
-    npu3_f12, // XXXXX
-    npu3_B01, // XXXXX
-    npu3_B02, // XXXXX
-    npu3_B03, // XXXXX
-    aie2ps, // Telluride aie2ps
+    npu3_f1, // npu3 classic (17f1:10)
+    npu3_B01, // npu3 classic SWV (1B0A:00)
+    npu3a_pf, // npu3a PF (17f2:10)
+    npu3a_vf, // npu3a VF (17f3:10)
+    npu3_B02_pf, // npu3a PF SWV (1B0B:00)
+    npu3_B03_vf, // npu3a VF SWV (1B0C:00)
+    npu7, // npu7 classic (17f1:11)
+    npu7_pf,
+    npu7_vf,
+    npu8, // npu8 classic (17f1:12)
+    npu8_pf,
+    npu8_vf,
+    npu9, // npu9 classic (17f1:13)
+    npu9_pf,
+    npu9_vf,
+    npu10, // npu10 classic (17f1:14)
+    npu10_pf,
+    npu10_vf,
+    npu11, // npu11 classic (17f1:15)
+    npu11_pf,
+    npu11_vf,
+    aie2ps,
     unknown // Unknown hardware type
   };
 

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <set>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -167,9 +168,14 @@ system_linux::
 get_driver_info(boost::property_tree::ptree &pt)
 {
   boost::property_tree::ptree _ptDriverInfo;
+  std::set<std::string> reported;
 
   for (const auto& drv : driver_list::get()) {
-    boost::property_tree::ptree _drv = driver_version(drv->name());
+    const auto& drv_name = drv->name();
+    if (!reported.insert(drv_name).second)
+      continue;
+
+    boost::property_tree::ptree _drv = driver_version(drv_name);
     if (!_drv.empty())
       _ptDriverInfo.push_back( {"", _drv} );
   }

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -35,7 +35,7 @@ void  main_(int argc, char** argv,
             const std::string & _description,
             const SubCmdsCollection &_subCmds) 
 {
-  bool isUserDomain = boost::iequals(_executable, "xrt-smi"); 
+  bool isUserDomain = boost::iequals(_executable, "xrt-smi");
 
   // Global options
   bool bVerbose = false;
@@ -65,10 +65,10 @@ void  main_(int argc, char** argv,
   globalOptions.add(globalSubCmdOptions);
 
   // Hidden Options
-  const std::string device_default = xrt_core::get_total_devices(isUserDomain).first == 1 ? "default" : "";
+  const std::string device_default = XBU::get_enumerated_device_count(isUserDomain) > 0 ? "default" : "";
   po::options_description hiddenOptions("Hidden Options");
   hiddenOptions.add_options()
-    ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "Specify a BDF. If the option is omitted and there is only 1 device, that device is used\n")
+    ("device,d",    boost::program_options::value<decltype(sDevice)>(&sDevice)->default_value(device_default)->implicit_value("default"), "Specify a BDF. If omitted, the first available user device is used\n")
     ("trace",       boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
     ("show-hidden", boost::program_options::bool_switch(&bShowHidden), "Shows hidden options and commands")
     ("subCmd",      po::value<decltype(sCmd)>(&sCmd), "Command to execute")
@@ -173,19 +173,15 @@ void  main_(int argc, char** argv,
 
     if (available_devices.empty()) //no device
       config = xrt_smi_default::get_default_smi_config();
-    else if (available_devices.size() == 1 || !sDevice.empty()) { //1 device
+    else {
       auto device = XBU::get_device(boost::algorithm::to_lower_copy(sDevice), isUserDomain);
-      config = xrt_core::device_query<xrt_core::query::xrt_smi_config>(device, xrt_core::query::xrt_smi_config::type::options_config);
-    }
-    else { //multiple devices
-      std::string dev;
-      for (auto& kd : available_devices) {
-        boost::property_tree::ptree& devpt = kd.second;
-        dev = devpt.get<std::string>("bdf");
+      if (vm["device"].defaulted() && available_devices.size() > 1) {
+        const auto bdf = xrt_core::query::pcie_bdf::to_string(
+          xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+        std::cout << (boost::format("NOTE: Multiple devices found, running for '%s'\n\n") % bdf).str();
       }
-      std::cout <<  (boost::format("NOTE: Multiple devices found. Showing help for %s device\n\n") % dev).str();
-      auto device = XBU::get_device(boost::algorithm::to_lower_copy(dev), isUserDomain);
-      config = xrt_core::device_query<xrt_core::query::xrt_smi_config>(device, xrt_core::query::xrt_smi_config::type::options_config);
+      config = xrt_core::device_query<xrt_core::query::xrt_smi_config>(
+        device, xrt_core::query::xrt_smi_config::type::options_config);
     }
 
     std::istringstream command_config_stream(config);

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <map>
 #include <regex>
+#include <set>
 #include <stdexcept>
 
 
@@ -62,6 +63,50 @@ struct fdt_header {
 };
 
 namespace xq = xrt_core::query;
+
+namespace {
+
+// User-domain paths enumerate user devices first, then mgmt devices.
+// Mgmt-domain paths (xbmgmt) use mgmt devices only.
+std::pair<bool, xrt_core::device::id_type>
+map_device_index(xrt_core::device::id_type index, bool in_user_domain)
+{
+  if (!in_user_domain)
+    return {false, index};
+
+  const auto user_total = xrt_core::get_total_devices(true).first;
+  if (index < user_total)
+    return {true, index};
+  return {false, index - user_total};
+}
+
+} // namespace
+
+xrt_core::device::id_type
+XBUtilities::get_enumerated_device_count(bool inUserDomain)
+{
+  if (!inUserDomain)
+    return xrt_core::get_total_devices(false).first;
+
+  const auto user_total = xrt_core::get_total_devices(true).first;
+  const auto mgmt_total = xrt_core::get_total_devices(false).first;
+
+  // xrt-smi user domain: include mgmt PF only on Ryzen (NPU) platforms.
+  if (mgmt_total) {
+    try {
+      const auto device = xrt_core::get_mgmtpf_device(0);
+      const auto device_class = xrt_core::device_query_default<xq::device_class>(
+        device, xq::device_class::type::alveo);
+      if (device_class == xq::device_class::type::ryzen)
+        return user_total + mgmt_total;
+    }
+    catch (const std::exception&) {
+      // mgmt present but not accessible; omit from xrt-smi user enumeration
+    }
+  }
+
+  return user_total;
+}
 
 // ------ F U N C T I O N S ---------------------------------------------------
 
@@ -225,7 +270,7 @@ XBUtilities::get_available_devices(bool inUserDomain)
       try {
         auto instance = xrt_core::device_query<xrt_core::query::instance>(device);
         std::string pf = device->is_userpf() ? "user" : "mgmt";
-        pt_dev.put("instance",boost::str(boost::format("%s(inst=%d)") % pf % instance));
+        pt_dev.put("instance", boost::str(boost::format("%s(inst=%d)") % pf % instance));
       }
       catch(const xrt_core::query::exception&) {
           // The instance wasn't added
@@ -236,6 +281,7 @@ XBUtilities::get_available_devices(bool inUserDomain)
 
     pt.push_back(std::make_pair("", pt_dev));
   }
+
   return pt;
 }
 
@@ -247,16 +293,9 @@ XBUtilities::resolve_device(bool is_user_domain,
   const auto& device_var = vm["device"];
   if (device_var.defaulted()) {
     if (boost::iequals(device_bdf, "default")) {
-      device_bdf.clear();
       boost::property_tree::ptree available_devices = get_available_bdfs(is_user_domain);
       if (available_devices.empty())
         throw std::runtime_error("No devices found.");
-      if (available_devices.size() > 1) {
-        std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
-        std::cerr << str_available_devs(is_user_domain) << std::endl;
-        std::cout << std::endl;
-        throw xrt_core::error(std::errc::operation_canceled);
-      }
       const auto kd = available_devices.begin();
       device_bdf = kd->second.get<std::string>("bdf");
     }
@@ -363,9 +402,13 @@ try {
   // Iterate through the available devices to find a BDF match
   // This must not open any devices! Doing do would slow down the software
   // quite a bit and cause other undesirable side affects
-auto devices = _inUserDomain ? xrt_core::get_total_devices(true).first : xrt_core::get_total_devices(false).first;
-  for (decltype(devices) i = 0; i < devices; i++) {
-    auto bdf = xrt_core::get_bdf_info(i, _inUserDomain);
+  const auto device_count = XBUtilities::get_enumerated_device_count(_inUserDomain);
+  for (xrt_core::device::id_type i = 0; i < device_count; ++i) {
+    const auto mapped = map_device_index(i, _inUserDomain);
+    const bool is_user = mapped.first;
+    const xrt_core::device::id_type domain_index = mapped.second;
+
+    auto bdf = xrt_core::get_bdf_info(domain_index, is_user);
     //if the user specifies func, compare
     //otherwise safely ignore
     auto cmp_func = [bdf](uint16_t func)
@@ -388,27 +431,31 @@ get_device_internal(xrt_core::device::id_type index, bool in_user_domain)
   static std::mutex mutex;
   std::lock_guard guard(mutex);
 
-  if (in_user_domain) {
+  const auto mapped = map_device_index(index, in_user_domain);
+  const bool is_user = mapped.first;
+  const xrt_core::device::id_type domain_index = mapped.second;
+
+  if (is_user) {
     static std::vector<std::shared_ptr<xrt_core::device>> user_devices(xrt_core::get_total_devices(true).first, nullptr);
   
-    if (user_devices.size() <= index )
+    if (user_devices.size() <= domain_index )
       throw std::runtime_error("no device present with index " + std::to_string(index));
     
-    if (!user_devices[index])
-      user_devices[index] = xrt_core::get_userpf_device(index);
+    if (!user_devices[domain_index])
+      user_devices[domain_index] = xrt_core::get_userpf_device(domain_index);
 
-    return user_devices[index];
+    return user_devices[domain_index];
   }
 
   static std::vector<std::shared_ptr<xrt_core::device>> mgmt_devices(xrt_core::get_total_devices(false).first, nullptr);
   
-  if (mgmt_devices.size() <= index )
+  if (mgmt_devices.size() <= domain_index )
     throw std::runtime_error("no device present with index " + std::to_string(index));
 
-  if (!mgmt_devices[index])
-    mgmt_devices[index] = xrt_core::get_mgmtpf_device(index);
+  if (!mgmt_devices[domain_index])
+    mgmt_devices[domain_index] = xrt_core::get_mgmtpf_device(domain_index);
 
-  return mgmt_devices[index];
+  return mgmt_devices[domain_index];
 }
 
 /*
@@ -419,7 +466,7 @@ static uint16_t
 str2index(const std::string& str, bool _inUserDomain)
 {
   //throw an error if no devices are present
-  uint64_t devices = _inUserDomain ? xrt_core::get_total_devices(true).first : xrt_core::get_total_devices(false).first;
+  uint64_t devices = XBUtilities::get_enumerated_device_count(_inUserDomain);
   if (devices == 0)
     throw std::runtime_error("No devices found");
   try {
@@ -470,7 +517,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     xrt_core::device::id_type total = 0;
     try {
       // If there are no devices in the server a runtime exception is thrown in  mgmt.cpp probe()
-      total = (xrt_core::device::id_type) xrt_core::get_total_devices(_inUserDomain /*isUser*/).first;
+      total = XBUtilities::get_enumerated_device_count(_inUserDomain);
     } catch (...) {
       /* Do nothing */
     }
@@ -944,9 +991,13 @@ fill_xrt_versions(const boost::property_tree::ptree& pt_xrt,
     output << boost::format("  %-20s : %s\n") % "Hash Date" % build_hash_date;
 
   const boost::property_tree::ptree& available_drivers = pt_xrt.get_child("drivers", empty_ptree);
+  std::set<std::string> reported_drivers;
   for(auto& drv : available_drivers) {
     const boost::property_tree::ptree& driver = drv.second;
     auto drv_name = driver.get<std::string>("name", "N/A");
+    if (!reported_drivers.insert(drv_name).second)
+      continue;
+
     auto drv_hash = driver.get<std::string>("hash", "N/A");
     auto drv_ver = driver.get<std::string>("version", "N/A");
 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -29,6 +29,9 @@
 
 namespace XBUtilities {
 
+  xrt_core::device::id_type
+  get_enumerated_device_count(bool inUserDomain);
+
   class Timer {
   private:
     std::chrono::high_resolution_clock::time_point m_time_start;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR extends user-domain device enumeration to include mgmt PF devices alongside user VFs, dedupe duplicate amdxdna driver version lines, and update the PCI hardware map with explicit npu7-npu11 PF/VF entries.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-40239
https://jira.xilinx.com/browse/AIESW-40240
Discovered through internal SRIOV efforts

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via handling PF specific dev ids and altering xrt-smi to enumerate pf devices as well.
This future work for this effort is to decide on the list of commands applicable to PF devices and handling pf specific configuration generation to run specific commands on pf devices. 
The change also relaxes the multiple devices case and allows running on first device when -d is not specified.

#### Risks (if any) associated the changes in the commit
This is a new addition and should not affect existing flows

#### What has been tested and how, request additional testing if necessary
Tested on a custom SRIOV setup on linux device : 
```
System Configuration
  OS Name              : Linux
  Release              : 7.1.0-rc7
  Machine              : x86_64
  CPU Cores            : 20
  Memory               : 31344 MB
  Distribution         : Ubuntu 24.04.3 LTS
  GLIBC                : 2.39
  Model                : Plum-MDS1
  BIOS Vendor          : AMD
  BIOS Version         : WMP66603N_239
  Processor            : AMD Eng Sample: 100-000001713-33_N

XRT
  Version              : 2.26.0
  Branch               : master
  Hash                 : 270ba11886e2e3cf5530deedd96ca7090e34d5fc
  Hash Date            : Wed, 5 Aug 2026 16:31:12 -0700
  amdxdna Version      : 2.26.0_20260806, f7965010734f044eeaf05b2bb575e44f0b7f7960
  virtio-pci Version   : 7.1.0-rc7
  NPU Firmware Version : 2.5.0.172
  CERT Firmware Version: 1.5.0.39

Device(s) Present
|BDF             |Name             |Architecture  |Topology  |
|----------------|-----------------|--------------|----------|
|[0000:c6:00.1]  |RyzenAI-npu9-vf  |aie4          |6x3       |
|[0000:c6:00.3]  |RyzenAI-npu9-vf  |aie4          |6x3       |
|[0000:c6:00.5]  |RyzenAI-npu9-vf  |aie4          |6x3       |
|[0000:c6:00.7]  |RyzenAI-npu9-vf  |aie4          |6x3       |
|[0000:c5:00.1]  |RyzenAI-npu9-pf  |aie4          |N/A       |
```

#### Documentation impact (if any)
None