### PR TITLE
 remove rave1 support in xrt 2026.2 and further

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2653,11 +2653,6 @@ struct xocl_subdev_map {
 		XOCL_DEVINFO_ICAP_USER,					\
 	 })
 
-#define RES_USER_RAVE_VSEC						\
-	((struct xocl_subdev_info []) {					\
-		XOCL_DEVINFO_FEATURE_ROM_USER_DYN,			\
-		XOCL_DEVINFO_ICAP_USER,					\
-	 })
 
 #define RES_MGMT_U2_VSEC						\
 	((struct xocl_subdev_info []) {					\
@@ -2916,28 +2911,6 @@ struct xocl_subdev_map {
 		.vbnv       = "xilinx_v80"				\
 	}
 
-#define	XOCL_BOARD_RAVE_MGMT_RAPTOR2					\
-	(struct xocl_board_private){					\
-		.flags = XOCL_DSAFLAG_VERSAL |				\
-			XOCL_DSAFLAG_FIXED_INTR |			\
-			XOCL_DSAFLAG_DYNAMIC_IP |			\
-			XOCL_DSAFLAG_EEMI_API_SRST,			\
-		.subdev_info = RES_MGMT_VSEC,				\
-		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
-		.flash_type = FLASH_TYPE_OSPI_VERSAL,			\
-		.board_name = "rave",				\
-		.vbnv       = "emb-plus"				\
-	}
-#define	XOCL_BOARD_RAVE_USER_RAPTOR2_ES3				\
-	(struct xocl_board_private){					\
-		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
-			XOCL_DSAFLAG_VERSAL_ES3 |			\
-			XOCL_DSAFLAG_VERSAL,				\
-		.subdev_info = RES_USER_RAVE_VSEC,			\
-		.subdev_num = ARRAY_SIZE(RES_USER_RAVE_VSEC),		\
-		.board_name = "rave",				\
-		.vbnv       = "emb-plus"				\
-	}
 
 #define	XOCL_BOARD_AVALON_USER_RAPTOR2				\
 	(struct xocl_board_private){					\
@@ -3402,6 +3375,7 @@ struct xocl_subdev_map {
 		.flash_type = FLASH_TYPE_QSPIPS_X4_SINGLE,		\
 	}
 
+
 #define	XOCL_MGMT_PCI_IDS						\
 	{ XOCL_PCI_DEVID(0x10EE, 0x4A47, PCI_ANY_ID, MGMT_DEFAULT) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x4A87, PCI_ANY_ID, MGMT_DEFAULT) },	\
@@ -3442,8 +3416,6 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5094, PCI_ANY_ID, V70_MGMT_RAPTOR2) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x50B0, PCI_ANY_ID, V70_MGMT_RAPTOR2) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x50B4, PCI_ANY_ID, V80_MGMT_RAPTOR2) },	\
-	{ XOCL_PCI_DEVID(0x10EE, 0x5700, PCI_ANY_ID, RAVE_MGMT_RAPTOR2) },	\
-	{ XOCL_PCI_DEVID(0x10EE, 0x5710, PCI_ANY_ID, RAVE_MGMT_RAPTOR2) },      \
 	{ XOCL_PCI_DEVID(0x10EE, 0x6098, PCI_ANY_ID, VCK190_MGMT_RAPTOR2) },    \
 	{ XOCL_PCI_DEVID(0x10EE, 0xE098, PCI_ANY_ID, XBB_MFG_VCK190) },		\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5078, PCI_ANY_ID, VERSAL_MGMT_RAPTOR2) },	\
@@ -3518,8 +3490,6 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5095, PCI_ANY_ID, V70_USER_RAPTOR2_ES3) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0x50B1, PCI_ANY_ID, V70_USER_RAPTOR2_ES3) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0x50B5, PCI_ANY_ID, V80_USER_RAPTOR2_ES3) }, \
-	{ XOCL_PCI_DEVID(0x10EE, 0x5701, PCI_ANY_ID, RAVE_USER_RAPTOR2_ES3) }, \
-	{ XOCL_PCI_DEVID(0x10EE, 0x5711, PCI_ANY_ID, RAVE_USER_RAPTOR2_ES3) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0x6099, PCI_ANY_ID, VCK190_USER_RAPTOR2) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0x5079, PCI_ANY_ID, VERSAL_USER_RAPTOR2) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0x5099, PCI_ANY_ID, AVALON_USER_RAPTOR2) }
@@ -3611,22 +3581,6 @@ struct xocl_subdev_map {
 		.vbnv = "xilinx_v80",				\
 		.priv_data = &XOCL_BOARD_V80_USER_RAPTOR2_ES3,	\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
-	{ 0x10EE, 0x5700, PCI_ANY_ID,					\
-		.vbnv = "emb-plus",				\
-		.priv_data = &XOCL_BOARD_RAVE_MGMT_RAPTOR2,		\
-		.type = XOCL_DSAMAP_RAPTOR2 },				\
-	{ 0x10EE, 0x5701, PCI_ANY_ID,					\
-		.vbnv = "emb-plus",				\
-		.priv_data = &XOCL_BOARD_RAVE_USER_RAPTOR2_ES3,	\
-		.type = XOCL_DSAMAP_RAPTOR2 },				\
-	{ 0x10EE, 0x5710, PCI_ANY_ID,                                   \
-                .vbnv = "emb-plus",                             \
-                .priv_data = &XOCL_BOARD_RAVE_MGMT_RAPTOR2,             \
-                .type = XOCL_DSAMAP_RAPTOR2 },                          \
-        { 0x10EE, 0x5711, PCI_ANY_ID,                                   \
-                .vbnv = "emb-plus",                             \
-                .priv_data = &XOCL_BOARD_RAVE_USER_RAPTOR2_ES3, \
-                .type = XOCL_DSAMAP_RAPTOR2 },                          \
 	{ 0x10EE, 0x6098, PCI_ANY_ID,					\
                 .vbnv = "xilinx_vck190",				\
                 .priv_data = &XOCL_BOARD_VCK190_MGMT_RAPTOR2,		\


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
removed rave1 support as part of 2026.2 and further
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
removed rave1 support as part of 2026.2 and further

#### How problem was solved, alternative solutions (if any) and why they were rejected
removed rave1 support as part of 2026.2 and further

#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
verified no support of xrt for rave boards
#### Documentation impact (if any)
None