### PR TITLE
AIESW-42728 buffer_dumper.cpp: device-selected format-string argument mismatch

### DIFF
--- a/src/runtime_src/core/common/buffer_dumper.cpp
+++ b/src/runtime_src/core/common/buffer_dumper.cpp
@@ -187,21 +187,16 @@ parse_log_entries(size_t start_offset, size_t bytes_to_end, size_t length,
     if (log.length == (offsetof(log_entry, argument1) / sizeof(uint32_t))) {
       out << log_format;
     }
-    else if (log.length == (offsetof(log_entry, argument2) / sizeof(uint32_t))) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-      static_cast<void>(std::snprintf(log_message.data(), log_message.size(),
-                                      log_format, log.argument1));
-      out << log_message.data();
-    }
-    else if (log.length == (sizeof(log_entry) / sizeof(uint32_t))) {
+    else {
+      // Always pass both arguments regardless of log.length so that the
+      // device cannot independently control the snprintf argument count
+      // relative to the format string's specifier count, which would
+      // cause snprintf to read uninitialized register/stack values.
+      // Passing surplus arguments to snprintf is harmless.
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
       static_cast<void>(std::snprintf(log_message.data(), log_message.size(),
                                       log_format, log.argument1, log.argument2));
       out << log_message.data();
-    }
-    else {
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "buffer_dumper",
-                              "Invalid UC log entry length: " + std::to_string(log.length));
     }
 
     parsed_bytes += m_config.metadata_size;


### PR DESCRIPTION
#### Problem solved by the commit

In the UC-log text parser, the format string and the `snprintf` argument count were independently controlled by device-supplied fields of the `log_entry` record read from firmware-written shared memory. A device could pair a format string with fewer variadic arguments than the format had conversion specifiers, causing `snprintf` to read uninitialized register/stack values and format them into the log file.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Discovered by internal AI-assisted security audit (leet campaign, AIESW-42728, reporter: obittner).

#### How problem was solved, alternative solutions (if any) and why they were rejected

Collapse the one-argument and two-argument `snprintf` branches into a single call that always passes both `argument1` and `argument2`. Passing surplus arguments to `snprintf` is harmless (they are ignored); passing too few is undefined behavior. This removes `log.length`'s ability to independently control the argument count relative to the format string's specifier count.

Alternative considered: validate that `log.length` matches the specifier count of the selected format string. Rejected as it requires parsing the format string at runtime and couples the schema to entry length in a fragile way.

#### Risks (if any) associated the changes in the commit

Low. The `uc_log` feature is disabled by default (`xrt.ini` opt-in). The change produces identical output for all well-formed log entries; only malformed entries (mismatched `log_id`/`log.length`) are formatted differently — they now produce two-argument output rather than a warning.

#### What has been tested and how, request additional testing if necessary

Code review only. Please test with `Debug.uc_log = true` in `xrt.ini` on an NPU device and verify log output for typical workloads is unchanged.

#### Documentation impact (if any)

None.