### PR TITLE
Update petalinux to latest version and added recurisve to fetch the nested submodules

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -338,7 +338,7 @@ GIT_MODULES=$XRT_REPO_DIR/.gitmodules
 if [ -f "$GIT_MODULES" ] && [ $init_submodule == 1 ]; then
     cd $XRT_REPO_DIR
     echo "Updating Git XRT submodules, use -noinit option to avoid updating"
-    git submodule update --init
+    git submodule update --init --recursive
     cd $ORIGINAL_DIR
 fi
 

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
 # When updating Petalinux build please file a SH ticket to retain the build
 # https://jira.xilinx.com/secure/CreateIssue!default.jspa
-PETALINUX=/proj/petalinux/2026.2/petalinux-v2026.2_06161249/tool/petalinux-v2026.2-final
+PETALINUX=/proj/petalinux/2026.2/petalinux-v2026.2_08200038/tool/petalinux-v2026.2-final/


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
build_edge.sh will fail because a new submodule has been added to aiebu. Using only --init will not fetch the nested submodules.
SH ticket to reatain the build: https://jira.xilinx.com/browse/SH-3053
updated petalinux to petalinux-v2026.2_08200038 version.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Update petalinux to latest version and added recurisve to fetch the nested submodules

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested by building versal/aarch64 project

#### Documentation impact (if any)
NA