### PR TITLE
Add compute_io_bound aie_dtrace metric: ini accessor and XDP submodule bump

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1003,6 +1003,14 @@ get_aie_dtrace_settings_tile_based_interface_tile_metrics()
   return value;
 }
 
+inline std::string
+get_aie_dtrace_settings_tile_based_aie_metrics()
+{
+  static std::string value =
+      detail::get_string_value("AIE_dtrace_settings.tile_based_aie_metrics", "");
+  return value;
+}
+
 // AIE_trace_settings
 
 inline std::string


### PR DESCRIPTION
## Summary

Enables the new `compute_io_bound` core-tile metric in the XDP `aie_dtrace` plugin. Two commits:

- **`AIE_dtrace_settings.tile_based_aie_metrics` config accessor.** The `aie_dtrace` plugin gains a core-tile metric set alongside its existing interface-tile bandwidth ones, and needs to read its own ini key rather than reuse `AIE_profile_settings`. Mirrors the neighbouring `tile_based_interface_tile_metrics` accessor and defaults to empty, so the metric stays off unless `xrt.ini` asks for it.
- **XDP submodule `e25b237` -> `3900554`**, picking up [XDP #101 "Aie dtrace compute io bound"](https://github.com/Xilinx/XDP/pull/101).

The metric classifies each layer as compute or IO bound by subtracting stall cycles from total execution cycles:

```
computeCycles = totalExecutionCycles - (memory + stream + cascade + lock) stall cycles
```

It measures a single AIE tile, using both of its modules: the core module counts total execution cycles (PC range over all of program memory) and group stall, and broadcasts the four individual stall events to the memory module, which counts them on its own counters. Six counters are needed and only a few are usable per module, hence the split. Results are reported by vaianalyze as a `COMPUTE_IO_BOUND_DATA` section in `instrumentation_stats*.json`, parallel to the existing `BW_DATA`, and folded into the per-layer report by MLProfilerEngine.

No AIE event trace is required, and there is no design-specific preparation step.

## Test plan

- [x] Built for VE2 (`build_ve2.sh`, aarch64 cross-compile) - `libxdp_aie_dtrace_plugin_xdna.so` builds and packages clean
- [x] Board runs on VEK385 with `tile_based_aie_metrics = all:compute_io_bound`, on two designs (BEVFormer ResNet50, garuda int8)
- [x] Generated CT file verified: expected broadcast, block, counter reset and control-register writes, plus six `read_reg` per probe across the core and memory module address ranges
- [x] Data consistency on hardware: the four individual stalls sum to within 346 cycles of the independently measured group stall over 6.5M stall cycles (1 cycle on the second design), and `groupStall <= total` holds
- [x] Broadcast relay cross-validated: memory stall measured natively on the core in one run and via broadcast on the memory module in the next agreed to 0.17%
- [x] Total execution cycles tracked the elapsed timestamp span to within 0.1%, confirming the PC-range counter covers the whole program
- [x] End-to-end post-processing through `vaiprofile` -> vaianalyze -> MLProfilerEngine, for a compute-only run and a combined bandwidth + compute run

## Notes

The core module's `Performance_Control0` is deliberately never written: it holds counter 0's start/stop events, the driver's ECC scrubbing owns core counter 0, and a counter programmed alongside it did not survive on hardware. Only control registers this metric fully owns are written.

Documented at [IO Bound vs Compute Bound Layer Using Control Instrumentation](https://amd.atlassian.net/wiki/spaces/XSW/pages/1514009209).