### PR TITLE
xclbinutil: enable critical compiler warnings

### DIFF
--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_cmd.h
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_cmd.h
@@ -106,7 +106,7 @@ typedef struct {
 typedef struct {
 	uint8_t bLeft;
 	uint32_t cmd_id;
-	uint16_t cmdNum;
+	uint32_t cmdNum;
 	uint32_t cmdHeaderLeft[MAX_HEADER_LEFT];
 	uint32_t cmdHeaderLeftLen;
 } XCdoCmdLeft;

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_debug_dma.h
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_debug_dma.h
@@ -20,8 +20,10 @@ extern "C" {
 
 /***************************** Include Files *********************************/
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "cdo_cmd.h"
+#include "cdo_io_debug.h"
 
 /************************** Constant Definitions *****************************/
 #define CACHE_INVALIDATE(cache, cpylen)
@@ -38,11 +40,11 @@ static inline int XCdo_IoMemCpy(void * dest, const void * src,
     const uint32_t length = (uint32_t)n;
     const uintptr_t destination = (uintptr_t)dest;
 
-	XCdo_Print("COPY: %s, Dest: %p, Src: %p, Size: %lu(Bytes)\n", __func__, 
+	XCdo_Print("COPY: %s, Dest: %p, Src: %p, Size: %zu(Bytes)\n", __func__,
 		dest, src, n);
 	IoAssignVar(XCDO_CMD_DMAWRITE);
     IoAssignVar((uint32_t)destination);
-    IoAssignVar((uint32_t)((uint64_t)destination >> 32U));
+    IoAssignVar((uint32_t)((uint64_t)destination >> XCDO_UINT32_WIDTH));
     IoAssignVar(length);
     IoCopyMem((void *)src, length);
 

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_debug_dma.h
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_debug_dma.h
@@ -19,6 +19,8 @@ extern "C" {
 #endif
 
 /***************************** Include Files *********************************/
+#include <limits.h>
+#include <stdint.h>
 #include "cdo_cmd.h"
 
 /************************** Constant Definitions *****************************/
@@ -28,15 +30,23 @@ extern "C" {
 static inline int XCdo_IoMemCpy(void * dest, const void * src,
 		size_t n)
 {
+	if (n > (size_t)INT_MAX) {
+        XCdo_PError("COPY size exceeds the supported range\n");
+        return -1;
+    }
+
+    const uint32_t length = (uint32_t)n;
+    const uintptr_t destination = (uintptr_t)dest;
+
 	XCdo_Print("COPY: %s, Dest: %p, Src: %p, Size: %lu(Bytes)\n", __func__, 
 		dest, src, n);
 	IoAssignVar(XCDO_CMD_DMAWRITE);
-	IoAssignVar((uint64_t)dest);
-	IoAssignVar(((uint64_t)dest)>>32);
-	IoAssignVar(n);
-	IoCopyMem((void *)src, n);
-	
-	return n;
+    IoAssignVar((uint32_t)destination);
+    IoAssignVar((uint32_t)((uint64_t)destination >> 32U));
+    IoAssignVar(length);
+    IoCopyMem((void *)src, length);
+
+	return (int)length;
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_io_debug.h
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_io_debug.h
@@ -18,6 +18,7 @@
 #define XCDO_IO_DEBUG_H
 
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -28,6 +29,8 @@ typedef uint32_t TaskHandle_t;
 /***************************** Include Files *********************************/
 
 /************************** Constant Definitions *****************************/
+#define XCDO_UINT32_WIDTH 32U
+
 #include "cdo_common.h"
 #include "cdo_cmd.h"  // XCDO_CMD_WRITE for clang-tidy check
 
@@ -117,7 +120,7 @@ static inline int XCdo_IoMemcpy(void * dest, const void * src,
 		dest, src, n, PdiOffset);
 	IoAssignVar(XCDO_CMD_DMAWRITE);
     IoAssignVar((uint32_t)destination);
-    IoAssignVar((uint32_t)((uint64_t)destination >> 32U));
+    IoAssignVar((uint32_t)((uint64_t)destination >> XCDO_UINT32_WIDTH));
 	//in some test case src is different but data is same, then we only need to
 	//veify the address when not check the data.
 	if (!gcheckDmaData) {

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_io_debug.h
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/libinclude/cdo_io_debug.h
@@ -17,6 +17,9 @@
 #ifndef XCDO_IO_DEBUG_H
 #define XCDO_IO_DEBUG_H
 
+#include <limits.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,7 +28,6 @@ typedef uint32_t TaskHandle_t;
 /***************************** Include Files *********************************/
 
 /************************** Constant Definitions *****************************/
-#include <stdint.h>
 #include "cdo_common.h"
 #include "cdo_cmd.h"  // XCDO_CMD_WRITE for clang-tidy check
 
@@ -78,7 +80,7 @@ static inline void XCdo_IoWrite32(uintptr_t Addr, uint32_t Val)
 {
 	XCdo_Print("WR32: Addr: 0x%lx, Val: 0x%x. PdiOffset =%d\n", (unsigned long)Addr, Val, PdiOffset);
 	IoAssignVar(XCDO_CMD_WRITE);
-	IoAssignVar(Addr);
+	IoAssignVar((uint32_t)Addr);
 	IoAssignVar(Val);
 }
 
@@ -88,7 +90,7 @@ static inline void XCdo_IoMaskWrite32(uintptr_t Addr, uint32_t Mask,
 	XCdo_Print("MW32: Addr: 0x%lx, Mask: 0x%x,  Val: 0x%x. PdiOffset = %d\n",
 		(unsigned long)Addr, Mask, Val, PdiOffset);
 	IoAssignVar(XCDO_CMD_MASK_WRITE);
-	IoAssignVar(Addr);
+	IoAssignVar((uint32_t)Addr);
 	IoAssignVar(Mask);
 	IoAssignVar(Val);
 }
@@ -102,23 +104,32 @@ static inline uint32_t XCdo_IoRead32(uintptr_t Addr)
 static inline int XCdo_IoMemcpy(void * dest, const void * src,
 		size_t n)
 {
+    if (n > (size_t)INT_MAX) {
+        XCdo_PError("COPY size exceeds the supported range\n");
+        return -1;
+    }
+
+    const uint32_t length = (uint32_t)n;
+    const uintptr_t destination = (uintptr_t)dest;
+    const uintptr_t source = (uintptr_t)src;
+
 	XCdo_Print("COPY: Dest: %p, Src: %p, Size: %zu(Bytes) PdiOffset =%d\n",
 		dest, src, n, PdiOffset);
 	IoAssignVar(XCDO_CMD_DMAWRITE);
-	IoAssignVar((uint64_t)dest);
-	IoAssignVar(((uint64_t)dest)>>32);
+    IoAssignVar((uint32_t)destination);
+    IoAssignVar((uint32_t)((uint64_t)destination >> 32U));
 	//in some test case src is different but data is same, then we only need to
 	//veify the address when not check the data.
 	if (!gcheckDmaData) {
-		IoAssignVar((uint64_t)src);
+		IoAssignVar((uint32_t)source);
 	}
-	IoAssignVar(n);
+	IoAssignVar(length);
 	// only copy data when asked.
 	
 	if (gcheckDmaData) {
-		IoCopyMem((void *)src, n);
+		IoCopyMem((void *)src, length);
 	}
-	return n;
+	return (int)length;
 }
 #ifdef __cplusplus
 }

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/CMakeLists.txt
@@ -4,7 +4,7 @@
 if(NOT WIN32)
   add_compile_options(-Wextra -fvisibility=default)
 else()
-  add_compile_options(/wd4244 /wd4267 /wd4477 /wd4245)
+  add_compile_options(/wd4477 /wd4245)
 endif()
 
 # This builds a static library libtransformcdo, which 

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-transform.c
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-transform.c
@@ -399,12 +399,24 @@ void XPdi_Compress_Transform(XPdiLoad* PdiLoad, const char* pdi_file_out)
   uint32_t Cmd_len = XPdi_Cmd_Parse(cdo_buf +
              (XCDO_CDO_HDR_LEN * sizeof(uint32_t)), BufLen, Buf);
 
+  if (Cmd_len == 0) {
+    XCdo_PError("Failed to parse PDI command zone - buffer overflow or empty PDI\n");
+    free(pdi_buf);
+    return;
+  }
+
   //Change the pdi header to mark that this is a tranform/compress pdi
   XPdi_Header_Set_Transform_Type(&newPdiLoad, CMDDATASPERATE, Cmd_len);
 
   //Parse and generate the data zone
   uint32_t TotalCdoLen = XPdi_Buf_Parse(cdo_buf  +
              (XCDO_CDO_HDR_LEN * sizeof(uint32_t)), Cmd_len, BufLen, (const char*)Buf);
+
+  if (TotalCdoLen == 0) {
+    XCdo_PError("Failed to parse PDI data zone - buffer overflow or malformed PDI\n");
+    free(pdi_buf);
+    return;
+  }
 
   //Update the pdi length.
   //TotalCdoLen is the total size of cdo command zone + data zone

--- a/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-transform.c
+++ b/src/runtime_src/tools/xclbinutil/aie-pdi-transform/src/pdi-transform.c
@@ -21,6 +21,8 @@
 
 /***************************** Include Files *********************************/
 #include <stdio.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 #include "cdo_cmd.h"
 #include "load_pdi.h"
@@ -29,6 +31,18 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+
+static int
+pointer_difference_to_u32(const char* end, const char* begin, uint32_t* result)
+{
+    const ptrdiff_t difference = end - begin;
+
+    if (difference < 0 || (uint64_t)difference > UINT32_MAX)
+        return 0;
+
+    *result = (uint32_t)difference;
+    return 1;
+}
 
 uint8_t XPdi_Cmd_Match(uint32_t CmdId)
 {
@@ -152,9 +166,15 @@ uint32_t XPdi_Cmd_Parse(char* pdi_buf, uint32_t BufLen, const uint32_t *Buf)
     Buf += Cmd.Size;
     BufLen -= Cmd.Size;
   }
-  // printf("buf len is %ld\n", cur_pdi_buf - pdi_buf);
-  XCdo_Print("buf len is %ld\n", cur_pdi_buf - pdi_buf);
-  return cur_pdi_buf - pdi_buf;
+  
+  uint32_t parsed_length = 0;
+  if (!pointer_difference_to_u32(cur_pdi_buf, pdi_buf, &parsed_length)) {
+      XCdo_PError("Parsed command length exceeds the supported range\n");
+      return 0;
+  }
+  // printf("buf len is %u\n", parsed_length);
+  XCdo_Print("buf len is %u\n", parsed_length);
+  return parsed_length;
 }
 
 uint8_t is_bss(uint32_t dst_addr)
@@ -227,8 +247,15 @@ uint32_t XPdi_Buf_Parse(char* pdi_buf, uint32_t CBufLen, uint32_t BufLen, const 
             ((uint32_t*)pdi_buf)[3] = ((uint32_t*)pdi_buf)[3] | (1 << 16);
           }
           //point to the offset location of data.
-          ((uint32_t*)pdi_buf)[2] = data_buf - odata_buf;
+            //point to the offset location of data.
+          uint32_t data_offset = 0;
+          if (!pointer_difference_to_u32(data_buf, odata_buf, &data_offset)) {
+              XCdo_PError("PDI data offset exceeds the supported range\n");
+              return 0;
+          }
+          ((uint32_t*)pdi_buf)[2] = data_offset;
           data_buf += mem_len;
+         
           //move cmd pointer
           pdi_buf += cmd_len;
           // printf("dma len %d \n", mem_len);
@@ -244,8 +271,13 @@ uint32_t XPdi_Buf_Parse(char* pdi_buf, uint32_t CBufLen, uint32_t BufLen, const 
   // printf("the all zero dma data length is  %d\n", dma_zero_data_size);
   XCdo_Print("the all zero dma data length is  %d\n", dma_zero_data_size);
 
-  return data_buf - obuf;
+  uint32_t total_length = 0;
+  if (!pointer_difference_to_u32(data_buf, obuf, &total_length)) {
+      XCdo_PError("Transformed PDI length exceeds the supported range\n");
+      return 0;
+  }
 
+  return total_length;
 }
 
 void XPdi_Export(const XPdiLoad* PdiLoad, const char* pdi_file_out)


### PR DESCRIPTION
#### Problem solved by the commit
Fix for Binskim scan error for MCDM driver
http://fisweb:8080/proj/aiebuilds/ryzen-ai/special_ops/BINSKIM/reports/binskim_dashboard.html

The Binskim scan showed BA2007 violation. Based on the SARIF report quoted below, the flags wd4244 (conversion between numeric types) and wd4267 (conversion from size_t to a smaller type) were causing the BA2007. The relevant library was transformcdo.lib. 

              "cdo_cmd.obj (transformcdo.lib) [Explicitly disabled warnings: 4244;4267]\r\nload_pdi.obj (transformcdo.lib) [Explicitly disabled warnings: 4244;4267]\r\npdi-parsing.obj (transformcdo.lib) [Explicitly disabled warnings: 4244;4267]\r\npdi-transform.obj (transformcdo.lib) [Explicitly disabled warnings: 4244;4267]\r\n"

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/9266
The above PR was raised to enable windows installation of --transform-pdi

#### How problem was solved, alternative solutions (if any) and why they were rejected
The flags wd4244 and wd4267 were removed from aie-pdi-transform/CMakeLists.txt. Since transformcdo.lib links statically to xclbinutil.exe, the code changes were made to aie-pdi-transform to remove warnings that pop up after removing the flags. After removing the flags and modifying code that was causing the warnings, the library has been successfully compiled and linked to xclbinutil on windows and linux.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Unit tests are successful on Linux and windows for this change. The regressions also pass on Linux (not enabled for windows)

#### Documentation impact (if any)
None