### PR TITLE
Enable cross-process BO import for edge zocl via pidfd

### DIFF
--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -43,6 +43,7 @@ extern "C" {
 #include "xaiengine/xlnx-ai-engine.h"
 #endif
 #include <sys/ioctl.h>
+#include <sys/syscall.h>
 
 
 
@@ -1357,7 +1358,30 @@ import_bo(pid_t pid, shared_handle::export_handle ehdl)
   if (pid == 0 || getpid() == pid)
     return xrt::shim_int::import_bo(get_device_handle(), ehdl);
 
-  throw xrt_core::error(std::errc::not_supported, __func__);
+#if defined(SYS_pidfd_open) && defined(SYS_pidfd_getfd)
+  auto pidfd = syscall(SYS_pidfd_open, pid, 0);
+  if (pidfd < 0)
+    throw xrt_core::system_error(errno, "pidfd_open failed");
+
+  auto bofd = syscall(SYS_pidfd_getfd, pidfd, ehdl, 0);
+  if (bofd < 0) {
+    ::close(pidfd);
+    throw xrt_core::system_error
+      (errno, "pidfd_getfd failed, check that ptrace access mode "
+       "allows PTRACE_MODE_ATTACH_REALCREDS.  For more details please "
+       "check /etc/sysctl.d/10-ptrace.conf");
+  }
+
+  auto bo = xrt::shim_int::import_bo(get_device_handle(), bofd);
+  ::close(bofd);
+  ::close(pidfd);
+  return bo;
+#else
+  throw xrt_core::system_error
+    (std::errc::not_supported,
+     "Importing buffer object from different process requires XRT "
+     " built and installed on a system with 'pidfd' kernel support");
+#endif
 }
 
 void


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Add pidfd_open/pidfd_getfd support to edge zocl import_bo() so child processes can import exported dma-buf fds from a parent process.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Cross-process BO import into edge zocl failed with: import_bo: Operation not supported. zocl only supported same-process import.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Ported the existing PCIe side cross-process import_bo() implementation to edge zocl 

#### Risks (if any) associated the changes in the commit
low, only affects cross-process import when pid != getpid(); same-process path unchanged.

#### What has been tested and how, request additional testing if necessary
Tested on VEK385

#### Documentation impact (if any)
NA