### PR TITLE
CR-1210115:Add non-blocking RTP update/read APIs.

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -119,6 +119,18 @@ public:
     m_graphHandle->read_graph_rtp(port, buffer, size);
   }
 
+  int
+  update_rtp_nb(const char* port, const char* buffer, size_t size)
+  {
+    return m_graphHandle->update_graph_rtp_nb(port, buffer, size);
+  }
+
+  int
+  read_rtp_nb(const char* port, char* buffer, size_t size)
+  {
+    return m_graphHandle->read_graph_rtp_nb(port, buffer, size);
+  }
+
   uint32_t
   gmio_bank_id(const std::string& gmio_name) const
   {
@@ -447,6 +459,24 @@ read_port(const std::string& port_name, void* value, size_t bytes)
 {
   xdp::native::profiling_wrapper("xrt::graph::read_port", [this, port_name, value, bytes]{
     handle->read_rtp(port_name.c_str(), reinterpret_cast<char *>(value), bytes);
+  });
+}
+
+int
+graph::
+update_port_nb(const std::string& port_name, const void* value, size_t bytes)
+{
+  return xdp::native::profiling_wrapper("xrt::graph::update_port_nb", [this, port_name, value, bytes]{
+    return handle->update_rtp_nb(port_name.c_str(), reinterpret_cast<const char*>(value), bytes);
+  });
+}
+
+int
+graph::
+read_port_nb(const std::string& port_name, void* value, size_t bytes)
+{
+  return xdp::native::profiling_wrapper("xrt::graph::read_port_nb", [this, port_name, value, bytes]{
+    return handle->read_rtp_nb(port_name.c_str(), reinterpret_cast<char*>(value), bytes);
   });
 }
 

--- a/src/runtime_src/core/common/shim/graph_handle.h
+++ b/src/runtime_src/core/common/shim/graph_handle.h
@@ -4,41 +4,69 @@
 #ifndef XRT_CORE_GRAPH_HANDLE_H
 #define XRT_CORE_GRAPH_HANDLE_H
 
+#include <cstddef>
+#include <cstdint>
+
 namespace xrt_core {
+
+// class graph_handle - shim base class for AIE graph objects
+//
+// Shim level implementations derive off this class to support
+// opaque graph objects where implementation details are platform
+// specific.  The xrt::graph API dispatches graph operations through
+// this virtual interface.
 class graph_handle
 {
 public:
   virtual ~graph_handle() {}
 
+  // Reset graph by disabling tiles and enabling tile reset
   virtual void
   reset_graph() = 0;
 
+  // Get graph timestamp in AIE cycles
   virtual uint64_t
   get_timestamp() = 0;
 
+  // Start graph execution for the given number of iterations
   virtual void
   run_graph(int iterations) = 0;
 
+  // Wait for graph run to complete; timeout in milliseconds
   virtual int
   wait_graph_done(int timeout) = 0;
 
+  // Wait for the given number of AIE cycles since last run, then suspend
   virtual void
   wait_graph(uint64_t cycle) = 0;
 
+  // Suspend a running graph
   virtual void
   suspend_graph() = 0;
 
+  // Resume a suspended graph
   virtual void
   resume_graph() = 0;
 
+  // Wait for the given number of AIE cycles since last run, then terminate
   virtual void
   end_graph(uint64_t cycle) = 0;
 
+  // Update a graph run-time parameter (RTP) port; blocks on tile locks
   virtual void
   update_graph_rtp(const char* port, const char* buffer, size_t size) = 0;
 
+  // Read a graph run-time parameter (RTP) port; blocks on tile locks
   virtual void
   read_graph_rtp(const char* port, char* buffer, size_t size) = 0;
+
+  // Non-blocking RTP update.  Returns 0 on success, EAGAIN if lock unavailable
+  virtual int
+  update_graph_rtp_nb(const char* port, const char* buffer, size_t size) = 0;
+
+  // Non-blocking RTP read.  Returns 0 on success, EAGAIN if lock unavailable
+  virtual int
+  read_graph_rtp_nb(const char* port, char* buffer, size_t size) = 0;
 };
 
 } // xrt_core

--- a/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_emu/generic_pcie_hal2/shim.h
@@ -353,6 +353,22 @@ namespace xclswemuhal2 {
         if (auto ret = xclGraphReadRTP(m_xclGraphHandle, port, buffer, size))
           throw xrt_core::system_error(ret, "fail to read graph rtp");
       }
+
+      int
+      update_graph_rtp_nb(const char* port, const char* buffer, size_t size) override
+      {
+        // sw_emu delegates to blocking RTP APIs
+        update_graph_rtp(port, buffer, size);
+        return 0;
+      }
+
+      int
+      read_graph_rtp_nb(const char* port, char* buffer, size_t size) override
+      {
+        // sw_emu delegates to blocking RTP APIs
+        read_graph_rtp(port, buffer, size);
+        return 0;
+      }
     }; // graph_object
   private:
       // This is a hidden signature of this class and helps in preventing

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -43,7 +43,17 @@ static constexpr int AIE_ML_ASYNC_REL = 1;
 static constexpr int AIE_ML_ASYNC_ACQ = -1; //negative lock value -> acquire_greater_equal
 static constexpr int AIE_ML_ASYNC_ACQ_FIRST_TIME = 0;
 static constexpr unsigned LOCK_TIMEOUT = 0x7FFFFFFF;
