### PR TITLE
ci: replace sourcemation Docker image with Ubuntu Toolchain PPA for GCC 16

### DIFF
--- a/.github/workflows/build-linux-gcc16-docker.yml
+++ b/.github/workflows/build-linux-gcc16-docker.yml
@@ -1,17 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
-# Builds XRT in a Linux container whose toolchain is GCC 16.
-#
-# The Docker Library gcc image may not publish gcc:16 yet on your registry; the default
-# below is a Debian-based GCC 16 toolchain image. Edit container.image to another tag
-# (for example gcc:16-bookworm from Docker Hub) when that suits your project.
-#
-# ccache + actions/cache work on GitHub-hosted runners; the workspace is bind-mounted into
-# the container so .ccache is visible to both. Fork PRs from outside contributors cannot
-# update the base repo cache (read-only token); same-repo branches still benefit.
+# Builds XRT on ubuntu-latest with GCC 16 installed from the Ubuntu Toolchain PPA.
+# No external Docker image required.
 
-name: Linux build (GCC 16, Docker)
+name: Linux build (GCC 16)
 
 on:
   workflow_dispatch:
@@ -33,33 +26,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      # Under workspace so actions/cache can archive it (bind-mounted into the container).
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_COMPRESS: "true"
       CCACHE_MAXSIZE: "2G"
-    container:
-      image: sourcemation/gcc-16:latest
     defaults:
       run:
         shell: bash
 
     steps:
-      # Workspace is bind-mounted from the runner and owned by a non-root UID; the
-      # container often runs as root, so Git 2.35+ refuses the repo unless trusted.
-      - name: Configure Git safe.directory (container)
-        run: git config --global --add safe.directory '*'
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      - name: Install GCC 16
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends gcc-16 g++-16
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-16 100
+
       - name: Restore ccache
         uses: actions/cache/restore@v4
         with:
           path: .ccache
-          # Unique key so restore always falls through to restore-keys and picks the latest
-          # cache for this OS + CMake fingerprint (save key uses the same prefix).
           key: ccache-gcc16-${{ runner.os }}-${{ hashFiles('src/CMakeLists.txt', 'src/CMake/**/*.cmake', 'build/build.sh') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ccache-gcc16-${{ runner.os }}-${{ hashFiles('src/CMakeLists.txt', 'src/CMake/**/*.cmake', 'build/build.sh') }}-
@@ -71,10 +62,10 @@ jobs:
           g++ --version
 
       - name: Install XRT dependencies
-        run: src/runtime_src/tools/scripts/xrtdeps.sh -docker
+        run: sudo src/runtime_src/tools/scripts/xrtdeps.sh -docker
 
       - name: Install ccache
-        run: apt-get install -y --no-install-recommends ccache
+        run: sudo apt-get install -y --no-install-recommends ccache
 
       - name: Build XRT (Release)
         run: |

--- a/src/runtime_src/tools/xclbinutil/RapidJsonUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/RapidJsonUtilities.h
@@ -21,7 +21,16 @@
 #define __RapidJsonUtilities_h_
 
 // Include files
+// GCC 16 added -Wtemplate-body which fires on a const-member copy-assignment in
+// rapidjson::GenericStringRef; suppress until an upstream rapidjson fix is available.
+#if defined(__GNUC__) && __GNUC__ >= 16
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtemplate-body"
+#endif
 #include <rapidjson/document.h>
+#if defined(__GNUC__) && __GNUC__ >= 16
+#pragma GCC diagnostic pop
+#endif
 #include <vector>
 #include <utility>
 #include <sstream>


### PR DESCRIPTION
#### Problem solved by the commit
Install gcc-16/g++-16 directly on ubuntu-latest via ppa:ubuntu-toolchain-r/test instead of relying on the external sourcemation/gcc-16:latest container image.

