### PR TITLE
xbmgmt: validate mem_topology size before ECC reset iteration

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -43,6 +43,7 @@ rmmodules()
 
 installdir=@CMAKE_INSTALL_PREFIX@
 systemddir=/etc/systemd/system
+# 0 = Alveo package (dkms.conf present); non-zero = skip Alveo/DKMS install
 test -e /usr/src/xrt-@XRT_VERSION_STRING@/dkms.conf
 alveo=$?
 
@@ -80,12 +81,12 @@ done
 rmmodules
 
 DRACUT_CONF_PATH=/etc/dracut.conf.d
-if [ -e $DRACUT_CONF_PATH ] && [ $alveo == 1]; then
-    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/userpf/xocl.dracut.conf $DRACUT_CONF_PATH
-    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/mgmtpf/xclmgmt.dracut.conf $DRACUT_CONF_PATH
+if [ -d "$DRACUT_CONF_PATH" ] && [ "$alveo" -eq 0 ]; then
+    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/userpf/xocl.dracut.conf "$DRACUT_CONF_PATH"
+    install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xocl/mgmtpf/xclmgmt.dracut.conf "$DRACUT_CONF_PATH"
 fi
 
-if [ $alveo == 0]; then
+if [ "$alveo" -ne 0 ]; then
     echo "Skipping XRT Alveo driver install"
     exit 0
 fi

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -30,6 +30,8 @@
 #include <variant>
 #include <vector>
 
+namespace xrt_core { class device; }
+
 namespace xrt {
 
 ////////////////////////////////////////////////////////////////
@@ -541,6 +543,20 @@ get_kernel_properties_and_args(std::shared_ptr<xrt::elf_impl> elf_impl,
 // Empty string if ELF was loaded from buffer/stream
 std::string
 get_filename(const xrt::elf_impl* elf_impl);
+
+// Package a raw AIE coredump blob into an ET_CORE ELF with metadata.
+// Metadata (timestamp, firmware version, device info, context status) is built
+// internally by querying the device.  The AIE architecture is derived from the
+// ELF's OS/ABI byte.
+//
+// uuid: UUID to embed in the coredump metadata.  Pass the UUID of the specific
+//   ELF that caused the fault (e.g. the timed-out run's ELF).  Pass empty string
+//   when no single ELF is attributable — e.g. a partition-level dump triggered
+//   from the public API where multiple ELFs may be loaded.
+std::vector<char>
+make_aie_coredump_elf(const xrt::elf& elf, const std::vector<char>& blob,
+                      const xrt_core::device* device, uint32_t slot,
+                      const std::string& uuid = "");
 
 } // namespace xrt_core::elf_int
 

--- a/src/runtime_src/core/common/api/hw_context_int.h
+++ b/src/runtime_src/core/common/api/hw_context_int.h
@@ -100,6 +100,15 @@ XRT_CORE_COMMON_EXPORT
 std::map<std::string, xrt::elf>
 get_elf_map(const xrt::hw_context& hwctx);
 
+// get_aie_coredump_elf() - Package AIE coredump for a specific faulting ELF
+//
+// Use this overload when the caller knows exactly which ELF caused the fault
+// (e.g. abort_coredump_or_noop passes the ELF of the timed-out run).
+// The UUID embedded in the coredump metadata is taken from the provided ELF.
+// The raw AIE dump blob is fetched internally from the hw_context.
+std::vector<char>
+get_aie_coredump_elf(const xrt::hw_context& hwctx, const xrt::elf& elf);
+
 // Get the configuration parameter / QoS map from the hw context.
 // The returned map contains key-value pairs
 // key: string, value: uint32_t for both QoS-related settings and

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -5,13 +5,19 @@
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "xrt/experimental/xrt_aie.h"
 #include "xrt/experimental/xrt_elf.h"
+#include "xrt/xrt_hw_context.h"
 #include "xrt/xrt_uuid.h"
 
 #include "elf_int.h"
 #include "elf_patcher.h"
+#include "core/common/aiebu/src/cpp/elf/aie_elf_constants.h"
+#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_assembler.h"
 #include "core/common/config_reader.h"
+#include "core/common/device.h"
 #include "core/common/error.h"
 #include "core/common/message.h"
+#include "core/common/query_requests.h"
+#include "core/common/system.h"
 #include "core/common/trace.h"
 #include "core/common/xclbin_parser.h"
 #include "core/common/runner/capture.h"
@@ -19,6 +25,7 @@
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <elfio/elfio.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -549,6 +556,7 @@ parse_sections()
 }
 
 // Get configuration UUID from ELF
