### PR TITLE
zocl: probe CU IRQs from fpga_accelerator DT overlay

### DIFF
--- a/build/yocto.build
+++ b/build/yocto.build
@@ -1,4 +1,4 @@
 REPO_URL=https://gitenterprise.xilinx.com/ssw-devops/yocto-tagged-manifest.git
 BRANCH=master
-MANIFEST_PATH=/proj/yocto/edf/2026.2/stable/Yocto_edf_2026.2_06121253
-MANIFEST_FILE=default_06121253.xml
+MANIFEST_PATH=/proj/yocto/edf/2026.2/stable/Yocto_edf_2026.2_08182207
+MANIFEST_FILE=default_08182207.xml

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -24,6 +24,7 @@
 #include <linux/pagemap.h>
 #include <linux/io.h>
 #include <linux/kernel.h>
+#include <linux/of.h>
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
 #include <linux/poll.h>
@@ -1312,6 +1313,65 @@ static const struct of_device_id zocl_drm_of_match[] = {
 };
 MODULE_DEVICE_TABLE(of, zocl_drm_of_match);
 
+static int zocl_cu_intc_setup(struct drm_zocl_dev *zdev, struct platform_device *pdev)
+{
+	struct device_node *fpga_np;
+	int index, irq, ret;
+
+	fpga_np = of_find_node_by_name(NULL, "fpga_accelerator");
+	for (index = 0; index < MAX_CU_NUM; index++) {
+		if (fpga_np && of_property_present(fpga_np, "interrupts-extended"))
+			irq = of_irq_get(fpga_np, index);
+		else
+			irq = platform_get_irq(pdev, index);
+		if (irq < 0)
+			break;
+		DRM_DEBUG("CU(%d) IRQ %d\n", index, irq);
+		zdev->cu_subdev.irq[index] = irq;
+	}
+	if (fpga_np)
+		of_node_put(fpga_np);
+
+	zdev->cu_subdev.cu_num = index;
+	if (!zdev->cu_subdev.cu_num)
+		return 0;
+
+	ret = zocl_ert_create_intc(&pdev->dev, zdev->cu_subdev.irq,
+				   zdev->cu_subdev.cu_num, 0,
+				   ERT_CU_INTC_DEV_NAME, &zdev->cu_intc);
+	if (ret)
+		DRM_ERROR("Failed to create cu intc device, ret %d\n", ret);
+	return ret;
+}
+
+void zocl_cu_intc_refresh(struct drm_zocl_dev *zdev)
+{
+	struct device_node *ert;
+	struct platform_device *pdev = to_platform_device(zdev->ddev->dev);
+
+	ert = of_find_node_by_name(NULL, "ert_hw");
+	if (ert) {
+		of_node_put(ert);
+		zert_cu_intc_refresh();
+		return;
+	}
+
+	if (zdev->cu_intc) {
+		zocl_ert_destroy_intc(zdev->cu_intc);
+		zdev->cu_intc = NULL;
+	}
+	zocl_cu_intc_setup(zdev, pdev);
+}
+
+static void zocl_cu_intc_fini(struct drm_zocl_dev *zdev)
+{
+	if (zdev->cu_intc) {
+		zocl_ert_destroy_intc(zdev->cu_intc);
+		zdev->cu_intc = NULL;
+	}
+	zdev->cu_subdev.cu_num = 0;
+}
+
 /*
  *
  * Initialization of Xilinx openCL DRM platform device.
@@ -1330,8 +1390,6 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	struct resource res_mem;
 	struct resource *res;
 	struct device_node *fnode;
-	int index;
-	int irq;
 	int ret;
 	int year, mon, day;
 
@@ -1350,21 +1408,9 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	zdev->slot_mask = 0;
 
 	/* Record and get IRQ number */