+static constexpr unsigned LOCK_TIMEOUT_NB = 0; // non-blocking RTP lock acquire
 
+static int
+undoLockAcquire(XAie_DevInst* dev, XAie_LocType tile, unsigned short lockId, int8_t acqVal)
+{
+    int8_t undoVal = acqVal;
+    if (acqVal != XAIE_LOCK_WITH_NO_VALUE && dev->DevProp.DevGen >= XAIE_DEV_GEN_AIEML)
+        undoVal = -acqVal;
+
+    return XAie_LockRelease(dev, tile, XAie_LockInit(lockId, undoVal), LOCK_TIMEOUT);
+}
 
 /********************************* config_manager *************************************/
 
@@ -546,6 +556,7 @@ err_code graph_api::update(const rtp_config* pRTPConfig, const void* pValue, siz
 
     if (pRTPConfig->hasLock && bAcquireLock && !pRTPConfig->blocking)
         driverStatus |= XAie_LockAcquire(config->get_dev(), selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, selAcqVal), LOCK_TIMEOUT);
+
     // write the new selector value
     driverStatus |= XAie_DataMemWrWord(config->get_dev(), selectorTile, pRTPConfig->selectorAddr, selector);
 
@@ -571,6 +582,160 @@ err_code graph_api::update(const rtp_config* pRTPConfig, const void* pValue, siz
 
     if (driverStatus != AieRC::XAIE_OK)
         return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::update: XAieTile_LockAcquire timeout or AIE driver error.");
+
+    return err_code::ok;
+}
+
+err_code graph_api::update_nb(const rtp_config* pRTPConfig, const void* pValue, size_t numBytes)
+{
+    ///////////////////////////// Error Checking //////////////////////////////
+
+    err_code ret = checkRTPConfigForUpdate(pRTPConfig, pGraphConfig, numBytes, isRunning);
+    if (ret != err_code::ok)
+        return ret;
+
+    ///////////////////////////// Configuration //////////////////////////////
+
+    size_t numReservedRows = config->get_num_reserved_rows();
+    XAie_LocType selectorTile = XAie_TileLoc(pRTPConfig->selectorColumn, pRTPConfig->selectorRow + numReservedRows + 1);
+    XAie_LocType pingTile = XAie_TileLoc(pRTPConfig->pingColumn, pRTPConfig->pingRow + numReservedRows + 1);
+    XAie_LocType pongTile = XAie_TileLoc(pRTPConfig->pongColumn, pRTPConfig->pongRow + numReservedRows + 1);
+
+    // Do NOT lock async RTP when graph is suspended; otherwise, it may deadlock. We don't support synchronous RTP in suspended mode
+    bool bAcquireLock = !(pRTPConfig->isAsync && !isRunning);
+
+    int8_t acquireVal = (pRTPConfig->isAsync ? XAIE_LOCK_WITH_NO_VALUE : ACQ_WRITE); //Versal
+    int8_t selAcqVal  = acquireVal;
+    int8_t bufAcqVal  = acquireVal;
+
+    int8_t releaseVal = REL_READ; //Versal
+    bool relSelLock = true;
+    bool relBufLock = true;
+
+    // defer asyncRtpUpdateTimes increment until the whole update succeeds
+    bool bCountThisUpdate = false;
+
+    if (config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIEML || config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIE2PS) //modification to accommodate AIEML semaphore
+    {
+        if (pRTPConfig->isAsync)
+        {
+            int rtpUpdateTimes = asyncRtpUpdateTimes[pRTPConfig->portId];
+            if (rtpUpdateTimes == 0)
+            {
+                selAcqVal = AIE_ML_ASYNC_ACQ_FIRST_TIME;
+                bufAcqVal = AIE_ML_ASYNC_ACQ_FIRST_TIME;
+
+                // For the first RTP update, release both the locks even if they are not acquired.
+                // Otherwise, the kernel won't be able to acquire the lock.
+                relSelLock = true;
+                relBufLock = true;
+
+                bCountThisUpdate = true;
+            }
+            else if (rtpUpdateTimes == 1)
+            {
+                selAcqVal = AIE_ML_ASYNC_ACQ;
+                relSelLock = bAcquireLock;
+                if (pRTPConfig->pingLockId == pRTPConfig->pongLockId) //single buffer
+                {
+                    bufAcqVal = AIE_ML_ASYNC_ACQ;
+                    relBufLock = bAcquireLock;
+                }
+                else
+                {
+                    bufAcqVal = AIE_ML_ASYNC_ACQ_FIRST_TIME; //double buffer, second update call to pong buffer, still first time for pong buffer lock
+                    relBufLock = true; // for pong, its the first update. Hence, release the lock.
+                }
+
+                bCountThisUpdate = true;
+            }
+            else // rtpUpdateTimes>=2
+            {
+                selAcqVal = AIE_ML_ASYNC_ACQ;
+                bufAcqVal = AIE_ML_ASYNC_ACQ;
+
+                // release the locks only if they are acquired. Otherwise, it can result in lock value overflow.
+                relSelLock = bAcquireLock;
+                relBufLock = bAcquireLock;
+            }
+        }
+    }
+
+    ///////////////////////////// RTP update operation //////////////////////////////
+
+    infoMsg("Updating RTP value to port " + pRTPConfig->portName);
+
+    XAie_DevInst* dev = config->get_dev();
+    bool acqLock = pRTPConfig->hasLock && bAcquireLock;
+    bool selectorLockHeld = false;
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    // sync ports acquire selector lock for WRITE, async ports acquire selector lock unconditionally
+    if (acqLock && pRTPConfig->blocking)
+    {
+        if (XAie_LockAcquire(dev, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, selAcqVal), LOCK_TIMEOUT_NB) != AieRC::XAIE_OK)
+            return err_code::resource_unavailable;
+
+        selectorLockHeld = true;
+    }
+
+    // Read the selector value
+    u32 selector;
+    driverStatus |= XAie_DataMemRdWord(dev, selectorTile, pRTPConfig->selectorAddr, ((u32*)&selector));
+    selector = 1 - selector;
+
+    XAie_LocType bufferTile = (selector == 1 ? pongTile : pingTile);
+    unsigned short bufferLockId = (selector == 1 ? pRTPConfig->pongLockId : pRTPConfig->pingLockId);
+    size_t bufferAddr = (selector == 1 ? pRTPConfig->pongAddr : pRTPConfig->pingAddr);
+
+    // sync ports acquire buffer lock for WRITE, async ports acquire buffer lock unconditionally
+    if (acqLock)
+    {
+        if (XAie_LockAcquire(dev, bufferTile, XAie_LockInit(bufferLockId, bufAcqVal), LOCK_TIMEOUT_NB) != AieRC::XAIE_OK)
+        {
+            if (selectorLockHeld)
+                undoLockAcquire(dev, selectorTile, pRTPConfig->selectorLockId, selAcqVal);
+
+            return err_code::resource_unavailable;
+        }
+    }
+
+    driverStatus |= XAie_DataMemBlockWrite(dev, bufferTile, bufferAddr, pValue, numBytes);
+
+    if (acqLock && !pRTPConfig->blocking)
+    {
+        if (XAie_LockAcquire(dev, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, selAcqVal), LOCK_TIMEOUT_NB) != AieRC::XAIE_OK)
+        {
+            // undo buffer lock only; selector not updated yet
+            undoLockAcquire(dev, bufferTile, bufferLockId, bufAcqVal);
+
+            return err_code::resource_unavailable;
+        }
+    }
+
+    // write the new selector value
+    driverStatus |= XAie_DataMemWrWord(dev, selectorTile, pRTPConfig->selectorAddr, selector);
+
+    if (pRTPConfig->hasLock)
+    {
+        // release selector and buffer locks for ME
+        // still need to release async RTP selector lock FOR_READ even when the graph is suspended;
+        // otherwise, the ME side may deadlock in acquiring selector lock FOR_READ
+        if (relSelLock)
+            driverStatus |= XAie_LockRelease(dev, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, releaseVal), LOCK_TIMEOUT);
+
+        // still need to release async RTP buffer lock FOR_READ even when the graph is suspended;
+        // otherwise, the AIE side may deadlock in acquiring buffer lock FOR_READ
+        // (note that there is one selector lock but two buffer locks)
+        if (relBufLock)
+            driverStatus |= XAie_LockRelease(dev, bufferTile, XAie_LockInit(bufferLockId, releaseVal), LOCK_TIMEOUT);
+    }
+
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::update_nb: AIE driver error.");
+
+    if (bCountThisUpdate)
+        asyncRtpUpdateTimes[pRTPConfig->portId]++;
 
     return err_code::ok;
 }
