### PR TITLE
SWSPLAT-9322 fix for heap buffer overflow

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -4529,6 +4529,13 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 			goto failed;
 		}
 
+		if (data_len > icap->rp_bit_len) {
+			ICAP_ERR(icap, "Write size %zu exceeds allocated buffer size %zu",
+				data_len, icap->rp_bit_len);
+			ret = -EINVAL;
+			goto failed;
+		}
+
 		ret = copy_from_user(icap->rp_bit, data, data_len);
 		if (ret) {
 			ICAP_ERR(icap, "copy bit file failed %ld", ret);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Heap buffer overflow in icap_write_rp — driver allocated memory based on m_length from the xclbin header but copied data based on the write() syscall's data_len with no bounds check between the two

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Reported via bug bounty (SWSPLAT-9322). No single PR introduced it — the missing check was in the original implementation. Discovered by external security researcher.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Heap buffer overflow in icap_write_rp — driver allocated memory based on m_length from the xclbin header but copied data based on the write() syscall's data_len with no bounds check between the two

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
verified against the existing else branch guard. Requesting validation on a board with a normal xclbin download to confirm no regression.

#### Documentation impact (if any)
None