+// Returns an empty UUID if the section is absent (e.g. partial ELFs).
 xrt::uuid
 elf_impl::
 get_cfg_uuid() const
@@ -558,15 +566,12 @@ get_cfg_uuid() const
 
   auto section = m_elfio.sections[".note.xrt.UID"];
   if (!section)
-    throw std::runtime_error("ELF is missing .note.xrt.UID section\n");
+    return {};
 
   auto data = get_note(section, first_note);
   if (data.size() != uuid_size)
-    throw std::runtime_error("Invalid UUID size in .note.xrt.UID section, expected 16 bytes but got " +
-                             std::to_string(data.size()) + " bytes\n");
+    return {};
 
-  // UUID is stored as raw 16 bytes in the note section
-  // Copy directly to uuid_t (which is unsigned char[16])
   xuid_t uuid_data;
   std::memcpy(uuid_data, data.data(), uuid_size);
   return xrt::uuid(uuid_data);
@@ -1659,6 +1664,101 @@ get_filename(const xrt::elf_impl* elf_impl)
   return elf_impl
     ? elf_impl->get_filename()
     : "";
+}
+
+static aiebu::aiebu_assembler::buffer_type
+osabi_to_coredump_type(uint8_t os_abi)
+{
+  switch (os_abi) {
+  case aiebu::osabi_aie2p:
+    return aiebu::aiebu_assembler::buffer_type::coredump_aie2p;
+  case aiebu::osabi_aie2ps:
+    return aiebu::aiebu_assembler::buffer_type::coredump_aie2ps;
+  case aiebu::osabi_aie4:
+    return aiebu::aiebu_assembler::buffer_type::coredump_aie4;
+  case aiebu::osabi_aie4a:
+    return aiebu::aiebu_assembler::buffer_type::coredump_aie4a;
+  case aiebu::osabi_aie4z:
+    return aiebu::aiebu_assembler::buffer_type::coredump_aie4z;
+  default:
+    throw std::runtime_error("AIE coredump not supported for this ELF architecture");
+  }
+}
+
+std::vector<char>
+make_aie_coredump_elf(const xrt::elf& elf, const std::vector<char>& blob,
+                      const xrt_core::device* device, uint32_t slot,
+                      const std::string& uuid)
+{
+  // Fail fast: verify arch is supported before doing any device queries.
+  auto buf_type = osabi_to_coredump_type(elf.get_handle()->get_os_abi());
+
+  aiebu::aie_coredump_meta meta{};
+  meta.timestamp_ns = static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::system_clock::now().time_since_epoch()).count());
+  meta.uuid = uuid;
+
+  try {
+    boost::property_tree::ptree pt_xrt;
+    xrt_core::get_driver_info(pt_xrt);
+    std::string drv_str;
+    if (const auto drivers = pt_xrt.get_child_optional("drivers")) {
+      for (const auto& [dummy, drv] : *drivers) {
+        auto name = drv.get<std::string>("name", "");
+        auto ver  = drv.get<std::string>("version", "");
+        if (!name.empty() && !ver.empty() && ver != "unknown") {
+          if (!drv_str.empty())
+            drv_str += "; ";
+
+          drv_str += name + " " + ver;
+        }
+      }
+    }
+    meta.driver_version = drv_str;
+  }
+  catch (const std::exception&) {
+    /* leave empty if not available */
+  }
+
+  try {
+    auto data = xrt_core::device_query<xrt_core::query::aie_partition_info>(device);
+    auto islot = static_cast<int>(slot);
+
+    for (const auto& entry : data) {
+      if (std::stoi(entry.metadata.id) != islot)
+        continue;
+
+      meta.context_status = entry.is_suspended
+          ? aiebu::aie_context_status::idle
+          : aiebu::aie_context_status::running;
+      break;
+    }
+  }
+  catch (const std::exception&) {
+    /* leave as default idle if query not supported */
+  }
+
+  try {
+    auto fw = xrt_core::device_query<xrt_core::query::firmware_version>(
+        device,
+        xrt_core::query::firmware_version::firmware_type::npu_firmware);
+    meta.fw_version = std::to_string(fw.major) + "." + std::to_string(fw.minor)
+                    + "." + std::to_string(fw.patch) + "." + std::to_string(fw.build);
+  }
+  catch (const std::exception&) {
+    /* leave empty if not supported */
+  }
+
+  try {
+    meta.device_info = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
+  }
+  catch (const std::exception&) {
+    /* leave empty if not supported */
+  }
+
+  aiebu::aiebu_assembler a(buf_type, blob, meta);
+  return a.get_elf();
 }
 
 } // xrt_core::elf_int