@@ -680,6 +845,82 @@ err_code graph_api::read(const rtp_config* pRTPConfig, void* pValue, size_t numB
         return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::read: XAieTile_LockAcquire timeout or AIE driver error.");
 
      return err_code::ok;
+}
+
+err_code graph_api::read_nb(const rtp_config* pRTPConfig, void* pValue, size_t numBytes)
+{
+    ///////////////////////////// Error Checking //////////////////////////////
+
+    err_code ret = checkRTPConfigForRead(pRTPConfig, pGraphConfig, numBytes);
+    if (ret != err_code::ok)
+        return ret;
+
+    ///////////////////////////// Configuration //////////////////////////////
+
+    // Do NOT lock async RTP when graph is suspended; otherwise, it may deadlock. We don't support synchronous RTP in suspended mode
+    bool bHasAndAcquireLock = !(pRTPConfig->isAsync && !isRunning) && pRTPConfig->hasLock;
+
+    int8_t acquireVal = ACQ_READ; //Versal
+    int8_t releaseVal = (pRTPConfig->isAsync ? REL_READ : REL_WRITE); //Versal
+
+    size_t numReservedRows = config->get_num_reserved_rows();
+    XAie_LocType selectorTile = XAie_TileLoc(pRTPConfig->selectorColumn, pRTPConfig->selectorRow + numReservedRows + 1);
+    XAie_LocType pingTile = XAie_TileLoc(pRTPConfig->pingColumn, pRTPConfig->pingRow + numReservedRows + 1);
+    XAie_LocType pongTile = XAie_TileLoc(pRTPConfig->pongColumn, pRTPConfig->pongRow + numReservedRows + 1);
+
+    if (config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIEML || config->get_dev()->DevProp.DevGen == XAIE_DEV_GEN_AIE2PS) //modification to accommodate AIEML semaphore
+    {
+        if (pRTPConfig->isAsync)
+            acquireVal = AIE_ML_ASYNC_ACQ;
+        else
+            releaseVal = AIE_ML_REL_WRITE;
+    }
+
+    ///////////////////////////// RTP read operation //////////////////////////////
+
+    infoMsg("Reading RTP value from port " + pRTPConfig->portName);
+
+    XAie_DevInst* dev = config->get_dev();
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    // synchronous RTP acquires lock for READ, async RTP requiring first-time sync acquires lock for READ
+    if (bHasAndAcquireLock)
+    {
+        if (XAie_LockAcquire(dev, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, acquireVal), LOCK_TIMEOUT_NB) != AieRC::XAIE_OK)
+            return err_code::resource_unavailable;
+    }
+
+    // Read the selector value
+    u32 selector;
+    driverStatus |= XAie_DataMemRdWord(dev, selectorTile, pRTPConfig->selectorAddr, ((u32*)&selector));
+
+    XAie_LocType bufferTile = (selector == 1 ? pongTile : pingTile);
+    unsigned short bufferLockId = (selector == 1 ? pRTPConfig->pongLockId : pRTPConfig->pingLockId);
+    size_t bufferAddr = (selector == 1 ? pRTPConfig->pongAddr : pRTPConfig->pingAddr);
+
+    if (bHasAndAcquireLock)
+    {
+        // synchronous RTP acquires buffer for READ, async RTP requiring first-time sync acquires lock for READ
+        if (XAie_LockAcquire(dev, bufferTile, XAie_LockInit(bufferLockId, acquireVal), LOCK_TIMEOUT_NB) != AieRC::XAIE_OK)
+        {
+            undoLockAcquire(dev, selectorTile, pRTPConfig->selectorLockId, acquireVal);
+            return err_code::resource_unavailable;
+        }
+
+        // synchronous RTP releases lock for WRITE, async RTP requiring first-time sync release lock for READ
+        driverStatus |= XAie_LockRelease(dev, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, releaseVal), LOCK_TIMEOUT);
+    }
+
+    driverStatus |= XAie_DataMemBlockRead(dev, bufferTile, bufferAddr, pValue, numBytes);
+
+    //release buffer lock
+    if (bHasAndAcquireLock)
+        driverStatus |= XAie_LockRelease(dev, bufferTile, XAie_LockInit(bufferLockId, releaseVal), LOCK_TIMEOUT);
+
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::read_nb: AIE driver error.");
+
+    return err_code::ok;
 }
 
 

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -49,7 +49,9 @@ public:
   err_code end();
   err_code end(unsigned long long cycleTimeout);
   err_code update(const rtp_config* pRTPConfig, const void* pValue, size_t numBytes);
