### PR TITLE
AIESW-35166 xrt-runner: report NPU memory usage

### DIFF
--- a/src/runtime_src/core/common/runner/xrt-runner.cpp
+++ b/src/runtime_src/core/common/runner/xrt-runner.cpp
@@ -38,6 +38,7 @@
 #include "xrt/experimental/xrt_message.h"
 
 #include "core/common/config_reader.h"
+#include "core/common/query_requests.h"
 #include "core/common/debug.h"
 #include "core/common/error.h"
 #include "core/common/time.h"
@@ -95,6 +96,18 @@ constexpr double
 to_mb(size_t bytes)
 {
   return bytes / (1024.0 * 1024.0); // NOLINT
+}
+
+static uint64_t
+get_npu_memory_bytes(const xrt::device& device)
+{
+  try {
+    return xrt_core::device_query_default<xrt_core::query::total_mem_usage>(
+      device.get_handle().get(), uint64_t{0});
+  }
+  catch (...) {
+    return 0;
+  }
 }
 
 size_t
@@ -619,6 +632,7 @@ run_script(const std::string& file, const std::string& dir,
     auto jrpt = runner.get_report();
     jrpt["system"] = { {"real", real.to_sec() }, {"user", user.to_sec() }, {"kernel", system.to_sec()} };
     jrpt["system"]["peak_memory_mb"] = to_mb(get_peak_rss());
+    jrpt["system"]["npu_memory_mb"]  = to_mb(get_npu_memory_bytes(device));
 
     if (report == "-")
       std::cout << jrpt.dump(2) << '\n';
@@ -646,6 +660,7 @@ run_single(const std::string& recipe, const std::string& profile, const std::str
     auto jrpt = json::parse(runner.get_report());
     jrpt["system"] = { {"real", real.to_sec() }, {"user", user.to_sec() }, {"kernel", system.to_sec()} };
     jrpt["system"]["peak_memory_mb"] = to_mb(get_peak_rss());
+    jrpt["system"]["npu_memory_mb"]  = to_mb(get_npu_memory_bytes(device));
 
     if (report == "-")
       std::cout << jrpt.dump(2) << '\n';
@@ -671,6 +686,7 @@ run_replay(const std::string& replay, const std::string& dir,
     auto jrpt = json::parse(rply.get_report());
     jrpt["system"] = { {"real", real.to_sec()}, {"user", user.to_sec()}, {"kernel", system.to_sec()} };
     jrpt["system"]["peak_memory_mb"] = to_mb(get_peak_rss());
+    jrpt["system"]["npu_memory_mb"]  = to_mb(get_npu_memory_bytes(device));
 
     if (report == "-")
       std::cout << jrpt.dump(2) << '\n';


### PR DESCRIPTION
#### Problem solved by the commit

xrt-runner reports RSS (peak host process memory) but not NPU device
memory allocated by the process, giving an incomplete picture of
resource consumption for workloads running on the NPU.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Feature request AIESW-35166. xrt-smi already reports per-process NPU
memory usage via the same query infrastructure; xrt-runner was not
wired up to it.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Add `npu_memory_mb` to the `system` section of the report by calling
`xrt_core::device_query_default<query::total_mem_usage>()` after
execution completes. The query returns 0 on devices that do not support
it (non-NPU), so no platform-specific code is needed in xrt-runner.

On Linux the query is backed by `DRM_AMDXDNA_BO_USAGE` in the
xdna-driver shim, which aggregates `total_bo_usage` across all open
file descriptors for the querying process. On Windows it is backed by
`D3DKMTQueryStatistics(PROCESS_SEGMENT)` in the MCDM shim. Both paths
were already implemented and registered; this change only surfaces the
result in the runner report.

#### Risks (if any) associated the changes in the commit

None. `device_query_default` returns the supplied default (0) rather
than throwing when the query is not registered, so existing
non-NPU use cases are unaffected. The new field is additive.

#### What has been tested and how, request additional testing if necessary

Validated on NPU device. Please verify the `system.npu_memory_mb`
field appears in the report on both Linux and Windows NPU targets, and
is absent (0) on non-NPU devices.

#### Documentation impact (if any)

None. The jobs.report.schema.json is not currently enforced.