### PR TITLE
Correctly enumerate PF device through xrt-smi when no VF present

### DIFF
--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -229,7 +229,9 @@ std::shared_ptr<device>
 system_linux::
 get_userpf_device(device::id_type id) const
 {
-  auto pdev = get_pcidev(id, true);
+  const auto user_ready = get_num_dev_ready(true);
+  auto pdev = (id < user_ready) ? get_pcidev(id, true) : get_pcidev(id - user_ready, false);
+
   return xrt_core::get_userpf_device(pdev->create_shim(id));
 }
 
@@ -237,8 +239,15 @@ std::shared_ptr<device>
 system_linux::
 get_userpf_device(device::handle_type handle, device::id_type id) const
 {
-  auto pdev = get_pcidev(id, true);
-  return pdev->create_device(handle, id);
+  const auto user_ready = get_num_dev_ready(true);
+  if (id < user_ready) {
+    auto pdev = get_pcidev(id, true);
+    return pdev->create_device(handle, id);
+  }
+
+  const auto mgmt_index = id - user_ready;
+  auto pdev = get_pcidev(mgmt_index, false);
+  return pdev->create_device(handle, mgmt_index);
 }
 
 std::shared_ptr<device>

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -452,8 +452,12 @@ get_device_internal(xrt_core::device::id_type index, bool in_user_domain)
   if (mgmt_devices.size() <= domain_index )
     throw std::runtime_error("no device present with index " + std::to_string(index));
 
-  if (!mgmt_devices[domain_index])
-    mgmt_devices[domain_index] = xrt_core::get_mgmtpf_device(domain_index);
+  if (!mgmt_devices[domain_index]) {
+    if (in_user_domain)
+      mgmt_devices[domain_index] = xrt_core::get_userpf_device(index);
+    else
+      mgmt_devices[domain_index] = xrt_core::get_mgmtpf_device(domain_index);
+  }
 
   return mgmt_devices[domain_index];
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xrt-smi examine failed with "No device handle" on PF device without VFs present.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Xrt-smi found the PF but opened it through the mgmt path. Xrt-smi runs in the user domain, with no VFs the user list is empty so index 0 had no user device. 
#### How problem was solved, alternative solutions (if any) and why they were rejected
Keep PF in the mgmt device list, but open it through the user/shim path (get_userpf_device()) instead of the mgmt-only path (get_mgmtpf_device()).

