### PR TITLE
Security fixes for AIE info parsing (leet audit)

### DIFF
--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -773,13 +773,16 @@ populate_buffer_only_cores(const boost::property_tree::ptree& pt,
       continue;
 
     boost::property_tree::ptree igraph;
-    auto dma_row_it = g_node.second.get_child("dma_rows", empty_pt).begin();
+    const auto& dma_rows = g_node.second.get_child("dma_rows", empty_pt);
+    auto dma_row_it = dma_rows.begin();
     for (const auto& node : g_node.second.get_child("dma_columns", empty_pt)) {
+      if (dma_row_it == dma_rows.end())
+        throw std::runtime_error("aie_metadata: dma_rows shorter than dma_columns");
+
       boost::property_tree::ptree tile;
       tile.put("column", (std::stoul(node.second.data()) +  start_col));
       tile.put("row", dma_row_it->second.data());
-      if (dma_row_it != g_node.second.end())
-        dma_row_it++;
+      dma_row_it++;
       // Check whether this core is already added
       if (is_duplicate_core(tile_array, tile))
         continue;
@@ -910,11 +913,18 @@ populate_aie_from_metadata(const xrt_core::device* device, boost::property_tree:
     int gr_id = igraph.get<int>("id");
     ograph.put("name", igraph.get<std::string>("name"));
     ograph.put("status", graph_status_to_string(gh_status.get<int>("graphs." + igraph.get<std::string>("name"), -1)));
+    const auto& core_cols = gr.second.get_child("core_columns", empty_pt);
+    if (gr.second.get_child("core_rows", empty_pt).size() != core_cols.size() ||
+        gr.second.get_child("iteration_memory_columns", empty_pt).size() != core_cols.size() ||
+        gr.second.get_child("iteration_memory_rows", empty_pt).size() != core_cols.size() ||
+        gr.second.get_child("iteration_memory_addresses", empty_pt).size() != core_cols.size())
+      throw std::runtime_error("aie_metadata: mismatched array sizes in graph");
+
     auto row_it = gr.second.get_child("core_rows").begin();
     auto memcol_it = gr.second.get_child("iteration_memory_columns").begin();
     auto memrow_it = gr.second.get_child("iteration_memory_rows").begin();
     auto memaddr_it = gr.second.get_child("iteration_memory_addresses").begin();
-    for (const auto& node : gr.second.get_child("core_columns", empty_pt)) {
+    for (const auto& node : core_cols) {
       boost::property_tree::ptree tile;
       tile.put("column", (std::stoul(node.second.data()) + start_col));
       tile.put("row", row_it->second.data());

--- a/src/runtime_src/core/common/info_aie2.cpp
+++ b/src/runtime_src/core/common/info_aie2.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #define XRT_CORE_COMMON_SOURCE
 #include "info_aie2.h"
@@ -744,6 +744,10 @@ get_aie_data(const xrt_core::device* device, const aie_tiles_info& info, aie_til
   if (tiles_status.cols_filled == 0)
     throw std::runtime_error("No open HW-Context\n");
 
+  // validate driver response: reject cols_filled bits beyond info.cols
+  if (tiles_status.cols_filled >> info.cols)
+    throw std::runtime_error("aie_tiles_status: cols_filled has bits set beyond info.cols");
+
   std::vector<aie2::aie_tiles_status> aie_status_vec;
 
   // Allocate an entry for each active column
@@ -755,6 +759,10 @@ get_aie_data(const xrt_core::device* device, const aie_tiles_info& info, aie_til
 
     cols_filled >>= 1;
   }
+
+  // use the already-computed column count to validate buffer size
+  if (tiles_status.buf.size() < aie_status_vec.size() * info.col_size)
+    throw std::runtime_error("aie_tiles_status: buffer too small for reported cols_filled");
 
   switch (tile_type) {
     case aie_tile_type::core:


### PR DESCRIPTION
#### Problem solved by the commit

Two heap out-of-bounds reads in the AIE status and metadata reporting
paths, both driven by device/firmware-supplied data without adequate
bounds validation.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Discovered by internal AI-assisted security audit (leet campaign, reporter: obittner).

- **AIESW-42790** `core/common/info_aie2.cpp`: `get_aie_data()` passed
  `tiles_status.buf` and `tiles_status.cols_filled` from the driver to
  three parse functions without checking that `cols_filled` has no bits
  set above `info.cols`, or that `buf.size() >= active_cols * col_size`.
  A short buffer or over-wide `cols_filled` caused `memcpy` to read past
  the heap allocation backing `buf`.

- **AIESW-42789** `core/common/info_aie.cpp`: `populate_aie_from_metadata()`
  drove four parallel iterators solely by the length of `core_columns`
  with no end-of-range check on the sibling arrays, allowing a crafted
  xclbin AIE_METADATA section to trigger OOB iterator dereference.
  `populate_buffer_only_cores()` checked `dma_row_it` against the wrong
  container's `end()` and did so after the dereference.

#### How problem was solved, alternative solutions (if any) and why they were rejected

- **42790**: Added two pre-parse checks in `get_aie_data()` after the
  driver query: reject `cols_filled` bits above `info.cols`, and reject
  buffers smaller than `aie_status_vec.size() * info.col_size`. The
  active-column count reuses the value already computed by the existing
  bit-counting loop — no platform-specific popcount needed.

- **42789**: Validate that all sibling arrays match `core_columns` size
  before iterating and throw on mismatch. In `populate_buffer_only_cores()`,
  capture `dma_rows`' own end iterator and check before each dereference.

#### Risks (if any) associated the changes in the commit

Both changes throw on malformed metadata that was previously silently
accepted, producing a clean error rather than heap corruption. Legitimate
device responses are unaffected.

#### What has been tested and how, request additional testing if necessary

Code review only. Please run AIE status reporting tests and `xbutil examine -r aie`
against devices with single- and multi-column AIE configurations.

#### Documentation impact (if any)

None.