-	for (index = 0; index < MAX_CU_NUM; index++) {
-		irq = platform_get_irq(pdev, index);
-		if (irq < 0)
-			break;
-		DRM_DEBUG("CU(%d) IRQ %d\n", index, irq);
-		zdev->cu_subdev.irq[index] = irq;
-	}
-	zdev->cu_subdev.cu_num = index;
-	if (zdev->cu_subdev.cu_num) {
-		ret = zocl_ert_create_intc(&pdev->dev, zdev->cu_subdev.irq,
-					   zdev->cu_subdev.cu_num, 0,
-					   ERT_CU_INTC_DEV_NAME, &zdev->cu_intc);
-		if (ret)
-			DRM_ERROR("Failed to create cu intc device, ret %d\n", ret);
-	}
+	ret = zocl_cu_intc_setup(zdev, pdev);
+	if (ret)
+		DRM_ERROR("Failed to create cu intc device, ret %d\n", ret);
 
 	/* set to 0xFFFFFFFF(32bit) or 0xFFFFFFFFFFFFFFFF(64bit) */
 	zdev->host_mem = (phys_addr_t) -1;
@@ -1404,11 +1450,9 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	if (subdev) {
 		DRM_INFO("ert_hw found: 0x%llx\n", (uint64_t)(uintptr_t)subdev);
 		res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-		if (res) {
+		if (res)
 			zdev->res_start = res->start;
-		}
 
-		zdev->res_start = res->start;
 		zdev->ert = (struct zocl_ert_dev *)platform_get_drvdata(subdev);
 		//ert_hw is present only for PCIe + PS devices (ex: U30,VCK5000
 		//Dont enable new kds for those devices
@@ -1569,7 +1613,7 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 	mutex_destroy(&zdev->mm_lock);
 	zocl_pr_slot_fini(zdev);
 	zdev->slot_mask = 0;
-	zocl_ert_destroy_intc(zdev->cu_intc);
+	zocl_cu_intc_fini(zdev);
 	zocl_fini_sysfs(drm->dev);
 	zocl_fini_error(zdev);
 

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_xclbin.c
@@ -86,6 +86,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	int ret = 0;
 	struct drm_zocl_slot *slot = NULL;
 	uint32_t flags = 0;
+	bool dt_overlay = false;
 	uint8_t hw_gen = axlf_obj->hw_gen;
 
 	/* Download the XCLBIN from user space to kernel space and validate */
@@ -202,6 +203,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 				    slot);
 		if (ret)
 			goto out0;
+		dt_overlay = true;
 
 	} else
 #endif
@@ -319,8 +321,22 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	/* Skip creating CUs for AIE only xclbin */
 	if (!zocl_xclbin_is_aie_only(axlf)) {
+		struct device_node *fpga_np = NULL;
+
 		/* Destroy the CUs specific for this slot */
 		zocl_destroy_cu_slot(zdev, slot->slot_idx);
+
+		/*
+		 * Refresh CU IRQ routing when this xclbin applied a DT overlay
+		 * or when fpga_accelerator was applied earlier (e.g. fpgautil)
+		 * and a plain xclbin is loaded without PARTITION_METADATA.
+		 */
+		fpga_np = of_find_node_by_name(NULL, "fpga_accelerator");
+		if (dt_overlay || (fpga_np &&
+		    of_property_present(fpga_np, "interrupts-extended")))
+			zocl_cu_intc_refresh(zdev);
+		if (fpga_np)
+			of_node_put(fpga_np);
 
 		/* Create the CUs for this slot */
 		ret = zocl_create_cu(zdev, slot);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -348,6 +348,8 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 int zocl_context_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp);
 struct platform_device *zocl_find_pdev(char *name);
+void zocl_cu_intc_refresh(struct drm_zocl_dev *zdev);
+int zert_cu_intc_refresh(void);
 
 static inline struct drm_zocl_dev *
 zocl_get_zdev(void)

--- a/src/runtime_src/core/edge/drm/zocl/zert/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zert/zocl_ctrl_ert.c
@@ -472,10 +472,34 @@ static int zert_cu_intc_init(struct zocl_ctrl_ert *zert)
 	const char *cu_interrupt = "cu_interrupt";
 	struct device_node *np = NULL;
 	struct device_node *parent = NULL;
+	struct device_node *fpga_np = NULL;
 	u32 *irqs = NULL;
 	int num_irq = 0;
 	int ret = 0;
 	int i;
