### PR TITLE
AIESW-42841, 42842 xbmgmt vulnerability fixes

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -24,6 +25,7 @@
 #include "core/common/info_vmr.h"
 
 // 3rd Party Library - Include Files
+#include <algorithm>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -237,7 +239,8 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
     pt_current_shell.put("id", (boost::format("0x%x") % part.timestamp));
 
     boost::property_tree::ptree pt_plps;
-    for (unsigned int i = 1; i < logic_uuids.size(); i++) {
+    const std::size_t num_partitions = std::min(logic_uuids.size(), interface_uuids.size());
+    for (std::size_t i = 1; i < num_partitions; ++i) {
       boost::property_tree::ptree pt_plp;
       DSAInfo partition("", NULL_TIMESTAMP, logic_uuids[i], "");
       pt_plp.put("vbnv", partition.name);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
@@ -1864,8 +1864,8 @@ static int installBitstreamGuard(xrt_core::device *dev, std::FILE *flashDev,
     int ret;
 
     memset(buf, 0xff, sizeof(buf));
-    memset(buf, 0xff, sizeof(buf1));
-    memset(buf, 0xff, sizeof(buf2));
+    memset(buf1, 0xff, sizeof(buf1));
+    memset(buf2, 0xff, sizeof(buf2));
     memcpy(buf + bitstream_guard_offset, BITSTREAM_GUARD,
         sizeof(BITSTREAM_GUARD));
     stripe_data(buf, buf1, buf2, sizeof(buf));

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
@@ -1863,9 +1863,9 @@ static int installBitstreamGuard(xrt_core::device *dev, std::FILE *flashDev,
     unsigned char buf[4096], buf1[4096], buf2[4096];
     int ret;
 
-    memset(buf, 0xff, sizeof(buf));
-    memset(buf1, 0xff, sizeof(buf1));
-    memset(buf2, 0xff, sizeof(buf2));
+    memset(buf, 0xff, sizeof(buf));   // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+    memset(buf1, 0xff, sizeof(buf1)); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+    memset(buf2, 0xff, sizeof(buf2)); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
     memcpy(buf + bitstream_guard_offset, BITSTREAM_GUARD,
         sizeof(BITSTREAM_GUARD));
     stripe_data(buf, buf1, buf2, sizeof(buf));


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-42841
https://jira.xilinx.com/browse/AIESW-42842
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered during internal review
#### How problem was solved, alternative solutions (if any) and why they were rejected
This PR hardens xbmgmt against two memory-safety issues when handling device-supplied metadata or writing to SPI flash. In ReportPlatform::getPropertyTree20202(), the 2RP branch now bounds the current-partitions loop by min(logic_uuids.size(), interface_uuids.size()) instead of iterating only over logic_uuids, preventing out-of-bounds reads of interface_uuids when FDT filtering yields mismatched vector lengths and avoiding crashes or heap leakage into platform JSON/text reports. In installBitstreamGuard(), corrected memset targets initialize buf1 and buf2 to 0xff (not just buf), so the dual-QSPI path no longer writes uninitialized stack bytes to the bitstream-guard flash region.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Testing on Alveo devices
#### Documentation impact (if any)
N/A