### PR TITLE
Added new section named DTBO with RAW format

### DIFF
--- a/src/runtime_src/core/include/xrt/detail/xclbin.h
+++ b/src/runtime_src/core/include/xrt/detail/xclbin.h
@@ -160,7 +160,7 @@ extern "C" {
         IP_METADATA            = 33,
         AIE_RESOURCES_BIN      = 34,
         AIE_TRACE_METADATA     = 35,
-	DTBO                   = 36,
+        DTBO                   = 36,
     };
 
     enum MEM_TYPE {

--- a/src/runtime_src/core/include/xrt/detail/xclbin.h
+++ b/src/runtime_src/core/include/xrt/detail/xclbin.h
@@ -160,6 +160,7 @@ extern "C" {
         IP_METADATA            = 33,
         AIE_RESOURCES_BIN      = 34,
         AIE_TRACE_METADATA     = 35,
+	DTBO                   = 36,
     };
 
     enum MEM_TYPE {

--- a/src/runtime_src/tools/xclbinutil/SectionDTBO.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDTBO.cxx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "SectionDTBO.h"
+
+#include <boost/functional/factory.hpp>
+
+// Static Variables / Classes
+SectionDTBO::init SectionDTBO::initializer;
+
+SectionDTBO::init::init()
+{
+  auto sectionInfo = std::make_unique<SectionInfo>(DTBO, "DTBO", boost::factory<SectionDTBO*>());
+
+  sectionInfo->supportedAddFormats.push_back(FormatType::raw);
+
+  sectionInfo->supportedDumpFormats.push_back(FormatType::raw);
+
+  addSectionType(std::move(sectionInfo));
+}

--- a/src/runtime_src/tools/xclbinutil/SectionDTBO.h
+++ b/src/runtime_src/tools/xclbinutil/SectionDTBO.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SectionDTBO_h_
+#define __SectionDTBO_h_
+
+// ----------------------- I N C L U D E S -----------------------------------
+#include "Section.h"
+
+// --------------- C L A S S :   S e c t i o n D T B O -----------------------
+class SectionDTBO : public Section {
+ private:
+  // Static initializer helper class
+  static class init {
+   public:
+    init();
+  } initializer;
+};
+
+#endif

--- a/src/runtime_src/tools/xclbinutil/SectionDTBO.h
+++ b/src/runtime_src/tools/xclbinutil/SectionDTBO.h
@@ -14,8 +14,8 @@
  * under the License.
  */
 
-#ifndef __SectionDTBO_h_
-#define __SectionDTBO_h_
+#ifndef SectionDTBO_h_
+#define SectionDTBO_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
 #include "Section.h"

--- a/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
@@ -7,6 +7,8 @@
 #include <boost/property_tree/json_parser.hpp>
 
 #include <filesystem>
+#include <fstream>
+#include <iterator>
 
 // Simple Add Test
 TEST(AddSection, AddClearingBitstream) {
@@ -35,6 +37,41 @@ TEST(AddSection, AddClearingBitstream) {
    // Check to see if section was removed
    pSection = xclBin.findSection(_eKind);
    ASSERT_NE(pSection, nullptr) << "Section  '" << sSection << "' was not added.";
+}
+
+// Add a raw device tree overlay section
+TEST(AddSection, AddDTBO) {
+   XclBin xclBin;
+
+   const std::string sSection = "DTBO";
+   enum axlf_section_kind eKind;
+   Section::translateSectionKindStrToKind(sSection, eKind);
+
+   // Use a binary resource as the raw DTBO payload.  Xclbinutil treats the
+   // contents as opaque data, so a compiled device tree is not required here.
+   std::filesystem::path inputFile(TestUtilities::getResourceDir());
+   inputFile /= "unique_data1.bin";
+
+   ASSERT_EQ(xclBin.findSection(eKind), nullptr)
+      << "Section '" << sSection << "' found.";
+
+   const std::string formattedString = sSection + ":RAW:" + inputFile.string();
+   ParameterSectionData psd(formattedString);
+   xclBin.addSection(psd);
+
+   const Section* pSection = xclBin.findSection(eKind);
+   ASSERT_NE(pSection, nullptr)
+      << "Section '" << sSection << "' was not added.";
+
+   std::ifstream input(inputFile, std::ios::binary);
+   ASSERT_TRUE(input.is_open())
+      << "Unable to open input file: " << inputFile;
+   const std::string expected((std::istreambuf_iterator<char>(input)),
+                              std::istreambuf_iterator<char>());
+
+   std::ostringstream actual;
+   pSection->dumpContents(actual, Section::FormatType::raw);
+   EXPECT_EQ(actual.str(), expected) << "DTBO payload was not preserved.";
 }
 
 // Add or replace test
@@ -165,6 +202,5 @@ TEST(AddSection, AddMergeIPLayout) {
       << "Output  : " << outputFile << std::endl 
       << "Expected: " << ip_layoutMergeExpect;
 }
-
 
 


### PR DESCRIPTION
#### Problem solved by the commit
To delegate image loading to libdfx, XRT requires a .dtbo for every .pdi. Provide .dtbo file through a new raw binary section named DTBO.
More information in spec https://amd.atlassian.net/wiki/spaces/SPEC/pages/1740307792/2026.2+VITIS-16522+Vitis+DFX+solution+enhancements?xpis=eyJicmlkZ2UiOiJxdWlja0ZpbmQiLCJpZCI6IjE3ODY0NzYwNzg0ODAiLCJzb3VyY2UiOiJjb25mbHVlbmNlIn0%3D#.dtbo-within-.xclbin

#### Risks (if any) associated the changes in the commit
Low risk. Added new section to xclbin keeping other functionalities the same.  

#### What has been tested and how, request additional testing if necessary
Unit tests added for add/dump of the DTBO section.