--- a/src/runtime_src/core/common/api/xrt_hw_context.cpp
+++ b/src/runtime_src/core/common/api/xrt_hw_context.cpp
@@ -718,6 +718,20 @@ public:
     }
   }
 
+  std::vector<char>
+  get_aie_coredump_elf() const
+  {
+    xrt::elf elf = [this] {
+      std::lock_guard lk(m_mutex);
+      if (m_elf_map.empty())
+        throw std::runtime_error("AIE coredump ELF not available: no ELF loaded in this context");
+      return m_elf_map.begin()->second;
+    }();
+
+    return xrt_core::elf_int::make_aie_coredump_elf(
+        elf, get_aie_coredump(), m_core_device.get(), m_hdl->get_slotidx());
+  }
+
   // Returns map of kernel names to their corresponding elf files
   // registered with this hardware context
   std::map<std::string, xrt::elf>
@@ -856,6 +870,17 @@ append_dtrace_result(const xrt::hw_context& hwctx,
 {
   // Append a per-run dtrace JSON result to the hw context coalesce buffer
   hwctx.get_handle()->append_dtrace_result(key, result_json);
+}
+
+std::vector<char>
+get_aie_coredump_elf(const xrt::hw_context& hwctx, const xrt::elf& elf)
+{
+  auto* impl = hwctx.get_handle().get();
+  auto cfg_uuid = elf.get_cfg_uuid();
+  return xrt_core::elf_int::make_aie_coredump_elf(
+      elf, impl->get_aie_coredump(), impl->get_core_device().get(),
+      static_cast<uint32_t>(static_cast<xrt_core::hwctx_handle*>(hwctx)->get_slotidx()),
+      cfg_uuid ? cfg_uuid.to_string() : std::string{});
 }
 
 } // xrt_core::hw_context_int
@@ -1013,6 +1038,13 @@ hw_context::
 get_aie_coredump() const
 {
   return get_handle()->get_aie_coredump();
+}
+
+std::vector<char>
+hw_context::
+get_aie_coredump_elf() const
+{
+  return get_handle()->get_aie_coredump_elf();
 }
 
 } // xrt

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -3154,7 +3154,12 @@ public:
   }
 
   // abort_coredump_or_noop() - AIE coredump if enabled
-  // Dump core and abort, or do nothing.
+  // Write AIE coredump ELF to the configured file then abort.
+  // std::abort() ensures the OS reclaims driver resources (hw_context, hardware
+  // state) after a timeout. Users who set xrt.ini to capture AIE coredump
+  // would get coredump and don't see the timeout exception message.
+  // The timeout excpetion message is seen only w/o this xrt.ini setting
+  // This coredump functionality is not applicable to non-elf flow
   void
   abort_coredump_or_noop(ert_cmd_state state) const
   {
@@ -3167,12 +3172,22 @@ public:
 
     try {
       auto hwctx = kernel->get_hw_context();
-      auto core = hwctx.get_aie_coredump();  // may throw
+      // Use the ELF from this run's own module
+      // Each ELF has its own UUID; using the run's module ensures the
+      // correct UUID is embedded in the coredump metadata.
+      if (!m_module)
+        throw std::runtime_error("AIE coredump ELF not available: no ELF associated with this run");
+
+      auto elf = xrt::elf{xrt_core::module_int::get_elf_handle(m_module)};
+
+      auto core = xrt_core::hw_context_int::get_aie_coredump_elf(hwctx, elf);
 
       std::ofstream ostr{file, std::ios::binary};
       if (!ostr)
         throw std::runtime_error("Could not open '" + file + "' for writing");
+
       ostr.write(core.data(), static_cast<std::streamsize>(core.size()));
+      ostr.flush();  // flush before abort — destructors do not run after std::abort()
       std::abort();
     }
     catch (const std::exception& ex) {

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -162,6 +162,17 @@ add_performance_info(const xrt_core::device* device, ptree_type& pt)
   }
 }
 