+  err_code update_nb(const rtp_config* pRTPConfig, const void* pValue, size_t numBytes);
   err_code read(const rtp_config* pRTPConfig, void* pValue, size_t numBytes);
+  err_code read_nb(const rtp_config* pRTPConfig, void* pValue, size_t numBytes);
   err_code update(const shared_buffer_config* pSharedBufferConfig, const void* pValue, size_t numBytes);
 
 private:

--- a/src/runtime_src/core/edge/user/aie/graph_object.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph_object.cpp
@@ -318,4 +318,57 @@ graph_object::read_graph_rtp(const char* port, char* buffer, size_t size)
 
   graph_api_obj->read(&rtp, (void*)buffer, size);
 }
+
+/* Non-blocking version of update_graph_rtp().
+ * Returns EAGAIN if RTP lock is unavailable.
+ */
+int
+graph_object::update_graph_rtp_nb(const char* port, const char* buffer, size_t size)
+{
+  auto it = rtps.find(port);
+  if (it == rtps.end()) {
+    /* find if the update is for shared buffer */
+    auto it = shared_buffer_configs.find(port);
+    if (it == shared_buffer_configs.end()) {
+      throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': RTP Port / Shared Buffer Name '" + port + "' not found");
+    }
+    else {
+      throw xrt_core::error(-ENOTSUP, "Can't update graph '" + name + "': non-blocking update is not supported for shared buffer '" + port + "'");
+    }
+  }
+  else {
+    auto& rtp = it->second;
+
+    if (access_mode == xrt::graph::access_mode::shared && !rtp.isAsync)
+      throw xrt_core::error(-EPERM, "Shared context can not update sync RTP");
+
+    if (rtp.isPL)
+      throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': RTP port '" + port + "' is not AIE RTP");
+
+    if (graph_api_obj->update_nb(&rtp, (const void*)buffer, size) == adf::err_code::resource_unavailable)
+      return EAGAIN;
+
+    return 0;
+  }
+}
+
+/* Non-blocking version of read_graph_rtp().
+ * Returns EAGAIN if RTP lock is unavailable.
+ */
+int
+graph_object::read_graph_rtp_nb(const char* port, char* buffer, size_t size)
+{
+  auto it = rtps.find(port);
+  if (it == rtps.end())
+    throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': RTP port '" + port + "' not found");
+  auto& rtp = it->second;
+
+  if (rtp.isPL)
+    throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': RTP port '" + port + "' is not AIE RTP");
+
+  if (graph_api_obj->read_nb(&rtp, (void*)buffer, size) == adf::err_code::resource_unavailable)
+    return EAGAIN;
+
+  return 0;
+}
 }

