### PR TITLE
xclbinutil: replace boost::factory with lambdas for Boost 1.92 compatibility

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEMetadata.cxx
@@ -17,7 +17,6 @@
 #include "SectionAIEMetadata.h"
 
 #include "XclBinUtilities.h"
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionAIEMetadata::init SectionAIEMetadata::initializer;
 
 SectionAIEMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(AIE_METADATA, "AIE_METADATA", boost::factory<SectionAIEMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_METADATA, "AIE_METADATA", []{ return new SectionAIEMetadata(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);

--- a/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEPartition.cxx
@@ -19,7 +19,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <iostream>
 
@@ -33,7 +32,7 @@ SectionAIEPartition::init SectionAIEPartition::initializer;
 
 SectionAIEPartition::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(AIE_PARTITION, "AIE_PARTITION", boost::factory<SectionAIEPartition*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_PARTITION, "AIE_PARTITION", []{ return new SectionAIEPartition(); });
   sectionInfo->nodeName = "aie_partition";
   sectionInfo->supportsSubSections = true;
   sectionInfo->supportsIndexing = true;

--- a/src/runtime_src/tools/xclbinutil/SectionAIEResources.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResources.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionAIEResources.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionAIEResources::init SectionAIEResources::initializer;
 
 SectionAIEResources::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(AIE_RESOURCES, "AIE_RESOURCES", boost::factory<SectionAIEResources*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_RESOURCES, "AIE_RESOURCES", []{ return new SectionAIEResources(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIEResourcesBin.cxx
@@ -5,7 +5,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -20,7 +19,7 @@ SectionAIEResourcesBin::init SectionAIEResourcesBin::initializer;
 
 SectionAIEResourcesBin::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(AIE_RESOURCES_BIN, "AIE_RESOURCES_BIN", boost::factory<SectionAIEResourcesBin*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_RESOURCES_BIN, "AIE_RESOURCES_BIN", []{ return new SectionAIEResourcesBin(); });
   sectionInfo->supportsSubSections = true;
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::obj));
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::metadata));

--- a/src/runtime_src/tools/xclbinutil/SectionAIETraceMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionAIETraceMetadata.cxx
@@ -17,7 +17,6 @@
 #include "SectionAIETraceMetadata.h"
 
 #include "XclBinUtilities.h"
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionAIETraceMetadata::init SectionAIETraceMetadata::initializer;
 
 SectionAIETraceMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(AIE_TRACE_METADATA, "AIE_TRACE_METADATA", boost::factory<SectionAIETraceMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(AIE_TRACE_METADATA, "AIE_TRACE_METADATA", []{ return new SectionAIETraceMetadata(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);

--- a/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBMC.cxx
@@ -19,7 +19,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -34,7 +33,7 @@ SectionBMC::init SectionBMC::initializer;
 
 SectionBMC::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(BMC, "BMC", boost::factory<SectionBMC*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(BMC, "BMC", []{ return new SectionBMC(); });
   sectionInfo->supportsSubSections = true;
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::fw));
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::metadata));

--- a/src/runtime_src/tools/xclbinutil/SectionBitstream.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstream.cxx
@@ -17,7 +17,6 @@
 #include "SectionBitstream.h"
 
 #include "XclBinUtilities.h"
-#include <boost/functional/factory.hpp>
 
 namespace XUtil = XclBinUtilities;
 
@@ -26,7 +25,7 @@ SectionBitstream::init SectionBitstream::initializer;
 
 SectionBitstream::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(BITSTREAM, "BITSTREAM", boost::factory<SectionBitstream*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(BITSTREAM, "BITSTREAM", []{ return new SectionBitstream(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBitstreamPartialPDI.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionBitstreamPartialPDI.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionBitstreamPartialPDI::init SectionBitstreamPartialPDI::initializer;
 
 SectionBitstreamPartialPDI::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", boost::factory<SectionBitstreamPartialPDI*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", []{ return new SectionBitstreamPartialPDI(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionBuildMetadata.cxx
@@ -5,7 +5,6 @@
 #include "XclBinUtilities.h"
 #include "xrt/detail/version.h"
 
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -15,7 +14,7 @@ SectionBuildMetadata::init SectionBuildMetadata::initializer;
 
 SectionBuildMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(BUILD_METADATA, "BUILD_METADATA", boost::factory<SectionBuildMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(BUILD_METADATA, "BUILD_METADATA", []{ return new SectionBuildMetadata(); });
   sectionInfo->nodeName = "build_metadata";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionClearBitstream.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionClearBitstream.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionClearBitstream.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionClearBitstream::init SectionClearBitstream::initializer;
 
 SectionClearBitstream::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", boost::factory<SectionClearBitstream*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", []{ return new SectionClearBitstream(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionClockFrequencyTopology.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <iostream>
 #include <stdint.h>
 
@@ -29,7 +28,7 @@ SectionClockFrequencyTopology::init SectionClockFrequencyTopology::initializer;
 
 SectionClockFrequencyTopology::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", boost::factory<SectionClockFrequencyTopology*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", []{ return new SectionClockFrequencyTopology(); });
   sectionInfo->nodeName = "clock_freq_topology";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionConnectivity.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionConnectivity.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <iostream>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionConnectivity::init SectionConnectivity::initializer;
 
 SectionConnectivity::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(CONNECTIVITY, "CONNECTIVITY", boost::factory<SectionConnectivity*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(CONNECTIVITY, "CONNECTIVITY", []{ return new SectionConnectivity(); });
   sectionInfo->nodeName = "connectivity";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionDNACertificate.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDNACertificate.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <string>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionDNACertificate::init SectionDNACertificate::initializer;
 
 SectionDNACertificate::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(DNA_CERTIFICATE, "DNA_CERTIFICATE", boost::factory<SectionDNACertificate*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(DNA_CERTIFICATE, "DNA_CERTIFICATE", []{ return new SectionDNACertificate(); });
 
   // Add format support empty (no support)
 

--- a/src/runtime_src/tools/xclbinutil/SectionDTBO.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDTBO.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionDTBO.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionDTBO::init SectionDTBO::initializer;
 
 SectionDTBO::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(DTBO, "DTBO", boost::factory<SectionDTBO*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(DTBO, "DTBO", []{ return new SectionDTBO(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionDebugData.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugData.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionDebugData.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionDebugData::init SectionDebugData::initializer;
 
 SectionDebugData::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(DEBUG_DATA, "DEBUG_DATA", boost::factory<SectionDebugData*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(DEBUG_DATA, "DEBUG_DATA", []{ return new SectionDebugData(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <iostream>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionDebugIPLayout::init SectionDebugIPLayout::initializer;
 
 SectionDebugIPLayout::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", boost::factory<SectionDebugIPLayout*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", []{ return new SectionDebugIPLayout(); });
   sectionInfo->nodeName = "debug_ip_layout";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDesignCheckPoint.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionDesignCheckPoint.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionDesignCheckPoint::init SectionDesignCheckPoint::initializer;
 
 SectionDesignCheckPoint::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", boost::factory<SectionDesignCheckPoint*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", []{ return new SectionDesignCheckPoint(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionEmbeddedMetadata.cxx
@@ -17,7 +17,6 @@
 #include "SectionEmbeddedMetadata.h"
 
 #include "XclBinUtilities.h"
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -27,7 +26,7 @@ SectionEmbeddedMetadata::init SectionEmbeddedMetadata::initializer;
 
 SectionEmbeddedMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(EMBEDDED_METADATA, "EMBEDDED_METADATA", boost::factory<SectionEmbeddedMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(EMBEDDED_METADATA, "EMBEDDED_METADATA", []{ return new SectionEmbeddedMetadata(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionEmulationData.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionEmulationData.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionEmulationData.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionEmulationData::init SectionEmulationData::initializer;
 
 SectionEmulationData::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(EMULATION_DATA, "EMULATION_DATA", boost::factory<SectionEmulationData*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(EMULATION_DATA, "EMULATION_DATA", []{ return new SectionEmulationData(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionFlash.cxx
@@ -6,7 +6,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -21,7 +20,7 @@ SectionFlash::init SectionFlash::initializer;
 
 SectionFlash::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(ASK_FLASH, "FLASH", boost::factory<SectionFlash*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(ASK_FLASH, "FLASH", []{ return new SectionFlash(); });
   sectionInfo->supportsSubSections = true;
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::data));
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::metadata));

--- a/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupConnectivity.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <iostream>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionGroupConnectivity::init SectionGroupConnectivity::initializer;
 
 SectionGroupConnectivity::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(ASK_GROUP_CONNECTIVITY, "GROUP_CONNECTIVITY", boost::factory<SectionGroupConnectivity*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(ASK_GROUP_CONNECTIVITY, "GROUP_CONNECTIVITY", []{ return new SectionGroupConnectivity(); });
   sectionInfo->nodeName = "group_connectivity";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <iostream>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionGroupTopology::init SectionGroupTopology::initializer;
 
 SectionGroupTopology::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(ASK_GROUP_TOPOLOGY, "GROUP_TOPOLOGY", boost::factory<SectionGroupTopology*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(ASK_GROUP_TOPOLOGY, "GROUP_TOPOLOGY", []{ return new SectionGroupTopology(); });
   sectionInfo->nodeName = "group_topology";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <iostream>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionIPLayout::init SectionIPLayout::initializer;
 
 SectionIPLayout::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(IP_LAYOUT, "IP_LAYOUT", boost::factory<SectionIPLayout*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(IP_LAYOUT, "IP_LAYOUT", []{ return new SectionIPLayout(); });
   sectionInfo->nodeName = "ip_layout";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionIPMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionIPMetadata.cxx
@@ -19,7 +19,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -29,7 +28,7 @@ SectionIPMetadata::init SectionIPMetadata::initializer;
 
 SectionIPMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(IP_METADATA, "IP_METADATA", boost::factory<SectionIPMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(IP_METADATA, "IP_METADATA", []{ return new SectionIPMetadata(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionKeyValueMetadata.cxx
@@ -17,7 +17,6 @@
 #include "SectionKeyValueMetadata.h"
 
 #include "XclBinUtilities.h"
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -27,7 +26,7 @@ SectionKeyValueMetadata::init SectionKeyValueMetadata::initializer;
 
 SectionKeyValueMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(KEYVALUE_METADATA, "KEYVALUE_METADATA", boost::factory<SectionKeyValueMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(KEYVALUE_METADATA, "KEYVALUE_METADATA", []{ return new SectionKeyValueMetadata(); });
   sectionInfo->nodeName = "keyvalue_metadata";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMCS.cxx
@@ -20,7 +20,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 
 // Disable windows compiler warnings
 #ifdef _WIN32
@@ -35,7 +34,7 @@ SectionMCS::init SectionMCS::initializer;
 
 SectionMCS::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(MCS, "MCS", boost::factory<SectionMCS*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(MCS, "MCS", []{ return new SectionMCS(); });
   sectionInfo->supportsSubSections = true;
   sectionInfo->subSections.push_back(getSubSectionName(MCS_PRIMARY));
   sectionInfo->subSections.push_back(getSubSectionName(MCS_SECONDARY));

--- a/src/runtime_src/tools/xclbinutil/SectionManagementFW.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionManagementFW.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionManagementFW.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionManagementFW::init SectionManagementFW::initializer;
 
 SectionManagementFW::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(FIRMWARE, "FIRMWARE", boost::factory<SectionManagementFW*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(FIRMWARE, "FIRMWARE", []{ return new SectionManagementFW(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <iostream>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionMemTopology::init SectionMemTopology::initializer;
 
 SectionMemTopology::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(MEM_TOPOLOGY, "MEM_TOPOLOGY", boost::factory<SectionMemTopology*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(MEM_TOPOLOGY, "MEM_TOPOLOGY", []{ return new SectionMemTopology(); });
   sectionInfo->nodeName = "mem_topology";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionOverlay.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionOverlay::init SectionOverlay::initializer;
 
 SectionOverlay::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(OVERLAY, "OVERLAY", boost::factory<SectionOverlay*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(OVERLAY, "OVERLAY", []{ return new SectionOverlay(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionPDI.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPDI.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionPDI.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionPDI::init SectionPDI::initializer;
 
 SectionPDI::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(PDI, "PDI", boost::factory<SectionPDI*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(PDI, "PDI", []{ return new SectionPDI(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -31,7 +30,7 @@ SectionPartitionMetadata::init SectionPartitionMetadata::initializer;
 
 SectionPartitionMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(PARTITION_METADATA, "PARTITION_METADATA", boost::factory<SectionPartitionMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(PARTITION_METADATA, "PARTITION_METADATA", []{ return new SectionPartitionMetadata(); });
   sectionInfo->nodeName = "partition_metadata";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSchedulerFW.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionSchedulerFW.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionSchedulerFW::init SectionSchedulerFW::initializer;
 
 SectionSchedulerFW::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(SCHED_FIRMWARE, "SCHED_FIRMWARE", boost::factory<SectionSchedulerFW*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(SCHED_FIRMWARE, "SCHED_FIRMWARE", []{ return new SectionSchedulerFW(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
@@ -26,7 +26,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/hex.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <filesystem>
 #include <fstream>
@@ -40,7 +39,7 @@ SectionSmartNic::init SectionSmartNic::initializer;
 
 SectionSmartNic::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(SMARTNIC, "SMARTNIC", boost::factory<SectionSmartNic*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(SMARTNIC, "SMARTNIC", []{ return new SectionSmartNic(); });
   sectionInfo->nodeName = "smartnic";
 
   sectionInfo->supportedAddFormats.push_back(FormatType::json);

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -6,7 +6,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -21,7 +20,7 @@ SectionSoftKernel::init SectionSoftKernel::initializer;
 
 SectionSoftKernel::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(SOFT_KERNEL, "SOFT_KERNEL", boost::factory<SectionSoftKernel*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(SOFT_KERNEL, "SOFT_KERNEL", []{ return new SectionSoftKernel(); });
   sectionInfo->supportsSubSections = true;
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::obj));
   sectionInfo->subSections.push_back(getSubSectionName(SubSection::metadata));

--- a/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
@@ -18,7 +18,6 @@
 
 #include "XclBinUtilities.h"
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -28,7 +27,7 @@ SectionSystemMetadata::init SectionSystemMetadata::initializer;
 
 SectionSystemMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(SYSTEM_METADATA, "SYSTEM_METADATA", boost::factory<SectionSystemMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(SYSTEM_METADATA, "SYSTEM_METADATA", []{ return new SectionSystemMetadata(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionUserMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionUserMetadata.cxx
@@ -16,14 +16,13 @@
 
 #include "SectionUserMetadata.h"
 
-#include <boost/functional/factory.hpp>
 
 // Static Variables / Classes
 SectionUserMetadata::init SectionUserMetadata::initializer;
 
 SectionUserMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(USER_METADATA, "USER_METADATA", boost::factory<SectionUserMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(USER_METADATA, "USER_METADATA", []{ return new SectionUserMetadata(); });
 
   sectionInfo->supportedAddFormats.push_back(FormatType::raw);
 

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -5,7 +5,6 @@
 #include "XclBinUtilities.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/functional/factory.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 namespace XUtil = XclBinUtilities;
@@ -20,7 +19,7 @@ SectionVenderMetadata::init SectionVenderMetadata::initializer;
 
 SectionVenderMetadata::init::init()
 {
-  auto sectionInfo = std::make_unique<SectionInfo>(VENDER_METADATA, "VENDER_METADATA", boost::factory<SectionVenderMetadata*>());
+  auto sectionInfo = std::make_unique<SectionInfo>(VENDER_METADATA, "VENDER_METADATA", []{ return new SectionVenderMetadata(); });
   sectionInfo->supportsSubSections = true;
 
   // There is only one-subsection that is supported.  By default it is not named.


### PR DESCRIPTION
#### Problem solved by the commit

`boost/functional/factory.hpp` and `boost::factory<T*>()` were removed in Boost 1.92. GitHub Actions Windows runners upgraded to Boost 1.92, causing the Windows build of `xclbinutil` to fail with C1083 (cannot open include file) errors across all 37 `Section*.cxx` files.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Discovered via CI failures on Windows public GitHub runners after the Boost version was bumped from 1.91 to 1.92.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Replaced `boost::factory<T*>()` with an equivalent C++ lambda `[]{ return new T(); }` in all 37 `Section*.cxx` files, and removed the now-unnecessary `#include <boost/functional/factory.hpp>`.

The `Section_factory` type alias is already `std::function<Section*()>`, so a zero-capture lambda is a direct drop-in with no behavior change. No other alternatives were considered — this is the canonical replacement for the removed Boost utility.

#### Risks (if any) associated the changes in the commit

None. The lambda is semantically identical to `boost::factory<T*>()` for this usage pattern (default-constructing a heap-allocated object).

#### What has been tested and how, request additional testing if necessary

CI on Windows with Boost 1.92 (the failing configuration). Please verify Linux build as well.

#### Documentation impact (if any)

None.