### PR TITLE
AIESW-41600 Consolidate throughput and latency tests for npu3

### DIFF
--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -125,8 +125,6 @@ config_gen_npu3()
 
   validate_test_desc = {
     {"all", "All applicable validate tests will be executed (default)", "common"},
-    {"runlist-latency", "Run end-to-end latency test using runlist", "hidden"},
-    {"runlist-throughput", "Run end-to-end throughput test using runlist", "hidden"},
     {"df-bw", "Run bandwidth test on data fabric", "hidden"},
     {"shim-dma-bw", "Run 2xRead/1xWrite bandwidth test for SHIM DMA", "hidden"},
     {"latency", "Run end-to-end latency test", "common"},

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -125,6 +125,8 @@ config_gen_npu3()
 
   validate_test_desc = {
     {"all", "All applicable validate tests will be executed (default)", "common"},
+    {"runlist-latency", "Run end-to-end latency test using runlist", "hidden"},
+    {"runlist-throughput", "Run end-to-end throughput test using runlist", "hidden"},
     {"df-bw", "Run bandwidth test on data fabric", "hidden"},
     {"shim-dma-bw", "Run 2xRead/1xWrite bandwidth test for SHIM DMA", "hidden"},
     {"latency", "Run end-to-end latency test", "common"},

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -7,6 +7,8 @@
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
 #include "core/common/runner/runner.h"
+#include "core/common/query_requests.h"
+#include "core/common/smi/smi.h"
 #include "xrt/xrt_device.h"
 #include "core/common/json/nlohmann/json.hpp"
 #include "core/common/archive.h"
@@ -47,8 +49,17 @@ TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_c
   }
   
   try {
-    std::string recipe_data = archive->data("recipe_throughput.json");
-    std::string profile_data = archive->data("profile_throughput.json"); 
+    const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(dev);
+    xrt_core::smi::smi_hardware_config smi_hrdw;
+    const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+    const bool use_runlist =
+      (smi_hrdw.get_family(hardware_type) == xrt_core::smi::smi_hardware_config::hardware_family::npu3);
+
+    const char* recipe_name = use_runlist ? "recipe_cmd_chain_throughput.json" : "recipe_throughput.json";
+    const char* profile_name = use_runlist ? "profile_cmd_chain_throughput.json" : "profile_throughput.json";
+
+    std::string recipe_data = archive->data(recipe_name);
+    std::string profile_data = archive->data(profile_name);
     
     auto artifacts_repo = XBUtilities::extract_artifacts_from_archive(archive, {
       "validate.xclbin", 
@@ -62,7 +73,7 @@ TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_c
 
     const auto report = json::parse(runner.get_report());
     const double throughput = get_throughput_from_report(report);
-    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f op/s") % throughput));
+    XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops/s") % throughput));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }
   catch(const std::exception& e) {

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -42,12 +42,11 @@ TestNPUThroughput::
 get_ops_throughput_from_report(const json& report, bool use_runlist) const
 {
   const auto runlist_throughput = get_throughput_from_report(report);
-  if (use_runlist) {
-    const auto recipe_runs = report.at("resources").at("runs").get<double>();
-    return runlist_throughput * recipe_runs;
-  } else {
+  if (!use_runlist)
     return runlist_throughput;
-  }
+    
+  const auto recipe_runs = report.at("resources").at("runs").get<double>();
+  return runlist_throughput * recipe_runs;
 }
 
 boost::property_tree::ptree

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.cpp
@@ -37,6 +37,19 @@ get_throughput_from_report(const json& report) const
   return report.at("cpu").at("throughput").get<double>();
 }
 
+double
+TestNPUThroughput::
+get_ops_throughput_from_report(const json& report, bool use_runlist) const
+{
+  const auto runlist_throughput = get_throughput_from_report(report);
+  if (use_runlist) {
+    const auto recipe_runs = report.at("resources").at("runs").get<double>();
+    return runlist_throughput * recipe_runs;
+  } else {
+    return runlist_throughput;
+  }
+}
+
 boost::property_tree::ptree
 TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
 {
@@ -72,7 +85,7 @@ TestNPUThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_c
     runner.wait();
 
     const auto report = json::parse(runner.get_report());
-    const double throughput = get_throughput_from_report(report);
+    const double throughput = get_ops_throughput_from_report(report, use_runlist);
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops/s") % throughput));
     ptree.put("status", XBValidateUtils::test_token_passed);
   }

--- a/src/runtime_src/core/tools/common/tests/TestNPUThroughput.h
+++ b/src/runtime_src/core/tools/common/tests/TestNPUThroughput.h
@@ -16,8 +16,11 @@ class TestNPUThroughput : public TestRunner {
     TestNPUThroughput();
 
   private:
-    double 
+    double
     get_throughput_from_report(const nlohmann::json& report) const;
+
+    double
+    get_ops_throughput_from_report(const nlohmann::json& report, bool use_runlist) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/tests/TestRunlistLatency.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestRunlistLatency.cpp
@@ -6,6 +6,8 @@
 #include "TestRunlistLatency.h"
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
+#include "core/common/query_requests.h"
+#include "core/common/smi/smi.h"
 #include "xrt/xrt_device.h"
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
@@ -23,6 +25,15 @@ boost::property_tree::ptree
 TestRunlistLatency::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
 {
   boost::property_tree::ptree ptree = get_test_header();
+
+  const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(dev);
+  xrt_core::smi::smi_hardware_config smi_hrdw;
+  const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+  if (smi_hrdw.get_family(hardware_type) == xrt_core::smi::smi_hardware_config::hardware_family::npu3) {
+    XBValidateUtils::logger(ptree, "Details", "N/A");
+    ptree.put("status", XBValidateUtils::test_token_skipped);
+    return ptree;
+  }
 
   if (archive == nullptr) {
     ptree.put("status", XBValidateUtils::test_token_failed);

--- a/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.cpp
@@ -6,6 +6,8 @@
 #include "TestRunlistThroughput.h"
 #include "TestValidateUtilities.h"
 #include "tools/common/XBUtilities.h"
+#include "core/common/query_requests.h"
+#include "core/common/smi/smi.h"
 #include "xrt/xrt_device.h"
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
@@ -21,6 +23,15 @@ boost::property_tree::ptree
 TestRunlistThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
 {
   boost::property_tree::ptree ptree = get_test_header();
+
+  const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(dev);
+  xrt_core::smi::smi_hardware_config smi_hrdw;
+  const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+  if (smi_hrdw.get_family(hardware_type) == xrt_core::smi::smi_hardware_config::hardware_family::npu3) {
+    XBValidateUtils::logger(ptree, "Details", "N/A");
+    ptree.put("status", XBValidateUtils::test_token_skipped);
+    return ptree;
+  }
 
   if (archive == nullptr) {
     ptree.put("status", XBValidateUtils::test_token_failed);

--- a/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTAllColumn.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -96,6 +96,12 @@ TestTCTAllColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
     const auto pcie_id = xrt_core::device_query<query>(dev);
     xrt_core::smi::smi_hardware_config smi_hrdw;
     const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+    if (smi_hrdw.get_family(hardware_type) == xrt_core::smi::smi_hardware_config::hardware_family::npu3) {
+      XBValidateUtils::logger(ptree, "Details", "N/A");
+      ptree.put("status", XBValidateUtils::test_token_skipped);
+      return ptree;
+    }
+
     const bool is_strix = XBU::is_strix_hardware(hardware_type);
 
     const std::vector<std::string> artifacts = is_strix

--- a/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestTCTOneColumn.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -96,6 +96,12 @@ TestTCTOneColumn::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_co
     const auto pcie_id = xrt_core::device_query<query>(dev);
     xrt_core::smi::smi_hardware_config smi_hrdw;
     const auto hardware_type = smi_hrdw.get_hardware_type(pcie_id);
+    if (smi_hrdw.get_family(hardware_type) == xrt_core::smi::smi_hardware_config::hardware_family::npu3) {
+      XBValidateUtils::logger(ptree, "Details", "N/A");
+      ptree.put("status", XBValidateUtils::test_token_skipped);
+      return ptree;
+    }
+
     const bool is_strix = XBU::is_strix_hardware(hardware_type);
 
     const std::vector<std::string> artifacts = is_strix


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-41600
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Consolidating throughput and latency xrt-smi validate tests for npu3, skip TCT tests as well
#### How problem was solved, alternative solutions (if any) and why they were rejected
Dropped runlist-latency and runlist-throughput (return N/A on npu3, shows up as "skipped" in output) and moved logic of runlist-throughput to default throughput test, skipped TCT tests on npu3
#### Risks (if any) associated the changes in the commit
Test deprecation, can break pipelines if numbers are expected when parsing output for the tests
#### What has been tested and how, request additional testing if necessary
Testing on STX/npu3
#### Documentation impact (if any)
Will need to update xrt-smi user guide