### PR TITLE
Add AIE dtrace INI getters for L2-L2 memtile metrics

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1011,6 +1011,22 @@ get_aie_dtrace_settings_tile_based_aie_metrics()
   return value;
 }
 
+inline std::string
+get_aie_dtrace_settings_tile_based_memory_tile_metrics()
+{
+  static std::string value =
+      detail::get_string_value("AIE_dtrace_settings.tile_based_memory_tile_metrics", "");
+  return value;
+}
+
+inline std::string
+get_aie_dtrace_settings_l2_l2_design_points()
+{
+  static std::string value =
+      detail::get_string_value("AIE_dtrace_settings.l2_l2_design_points", "");
+  return value;
+}
+
 // AIE_trace_settings
 
 inline std::string

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1020,10 +1020,10 @@ get_aie_dtrace_settings_tile_based_memory_tile_metrics()
 }
 
 inline std::string
-get_aie_dtrace_settings_l2_l2_design_points()
+get_aie_dtrace_settings_memory_tile_input_ports()
 {
   static std::string value =
-      detail::get_string_value("AIE_dtrace_settings.l2_l2_design_points", "");
+      detail::get_string_value("AIE_dtrace_settings.memory_tile_input_ports", "");
   return value;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enabling l2-l2 (memtile level) aie_dtrace from xrt.ini 

#### What has been tested and how, request additional testing if necessary
Tested on telluride board, on a baseline overlay design.

