### PR TITLE
Fix self-deadlock on hw_context m_mutex when XDP re-enters add_config().

### DIFF
--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -273,6 +273,10 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
   // init_from_elf() - Initialize this hwctx from an ELF
   // This function is called if and only if the hwctx has no
   // underlying representation (no m_hdl).
+  //
+  // The caller (add_config()) is responsible for calling
+  // xdp::update_device() once this function has returned and the
+  // hwctx lock has been released.
   void
   init_from_elf(const xrt::elf& elf, uint32_t partition_size)
   {
@@ -281,10 +285,6 @@ class hw_context_impl : public std::enable_shared_from_this<hw_context_impl>
     update_from_elf(elf);
     m_elf_flow = true; // ELF flow
     m_uc_log_buf = init_uc_log_buf(m_core_device, m_hdl.get()); // create only for first config
-
-    // XDP configuration is required only once,
-    // as all the elfs in one HWCtx will have the same partition size
-    xrt_core::xdp::update_device(this, true);
   }
 
   // Amend configuration parameters 
@@ -487,20 +487,37 @@ public:
   add_config(const xrt::elf& elf)
   {
     auto part_size = elf.get_partition_size();
+    bool initialized = false;
 
-    // The lock must be held here to prevent race on m_hdl
-    // in case it is created in init_from_elf(). The lock
-    // also protects updated data structures.
-    std::lock_guard lk(m_mutex);
-    if (m_hdl && m_partition_size != part_size)
-      throw std::runtime_error("can not add config to ctx with different configuration\n");
+    {
+      // The lock must be held here to prevent race on m_hdl
+      // in case it is created in init_from_elf(). The lock
+      // also protects updated data structures.
+      std::lock_guard lk(m_mutex);
+      if (m_hdl && m_partition_size != part_size)
+        throw std::runtime_error("can not add config to ctx with different configuration\n");
 
-    if (m_hdl)
-      // Add ELF kernels to elf map. Throws if kernel already in map
-      update_from_elf(elf);
-    else
-      // Intialize this hwctx, and add kernels
-      init_from_elf(elf, part_size);
+      if (m_hdl) {
+        // Add ELF kernels to elf map. Throws if kernel already in map
+        update_from_elf(elf);
+      }
+      else {
+        // Intialize this hwctx, and add kernels
+        init_from_elf(elf, part_size);
+        initialized = true;
+      }
+    }
+
+    // XDP configuration is required only once, as all the elfs in one
+    // HWCtx will have the same partition size.
+    //
+    // This must run with m_mutex released. The profiling plugins call
+    // back into this hwctx from their hooks, both to read the
+    // configuration elfs and to register their own control code elf via
+    // add_config(). m_mutex is not recursive, so invoking the hooks with
+    // it held self deadlocks the calling thread.
+    if (initialized)
+      xrt_core::xdp::update_device(this, true);
   }
 
   void


### PR DESCRIPTION
#### Problem solved by the commit
Full-ELF designs hang during hardware-context setup when XDP profiling is enabled.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug came in with the full-ELF XDP hook: init_from_elf() calls xrt_core::xdp::update_device(), and its only caller add_config() holds m_mutex across that call. Discovered on VEK385 while validating XDP profiling on full-ELF designs — runs with aie_trace/aie_profile hung before inference and left the AIE partition claimed, requiring a board re-flash. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
m_mutex is now held only around the mutation. add_config() records whether the call performed the initialization, releases the lock, and then calls xdp::update_device(); the call is removed from init_from_elf(), which documents that the caller owns it.

#### Risks (if any) associated the changes in the commit
Low. The lock still covers m_hdl creation and all data-structure updates, so no new race is introduced; only the XDP notification moved. The notification remains one-shot per context via the initialized latch, so XDP's re-entrant add_config() calls take the update_from_elf() branch and do not recurse. 

#### What has been tested and how, request additional testing if necessary
Verified on VEK385 (VE2) hardware with two unrelated full-ELF designs, across all combinations of aie_trace, aie_profile, and ml_timeline. No hangs occurred, and instrumentation output is produced in each case.