### PR TITLE
[XRT-SMI] Update runlist throughput test

### DIFF
--- a/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.cpp
+++ b/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.cpp
@@ -10,12 +10,39 @@
 #include "core/common/runner/runner.h"
 #include "core/common/json/nlohmann/json.hpp"
 #include "core/common/archive.h"
+#include <stdexcept>
 namespace XBU = XBUtilities;
+
+using json = nlohmann::json;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 TestRunlistThroughput::TestRunlistThroughput()
   : TestRunner("runlist-throughput", "Run end-to-end throughput test using runlist")
 {}
+
+double
+TestRunlistThroughput::
+get_runlist_throughput_from_report(const json& report)
+{
+  if (report.contains("executions")) {
+    const auto& execs = report.at("executions");
+    if (!execs.is_array() || execs.size() != 1)
+      throw std::runtime_error("profile_cmd_chain_throughput.json must define exactly one execution");
+
+    return execs.at(0).at("cpu").at("throughput").get<double>();
+  }
+
+  return report.at("cpu").at("throughput").get<double>();
+}
+
+double
+TestRunlistThroughput::
+get_ops_throughput_from_report(const json& report)
+{
+  const auto runlist_throughput = get_runlist_throughput_from_report(report);
+  const auto recipe_runs = report.at("resources").at("runs").get<double>();
+  return runlist_throughput * recipe_runs;
+}
 
 boost::property_tree::ptree
 TestRunlistThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const xrt_core::archive* archive)
@@ -41,8 +68,8 @@ TestRunlistThroughput::run(const std::shared_ptr<xrt_core::device>& dev, const x
     runner.execute();
     runner.wait();
 
-    auto report = nlohmann::json::parse(runner.get_report());
-    auto throughput = report["cpu"]["throughput"].get<double>();
+    const auto report = json::parse(runner.get_report());
+    const auto throughput = get_ops_throughput_from_report(report);
 
     XBValidateUtils::logger(ptree, "Details", boost::str(boost::format("Average throughput: %.1f ops/s") % throughput));
     ptree.put("status", XBValidateUtils::test_token_passed);

--- a/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.h
+++ b/src/runtime_src/core/tools/common/tests/TestRunlistThroughput.h
@@ -5,14 +5,21 @@
 #define TestRunlistThroughput_h_
 
 #include "tools/common/TestRunner.h"
+#include "core/common/json/nlohmann/json.hpp"
 #include "xrt/xrt_device.h"
 
 class TestRunlistThroughput : public TestRunner {
   public:
     boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>&, const xrt_core::archive*) override;
 
-  public:
     TestRunlistThroughput();
+
+  private:
+    static double
+    get_runlist_throughput_from_report(const nlohmann::json& report);
+
+    static double
+    get_ops_throughput_from_report(const nlohmann::json& report);
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR updates the runlist throughput test to run in non legacy mode so that the throughput reported inculcates the depth used in the test. In non legacy runner, the throughput reported in runlist throughput while we want xrt-smi to report per run throughput. This PR also adds an API to query runs per runlist and use it for throughput reporting.
As the next step, for npu3 we need the throughput test to default to runlist throughput and remove the redundant runlist latency and runlist throughput tests.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-41600

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
Might change the throughput reported slightly.

#### What has been tested and how, request additional testing if necessary
Tested on windows : 
```
C:\Users\aktondak\Downloads\mcdm_stack_rel_preprod-run10599-3b02293\mcdm_stack_rel_preprod>xrt-smi validate --advanced -r runlist-throughput
-------------------------------------------------------------------------
                    DISCLAIMER  (xrt-smi --advanced)
You are running a developer command that may change system configuration.
                Continue only if you understand the risks.
-------------------------------------------------------------------------
Validate Device           : [0083:00:01.1]
    Platform              : NPU Medusa B0
    Power Mode            : performance
-------------------------------------------------------------------------------
Test 1 [0083:00:01.1]     : runlist-throughput
    Details               : Average throughput: 162528.0 ops/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

#### Documentation impact (if any)
None
