### PR TITLE
Fix postinst shell test syntax for alveo checks

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -43,6 +43,7 @@ rmmodules()
 
 installdir=@CMAKE_INSTALL_PREFIX@
 systemddir=/etc/systemd/system
+# 0 = Alveo package (dkms.conf present); non-zero = skip Alveo/DKMS install
 test -e /usr/src/xrt-@XRT_VERSION_STRING@/dkms.conf
 alveo=$?
 
@@ -80,12 +81,12 @@ done
 rmmodules
 
 DRACUT_CONF_PATH=/etc/dracut.conf.d
-if [ -e $DRACUT_CONF_PATH ] && [ $alveo == 1]; then
-    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/userpf/xocl.dracut.conf $DRACUT_CONF_PATH
-    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/mgmtpf/xclmgmt.dracut.conf $DRACUT_CONF_PATH
+if [ -d "$DRACUT_CONF_PATH" ] && [ "$alveo" -eq 0 ]; then
+    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/userpf/xocl.dracut.conf "$DRACUT_CONF_PATH"
+    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/mgmtpf/xclmgmt.dracut.conf "$DRACUT_CONF_PATH"
 fi
 
-if [ $alveo == 0]; then
+if [ "$alveo" -ne 0 ]; then
     echo "Skipping XRT Alveo driver install"
     exit 0
 fi


### PR DESCRIPTION
Correct missing spaces before ']' in test expressions that caused "[: missing ]" errors during xrt package post-install.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix shell syntax errors in the XRT Debian postinst script that caused [: missing ] failures during package installation.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add required space before ]. Quote "$alveo" for safe expansion. Use -eq instead of == for numeric comparison in POSIX [
#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary
Tested on ubuntu 26.04

#### Documentation impact (if any)
NA