--- a/src/runtime_src/core/edge/user/aie/graph_object.h
+++ b/src/runtime_src/core/edge/user/aie/graph_object.h
@@ -98,6 +98,12 @@ namespace zynqaie {
 
     void
     read_graph_rtp(const char* port, char* buffer, size_t size) override;
+
+    int
+    update_graph_rtp_nb(const char* port, const char* buffer, size_t size) override;
+
+    int
+    read_graph_rtp_nb(const char* port, char* buffer, size_t size) override;
   }; // graph_object
 }
 #endif  //_ZYNQ_GRAPH_OBJECT_H_

--- a/src/runtime_src/core/include/xrt/xrt_graph.h
+++ b/src/runtime_src/core/include/xrt/xrt_graph.h
@@ -267,6 +267,76 @@ public:
     read_port(port_name, value, bytes);
   }
 
+  /**
+   * update_nb() - Update graph Run Time Parameters without blocking.
+   *
+   * @param port_name
+   *  Hierarchical name of RTP port.
+   * @param arg
+   *  The argument to set.
+   *
+   * Return 0 on success, EAGAIN if RTP lock is unavailable.
+   */
+  template<typename ArgType>
+  int
+  update_nb(const std::string& port_name, const ArgType& arg)
+  {
+    return update_nb(port_name, &arg, sizeof(arg));
+  }
+
+  /**
+   * update_nb() - Update graph Run Time Parameters without blocking.
+   *
+   * @param port_name
+   *  Hierarchical name of RTP port.
+   * @param value
+   *  Pointer to the RTP value.
+   * @param bytes
+   *  The size in bytes of the RTP value.
+   *
+   * Return 0 on success, EAGAIN if RTP lock is unavailable.
+   */
+  int
+  update_nb(const std::string& port_name, const void* value, size_t bytes)
+  {
+    return update_port_nb(port_name, value, bytes);
+  }
+
+  /**
+   * read_nb() - Read graph Run Time Parameters value without blocking.
+   *
+   * @param port_name
+   *  Hierarchical name of RTP port.
+   * @param arg
+   *  The RTP value is written to.
+   *
+   * Return 0 on success, EAGAIN if RTP lock is unavailable.
+   */
+  template<typename ArgType>
+  int
+  read_nb(const std::string& port_name, ArgType& arg)
+  {
+    return read_nb(port_name, &arg, sizeof(arg));
+  }
+
+  /**
+   * read_nb() - Read graph Run Time Parameters value without blocking.
+   *
+   * @param port_name
+   *  Hierarchical name of RTP port.
+   * @param value
+   *  Data pointer to hold the RTP value.
+   * @param bytes
+   *  The size in bytes of the data to be read.
+   *
+   * Return 0 on success, EAGAIN if RTP lock is unavailable.
+   */
+  int
+  read_nb(const std::string& port_name, void* value, size_t bytes)
+  {
+    return read_port_nb(port_name, value, bytes);
+  }
+
 private:
   std::shared_ptr<graph_impl> handle;
 