+
+	fpga_np = of_find_node_by_name(NULL, "fpga_accelerator");
+	if (fpga_np && of_property_present(fpga_np, "interrupts-extended")) {
+		num_irq = of_irq_count(fpga_np);
+		if (num_irq > 0) {
+			irqs = kcalloc(num_irq, sizeof(*irqs), GFP_KERNEL);
+			if (!irqs) {
+				of_node_put(fpga_np);
+				return -ENOMEM;
+			}
+			for (i = 0; i < num_irq; i++)
+				irqs[i] = of_irq_get(fpga_np, i);
+			of_node_put(fpga_np);
+			ret = zocl_ert_create_intc(ZERT2DEV(zert), irqs, num_irq, 0,
+						   ERT_CU_INTC_DEV_NAME,
+						   &zert->zce_cu_intc);
+			kfree(irqs);
+			if (ret)
+				zert_err(zert, "Failed to create CU intc device: %d", ret);
+			return ret;
+		}
+	}
+	of_node_put(fpga_np);
 
 	/* TODO: We only have one AXI intc for 32 CU interrupts at the moment */
 	np = of_get_child_by_name(ZERT2DEV(zert)->of_node, cu_interrupt);
@@ -488,13 +512,15 @@ static int zert_cu_intc_init(struct zocl_ctrl_ert *zert)
 	parent = of_irq_find_parent(np);
 	if (!parent) {
 		zert_err(zert, "failed to find CU intc");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out;
 	}
 
 	ret = of_property_read_u32(parent, "xlnx,num-intr-inputs", &num_irq);
 	if (ret < 0) {
 		zert_err(zert, "unable to read xlnx,num-intr-inputs");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out;
 	}
 
 	irqs = kzalloc(sizeof(u32) * num_irq, GFP_KERNEL);
@@ -512,7 +538,27 @@ static int zert_cu_intc_init(struct zocl_ctrl_ert *zert)
 	kfree(irqs);
 
 out:
+	of_node_put(np);
 	return 0;
+}
+
+int zert_cu_intc_refresh(void)
+{
+	struct platform_device *pdev = zocl_find_pdev("ert_hw");
+	struct zocl_ctrl_ert *zert;
+
+	if (!pdev)
+		return -ENODEV;
+
+	zert = platform_get_drvdata(pdev);
+	if (!zert)
+		return -ENODEV;
+
+	if (zert->zce_cu_intc) {
+		zocl_ert_destroy_intc(zert->zce_cu_intc);
+		zert->zce_cu_intc = NULL;
+	}
+	return zert_cu_intc_init(zert);
 }
 
 static int zert_versal_init(struct zocl_ctrl_ert *zert)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
As part of [VITIS-16571](https://jira.xilinx.com/browse/VITIS-16571) / [VITIS-16885](https://jira.xilinx.com/browse/VITIS-16885), CU interrupt routing is moving out of the static zyxclmm_drm node into a driver-agnostic fpga_accelerator node delivered with the RM .dtbo. zocl previously always obtained CU IRQs via platform_get_irq() on zyxclmm_drm at driver probe and never re-probed after a DT overlay update. This commit adds the new probe path, keeps backward compatibility, and refreshes the CU interrupt controller when an xclbin carries a PARTITION_METADATA dtbo overlay.

Created SH ticket: https://jira.xilinx.com/browse/SH-3057

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Read interrupts-extended from the fpga_accelerator overlay node when present, with legacy platform_get_irq fallback, and refresh CU INTC after PARTITION_METADATA overlay apply so DFX xclbin loads pick up updated interrupt routing.

1. zocl_cu_intc_setup() If fpga_accelerator exists and has interrupts-extended, use of_irq_get(fpga_np, index); otherwise fall back to platform_get_irq(pdev, index) on zyxclmm_drm.
2. zocl_cu_intc_refresh() / zocl_cu_intc_fini() Tear down and recreate CU INTC using current live DT state.
3. zocl_edge_xclbin.c After successful PARTITION_METADATA section load, call zocl_cu_intc_refresh() before CU creation so DFX xclbin loads pick up updated overlay IRQ routing.
4. zert_cu_intc_init() / zert_cu_intc_refresh() Same fpga_accelerator probe path for ERT HW (ert_hw) platforms; delegate refresh from zocl when ert_hw is present.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on VEK385 rev b by modifying the dtbo(included fpga_accelerator node with interrupts-extended region)

#### Documentation impact (if any)
