### PR TITLE
[AIESW-42724] TestRunner.cpp: detached thread writes dangling stack refs

### DIFF
--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -135,7 +135,7 @@ TestRunner::startTest(const std::shared_ptr<xrt_core::device>& dev,
     if (ctx->error)
       std::rethrow_exception(ctx->error);
 
-    result = std::move(ctx->result);
+    result = ctx->result;
   }
 
   return result;

--- a/src/runtime_src/core/tools/common/TestRunner.cpp
+++ b/src/runtime_src/core/tools/common/TestRunner.cpp
@@ -26,6 +26,8 @@ namespace xq = xrt_core::query;
 #include <thread>
 #include <csignal>
 #include <atomic>
+#include <exception>
+#include <memory>
 
 static constexpr std::chrono::seconds max_test_duration = std::chrono::seconds(60 * 5); //5 minutes
 std::atomic<bool> force_exit(false);
@@ -42,15 +44,32 @@ signal_handler(int signal) {
   }
 }
 
-static void
-runTestInternal(const std::shared_ptr<xrt_core::device>& dev,
-                boost::property_tree::ptree& ptree,
-                TestRunner* test,
-                bool& is_thread_running,
-                const xrt_core::archive* archive = nullptr)
+// Everything the worker thread touches lives here. The worker is detached when
+// the watchdog fires or the user interrupts, so it must not reference the
+// startTest() stack frame or anything owned by the caller; holding the context
+// by shared_ptr keeps all of it alive for as long as the worker runs.
+struct test_context
 {
-  ptree = test->run(dev, archive);
-  is_thread_running = false;
+  std::shared_ptr<xrt_core::device> dev;
+  std::shared_ptr<TestRunner> test;
+  std::shared_ptr<const xrt_core::archive> archive;
+  boost::property_tree::ptree result;
+  std::exception_ptr error;
+  std::atomic<bool> running{true};
+};
+
+static void
+runTestInternal(const std::shared_ptr<test_context>& ctx)
+{
+  // An exception escaping a thread function terminates the process, so hand it
+  // back through the context and let the joining side rethrow it.
+  try {
+    ctx->result = ctx->test->run(ctx->dev, ctx->archive.get());
+  }
+  catch (...) {
+    ctx->error = std::current_exception();
+  }
+  ctx->running = false;
 }
 
 } //end anonymous namespace