+void
+add_npu_load_info(const xrt_core::device* device, ptree_type& pt)
+{
+  try {
+    pt.put("npu_load", xrt_core::device_query<xq::npu_load>(device));
+  }
+  catch (const xq::exception&) {
+    // Query not supported on this device
+  }
+}
+
 static std::string
 get_host_mem_status(const xrt_core::device* device)
 {
@@ -431,6 +442,7 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
   {
     add_electrical_info(device, pt_platform);
     add_thermal_info(device, pt_platform);
+    add_npu_load_info(device, pt_platform);
     break;
   }
   default:

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -129,6 +129,7 @@ enum class key_type
   aie_mem_info_sysfs,
 
   total_cols,
+  npu_load,
   aie_status_version,
   aie_tiles_stats,
   aie_tiles_status_info,
@@ -1729,6 +1730,16 @@ struct total_cols : request
 {
   using result_type = uint32_t;
   static const key_type key = key_type::total_cols;
+
+  virtual std::any
+  get(const device*) const override = 0;
+};
+
+// NPU utilization as a percentage (0-100), sourced from the driver
+struct npu_load : request
+{
+  using result_type = uint32_t;
+  static const key_type key = key_type::npu_load;
 
   virtual std::any
   get(const device*) const override = 0;

--- a/src/runtime_src/core/include/xrt/xrt_hw_context.h
+++ b/src/runtime_src/core/include/xrt/xrt_hw_context.h
@@ -14,6 +14,8 @@
 #ifdef __cplusplus
 
 #include <map>
+#include <string>
+#include <vector>
 
 // Opaque handle for internal use
 namespace xrt_core {
@@ -356,6 +358,21 @@ public:
   XRT_API_EXPORT
   std::vector<char>
   get_aie_coredump() const;
+
+  /**
+   * get_aie_coredump_elf() - Returns the coredump of AIE Array as an ELF (e_type = ET_CORE).
+   * Fetches the raw AIE dump blob and packages it into a coredump ELF.
+   * The AIE architecture is derived from the ELF loaded in this context.
+   * Metadata (timestamp, firmware version, device info) is always
+   * embedded and populated internally from the hw_context and device.
+   * This function can throw.
+   *
+   * @return
+   *  ELF bytes of the ET_CORE coredump ELF
+   */
+  XRT_API_EXPORT
+  std::vector<char>
+  get_aie_coredump_elf() const;
 
 public:
   /// @cond

--- a/src/runtime_src/core/tools/common/reports/ReportClocks.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportClocks.cpp
@@ -51,5 +51,5 @@ ReportClocks::writeReport(const xrt_core::device* /*_pDevice*/,
     ss << boost::format("  %-23s: %3s MHz\n") % pt_clock.get<std::string>("id") 
                                               % pt_clock.get<std::string>("freq_mhz");
   }
-  std::cout << ss.str();
+  _output << ss.str();
 }

--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -145,7 +145,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << xrt_version_ss.str();
   }
   catch (const boost::property_tree::ptree_error &ex) {
-    throw xrt_core::error(boost::str(boost::format("%s. Please contact your Xilinx representative to fix the issue")
+    throw xrt_core::error(boost::str(boost::format("%s. Please contact your representative to fix the issue")
          % ex.what()));
   }
   _output << std::endl << "Device(s) Present\n";

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -60,6 +60,11 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     else
       _output << std::endl << boost::format("%-23s  : %s\n") % "Estimated Power" % watts;
 
+    if (auto load = pt_platform.get_optional<uint32_t>("npu_load"))
+      _output << boost::format("%-23s  : %u%%\n") % "NPU Load" % *load;
+    else
+      _output << boost::format("%-23s  : %s\n") % "NPU Load" % "N/A";
+
     auto temp_c = pt_platform.get<std::string>("thermal.temp_C", "N/A");
     _output << boost::format("%-23s  : %s\n") % "Temperature (C)" % temp_c;
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -37,13 +37,15 @@ static void
 reset_ecc(const std::shared_ptr<xrt_core::device>& dev, xrt_core::query::reset_type& reset)
 {
   auto raw_mem = xrt_core::device_query<xrt_core::query::mem_topology_raw>(dev);
-  const mem_topology *map = (mem_topology *)raw_mem.data();
-    if(raw_mem.empty() || map->m_count == 0) {
-      std::cout << "WARNING: 'mem_topology' not found, "
+  const auto *map = reinterpret_cast<const mem_topology *>(raw_mem.data());
+  if (map->m_count <= 0 || 
+      raw_mem.size() < sizeof(mem_topology) + (static_cast<size_t>(map->m_count) - 1) * sizeof(mem_data)) 
+  {
+    std::cout << "WARNING: 'mem_topology' not found, "
         << "unable to query ECC info. Has the xclbin been loaded? "
         << "See 'xbmgmt status'." << std::endl;
-      return;
-    }
+    return;
+  }
 
     for(int32_t i = 0; i < map->m_count; i++) {
       if(!map->m_mem_data[i].m_used)

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -50,7 +50,8 @@ reset_ecc(const std::shared_ptr<xrt_core::device>& dev, xrt_core::query::reset_t
     for(int32_t i = 0; i < map->m_count; i++) {
       if(!map->m_mem_data[i].m_used)
         continue;
-      reset.set_subdev(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag));
+      reset.set_subdev(std::string(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag),
+                                   sizeof(map->m_mem_data[i].m_tag)));
       dev->reset(reset);
     }
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -19,6 +19,7 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+#include <cstring>
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
@@ -33,27 +34,46 @@ pretty_print_action_list(xrt_core::device* device, xrt_core::query::reset_type& 
     std::cout << "WARNING: " << reset.get_warning() << std::endl;
 }
 
-static void 
+static void
 reset_ecc(const std::shared_ptr<xrt_core::device>& dev, xrt_core::query::reset_type& reset)
 {
   auto raw_mem = xrt_core::device_query<xrt_core::query::mem_topology_raw>(dev);
-  const auto *map = reinterpret_cast<const mem_topology *>(raw_mem.data());
-  if (map->m_count <= 0 || 
-      raw_mem.size() < sizeof(mem_topology) + (static_cast<size_t>(map->m_count) - 1) * sizeof(mem_data)) 
-  {
+  const mem_topology *map = (mem_topology *)raw_mem.data();
+
+  if (raw_mem.empty()) {
     std::cout << "WARNING: 'mem_topology' not found, "
-        << "unable to query ECC info. Has the xclbin been loaded? "
-        << "See 'xbmgmt status'." << std::endl;
+      << "unable to query ECC info. Has the xclbin been loaded? "
+      << "See 'xbmgmt status'." << std::endl;
     return;
   }
 
-    for(int32_t i = 0; i < map->m_count; i++) {
-      if(!map->m_mem_data[i].m_used)
-        continue;
-      reset.set_subdev(std::string(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag),
-                                   sizeof(map->m_mem_data[i].m_tag)));
-      dev->reset(reset);
-    }
+  // Ensure the blob is large enough to read m_count before dereferencing it.
+  if (raw_mem.size() < sizeof(map->m_count)) {
+    std::cout << "WARNING: 'mem_topology' section is malformed, skipping ECC reset." << std::endl;
+    return;
+  }
+
+  if (map->m_count == 0)
+    return;
+
+  // Validate blob is large enough to hold all claimed mem_data entries.
+  const size_t min_size = sizeof(mem_topology) + (map->m_count - 1) * sizeof(mem_data);
+  if (raw_mem.size() < min_size) {
+    std::cout << "WARNING: 'mem_topology' blob too small for m_count=" << map->m_count
+      << ", skipping ECC reset." << std::endl;
+    return;
+  }
+
+  for (int32_t i = 0; i < map->m_count; i++) {
+    if (!map->m_mem_data[i].m_used)
+      continue;
+
+    // m_tag is 16 bytes and may not be NUL-terminated in externally-produced xclbins.
+    const auto& tag = map->m_mem_data[i].m_tag;
+    reset.set_subdev(std::string(reinterpret_cast<const char *>(tag),
+                                 strnlen(reinterpret_cast<const char *>(tag), sizeof(tag))));
+    dev->reset(reset);
+  }
 }
 
 static void

--- a/src/runtime_src/core/tools/xbutil2/EventTracing/EventTraceNpu3.cpp
+++ b/src/runtime_src/core/tools/xbutil2/EventTracing/EventTraceNpu3.cpp
@@ -160,11 +160,16 @@ decode_event(const event_data_t& event_data) const
     decoded.description = event.description;
     decoded.categories = event.categories;
     
+    const size_t payload_bytes = static_cast<size_t>(event_data.payload_words) * 8; //NOLINT
+    const size_t payload_size = payload_bytes > event_header_bytes
+      ? payload_bytes - event_header_bytes 
+      : 0;
+
     // Extract arguments from struct payload
     size_t offset = 0;
     for (const auto& arg : event.args) {
       try {
-        std::string value = extract_arg_value(event_data.payload_ptr, offset, arg);
+        std::string value = extract_arg_value(event_data.payload_ptr, offset, payload_size, arg);
         decoded.args[arg.name] = value;
       } catch (const std::exception& e) {
         decoded.args[arg.name] = "ERROR: " + std::string(e.what());
@@ -205,6 +210,7 @@ std::string
 config_npu3::
 extract_arg_value(const uint8_t* payload_ptr,
                   size_t& offset,
+                  size_t payload_size,
                   const event_arg_npu3& arg) const
 {
   size_t type_size = get_type_size(arg.type);
@@ -216,6 +222,9 @@ extract_arg_value(const uint8_t* payload_ptr,
     for (uint32_t i = 0; i < arg.count; ++i) {
       if (i > 0) ss << ",";
       
+      if (offset + type_size > payload_size)
+        throw std::runtime_error("payload truncated");
+
       uint64_t value = 0;
       std::memcpy(&value, payload_ptr + offset, type_size);
       offset += type_size;
@@ -238,6 +247,9 @@ extract_arg_value(const uint8_t* payload_ptr,
     ss << "]";
   } else {
     // Single value
+    if (offset + type_size > payload_size)
+      throw std::runtime_error("payload truncated");
+
     uint64_t value = 0;
     std::memcpy(&value, payload_ptr + offset, type_size);
     offset += type_size;
@@ -312,6 +324,26 @@ parser_npu3(config_npu3 config)
   : m_config(std::move(config))
 {}
 
+std::optional<parser_npu3::located_entry>
+parser_npu3::
+locate_entry(const uint8_t* data_ptr, size_t buf_size, size_t offset) const
+{
+  if (offset >= buf_size || data_ptr[offset] != header_magic)
+    return std::nullopt;
+
+  if (offset + min_entry_bytes > buf_size)
+    return std::nullopt;
+
+  const uint8_t payload_words = data_ptr[offset + 1];
+  const size_t entry_size = header_bytes
+                            + (static_cast<size_t>(payload_words) * 8) //NOLINT
+                            + footer_bytes;
+  if (offset + entry_size > buf_size)
+    return std::nullopt;
+
+  return located_entry{data_ptr + offset, entry_size};
+}
+
 parser_npu3::event_data_t
 parser_npu3::
 parse_payload(const uint8_t* buffer_ptr) const
@@ -346,19 +378,19 @@ parse(const uint8_t* data_ptr, size_t buf_size) const
 
   std::optional<uint16_t> prev_seq;
   for (size_t offset = 0; offset < buf_size; ) {
-    if (data_ptr[offset] != npu3_rbe_header_magic) {
-      offset++;
+    const auto located = locate_entry(data_ptr, buf_size, offset);
+    if (!located) {
+      ++offset;
       continue;
     }
-    auto event_data = parse_payload(data_ptr + offset);
-    const size_t entry_size = npu3_rbe_header_bytes 
-                              + (static_cast<size_t>(event_data.payload_words) * 8) //NOLINT
-                              + npu3_rbe_footer_bytes; 
+
+    const auto event_data = parse_payload(located->ptr);
     if (prev_seq)
       ss << format_sequence_gap(*prev_seq, event_data.sequence_number);
+
     prev_seq = event_data.sequence_number;
     ss << format_event(event_data);
-    offset += entry_size;
+    offset += located->size;
   }
   return ss.str();
 }

--- a/src/runtime_src/core/tools/xbutil2/EventTracing/EventTraceNpu3.h
+++ b/src/runtime_src/core/tools/xbutil2/EventTracing/EventTraceNpu3.h
@@ -20,18 +20,36 @@ namespace xrt_core { class device; }
 
 namespace xrt_core::tools::xrt_smi{
 
-constexpr uint8_t npu3_rbe_header_magic = 0xCA; // NOLINT This is hardcoded. Ideally this should come from the config json. TODO: remove this once this is a part of json
-constexpr uint8_t npu3_rbe_footer_magic = 0xBA; // NOLINT This is hardcoded. Ideally this should come from the config json. TODO: remove this once this is a part of json
-constexpr size_t npu3_rbe_header_bytes = 8;  // NOLINT RBE header: magic(1) + payload_words(2) + seq_num(2) + reserved(3)
-constexpr size_t npu3_event_header_bytes = 12; // NOLINT Event header: timestamp(8) + unique_id(4)
-constexpr size_t npu3_rbe_footer_bytes = 8;  // NOLINT RBE footer: reserved(3) + seq_num(2) + payload_words(2) + magic(1)
+// NPU3 event-trace record layout (one entry in the device buffer):
+//
+//   +-- header_bytes (8) -------------------------------------+
+//   | magic(1) | payload_words(1) | seq_num(2) | reserved(4) |
+//   +---------------------------------------------------------+
+//   +-- payload_words * 8 bytes -------------------------------+
+//   | +-- event_header_bytes (12) ----+                       |
+//   | | timestamp(8) | event_id(4)     |  <- parse starts here |
+//   | +-------------------------------+                       |
+//   | event args (size/format from trace_events.json)         |
+//   +---------------------------------------------------------+
+//   +-- footer_bytes (8) -------------------------------------+
+//   | reserved(3) | seq_num(2) | payload_words(2) | magic(1)|
+//   +---------------------------------------------------------+
+//
+// Entry size = header_bytes + (payload_words * 8) + footer_bytes
+// min_entry_bytes = header_bytes + event_header_bytes (fixed prefix before args)
+
+constexpr uint8_t header_magic = 0xCA; // NOLINT hardcoded; TODO: load from config json
+constexpr uint8_t footer_magic = 0xBA; // NOLINT hardcoded; TODO: load from config json
+constexpr size_t header_bytes = 8;     // NOLINT see layout above
+constexpr size_t event_header_bytes = 12; // NOLINT see layout above
+constexpr size_t footer_bytes = 8;     // NOLINT see layout above
+constexpr size_t min_entry_bytes = header_bytes + event_header_bytes;
 
 
 /**
  * @brief NPU3-specific event trace configuration
- * 
- * Handles NPU3 format with variable-size events and struct-based payload.
- * Format: [timestamp:8][magic:0xAA][category_id:2][payload_size:1][payload:variable]
+ *
+ * Handles NPU3 variable-size records; see byte layout above header_bytes.
  */
 class config_npu3 : public event_trace_config {
 public:
@@ -57,8 +75,8 @@ public:
     uint64_t timestamp;
     uint32_t event_id;         // unique_id from event header
     const uint8_t* payload_ptr;
-    uint8_t payload_words;    // number of 64-bit words (from RBE header, 1 byte)
-    uint16_t sequence_number; // sequence number (from RBE header, 2 bytes)
+    uint8_t payload_words;    // number of 64-bit words (from record header, 1 byte)
+    uint16_t sequence_number; // sequence number (from record header, 2 bytes)
   };
 
 public:
@@ -124,6 +142,7 @@ private:
   std::string 
   extract_arg_value(const uint8_t* payload_ptr,
                     size_t& offset,
+                    size_t payload_size,
                     const event_arg_npu3& arg) const;
 
   size_t 
@@ -165,6 +184,14 @@ public:
         size_t buf_size) const override;
 
 private:
+  struct located_entry {
+    const uint8_t* ptr;
+    size_t size;
+  };
+
+  std::optional<located_entry>
+  locate_entry(const uint8_t* data_ptr, size_t buf_size, size_t offset) const;
+
   event_data_t parse_payload(const uint8_t* buffer_ptr) const;
 
   std::string format_event(const event_data_t& event_data) const;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Reject undersized or empty mem_topology sysfs blobs before iterating m_mem_data entries in reset_ecc(), preventing out-of-bounds reads. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-42781

#### How problem was solved, alternative solutions (if any) and why they were rejected
Resolved via accepting the ticket's suggestion

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