@@ -277,6 +347,14 @@ private:
   XRT_API_EXPORT
   void
   read_port(const std::string& port_name, void* value, size_t bytes);
+
+  XRT_API_EXPORT
+  int
+  update_port_nb(const std::string& port_name, const void* value, size_t bytes);
+
+  XRT_API_EXPORT
+  int
+  read_port_nb(const std::string& port_name, void* value, size_t bytes);
 };
 
 } // namespace xrt

--- a/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/sw_emu/generic_pcie_hal2/shim.h
@@ -359,6 +359,22 @@ namespace xclswemuhal2
         if (auto ret = xclGraphReadRTP(m_xclGraphHandle, port, buffer, size))
           throw xrt_core::system_error(ret, "fail to read graph rtp");
       }
+
+      int
+      update_graph_rtp_nb(const char* port, const char* buffer, size_t size) override
+      {
+        // sw_emu delegates to blocking RTP APIs
+        update_graph_rtp(port, buffer, size);
+        return 0;
+      }
+
+      int
+      read_graph_rtp_nb(const char* port, char* buffer, size_t size) override
+      {
+        // sw_emu delegates to blocking RTP APIs
+        read_graph_rtp(port, buffer, size);
+        return 0;
+      }
     }; // graph_object
   public:
     static const unsigned TAG;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Blocking xrt::graph::update() and read() wait on AIE tile locks. HIL host code needs to poll RTP ports without blocking. This commit adds update_nb() and read_nb(); they return EAGAIN when the lock is held by the kernel.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
No bug fix. New feature for [CR-1210115](https://jira.xilinx.com/browse/CR-1210115) / [VITIS-16628](https://jira.xilinx.com/browse/VITIS-16628).
#### How problem was solved, alternative solutions (if any) and why they were rejected
Added update_nb() / read_nb() through the existing graph layers down to adf_runtime_api, using non-blocking lock acquire (LOCK_TIMEOUT_NB) and undoLockAcquire() on partial failure.
#### Risks (if any) associated the changes in the commit
Low. Callers must retry on EAGAIN. Blocking RTP APIs are unchanged.
#### What has been tested and how, request additional testing if necessary
Tested on hardware (vck190): update_nb() and read_nb() return 0 when the lock is free and EAGAIN when the kernel holds it.
#### Documentation impact (if any)
API comments added in xrt_graph.h for update_nb() and read_nb(). No other docs changed.