@@ -78,7 +97,7 @@ TestRunner::run(const std::shared_ptr<xrt_core::device>& dev)
 
 boost::property_tree::ptree
 TestRunner::startTest(const std::shared_ptr<xrt_core::device>& dev, 
-                      const xrt_core::archive* archive, 
+                      std::shared_ptr<const xrt_core::archive> archive, 
                       unsigned int iter)
 {
   boost::property_tree::ptree result;
@@ -86,12 +105,16 @@ TestRunner::startTest(const std::shared_ptr<xrt_core::device>& dev,
   for (unsigned int i = 0; i < iter; ++i) {
     XBUtilities::BusyBar busy_bar("Running Test", std::cout);
     busy_bar.start(XBUtilities::is_escape_codes_disabled());
-    bool is_thread_running = true;
+
+    auto ctx = std::make_shared<test_context>();
+    ctx->dev = dev;
+    ctx->test = shared_from_this();
+    ctx->archive = archive;
 
     // Start the test process
-    std::thread test_thread([&] { runTestInternal(dev, result, this, is_thread_running, archive); });
+    std::thread test_thread([ctx] { runTestInternal(ctx); });
     // Wait for the test process to finish or for the signal to be caught
-    while (is_thread_running && !force_exit) {
+    while (ctx->running && !force_exit) {
       std::this_thread::sleep_for(std::chrono::seconds(1));
       try {
         busy_bar.check_timeout(max_test_duration);
@@ -108,6 +131,11 @@ TestRunner::startTest(const std::shared_ptr<xrt_core::device>& dev,
 
     test_thread.join();
     busy_bar.finish();
+
+    if (ctx->error)
+      std::rethrow_exception(ctx->error);
+
+    result = std::move(ctx->result);
   }
 
   return result;

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -29,7 +29,7 @@ namespace xrt_core {
   class archive; 
 }
 
-class TestRunner : public JSONConfigurable {
+class TestRunner : public JSONConfigurable, public std::enable_shared_from_this<TestRunner> {
   public:
     // Default forwards to archive overload; legacy tests override only run(dev).
     virtual boost::property_tree::ptree run(const std::shared_ptr<xrt_core::device>& dev);
@@ -41,8 +41,11 @@ class TestRunner : public JSONConfigurable {
       return run(dev);
     }
     
+    // Requires the TestRunner to be owned by a shared_ptr: a test that times
+    // out keeps running in a detached thread which must not outlive its
+    // referents, so the worker takes shared ownership of them.
     boost::property_tree::ptree startTest(const std::shared_ptr<xrt_core::device>&,
-                                          const xrt_core::archive* archive,
+                                          std::shared_ptr<const xrt_core::archive> archive,
                                           unsigned int iter);
     
     virtual void set_param(const std::string&, const std::string&) {}

--- a/src/runtime_src/core/tools/common/TestRunner.h
+++ b/src/runtime_src/core/tools/common/TestRunner.h
@@ -80,6 +80,14 @@ class TestRunner : public JSONConfigurable, public std::enable_shared_from_this<
   public:
     virtual ~TestRunner() = default;
 
+    // Instances must stay shared_ptr owned so that startTest() can hand the
+    // worker thread a strong reference; a copy would not be owned by that
+    // shared_ptr and shared_from_this() would throw on it.
+    TestRunner(const TestRunner&) = delete;
+    TestRunner(TestRunner&&) = delete;
+    TestRunner& operator=(const TestRunner&) = delete;
+    TestRunner& operator=(TestRunner&&) = delete;
+
 };
   
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -302,7 +302,9 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   if (testObjectsToRun.empty())
     throw std::runtime_error("No test given to validate against.");
 
-  auto test_archive = XBU::open_archive(device.get());
+  // Shared ownership: a test that times out keeps running in a detached thread
+  // which may still be using the archive after this function returns.
+  std::shared_ptr<const xrt_core::archive> test_archive = XBU::open_archive(device.get());
 
   get_platform_info(device, ptDeviceInfo, schemaVersion, std::cout);
   std::cout << "-------------------------------------------------------------------------------" << std::endl;
@@ -315,8 +317,8 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     boost::property_tree::ptree ptTest;
     pretty_print_test_desc(testPtr, ptTest, test_idx, std::cout, xq::pcie_bdf::to_string(bdf));
     try {
-      // Call startTest with archive if available, otherwise use standard call; pass iter_count for repeated runs
-      ptTest = test_archive ? testPtr->startTest(device, test_archive.get(), iter_count) : testPtr->startTest(device, nullptr, iter_count);
+      // Archive is null on devices that don't provide one; pass iter_count for repeated runs
+      ptTest = testPtr->startTest(device, test_archive, iter_count);
     } catch (const std::runtime_error& e) {
       std::cout << e.what() << std::endl;
       return test_status::failed;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[AIESW-42724](https://jira.xilinx.com/browse/AIESW-42724) TestRunner.cpp: detached thread writes dangling stack refs

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Mythos scan

#### How problem was solved, alternative solutions (if any) and why they were rejected
TestRunner::startTest() spawned its worker with a capture-by-reference lambda and detached it when the watchdog fired or the user pressed Ctrl+C. The frame then unwound, so a worker that later returned from test->run() wrote the result ptree into a dead stack slot and dereferenced the archive already freed by the caller.

Give the worker shared ownership of everything it touches via a test_context held by shared_ptr, so a detached worker can no longer outlive its referents. TestRunner gains enable_shared_from_this and startTest() takes the archive as a shared_ptr.

Also make the thread-running flag atomic (it was a plain bool raced between the worker and the polling loop) and propagate an exception from the worker through the context instead of letting it escape the thread function and terminate the process.

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
tested on linux (no behavior change)

#### Documentation impact (if any)
N/A
