### PR TITLE
zocl: fix hw context use-after-free during client teardown (CR-1278833)

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -191,6 +191,7 @@ int kds_init_ert(struct kds_sched *kds, struct kds_ert *ert);
 int kds_init_client(struct kds_sched *kds, struct kds_client *client);
 void kds_fini_sched(struct kds_sched *kds);
 int kds_fini_ert(struct kds_sched *kds);
+void kds_fini_client_ctxs(struct kds_sched *kds, struct kds_client *client);
 void kds_fini_client(struct kds_sched *kds, struct kds_client *client);
 void kds_reset(struct kds_sched *kds);
 int kds_cfg_update(struct kds_sched *kds);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -692,12 +692,23 @@ kds_del_cu_context(struct kds_sched *kds, struct kds_client *client,
 	struct kds_cu_mgmt *cu_mgmt = NULL;
 	u32 cu_idx = cu_ctx->cu_idx;
 	int domain = cu_ctx->cu_domain;
-	uint32_t hw_ctx = cu_ctx->hw_ctx->hw_ctx_idx;
 	unsigned long submitted;
 	unsigned long completed;
 	bool bad_state = false;
+	uint32_t hw_ctx;
 	int wait_ms;
 	int cu_set;
+
+	/* kds_initialize_cu_ctx() does not set this; each shim assigns it
+	 * after kds_alloc_cu_ctx() returns, so NULL is reachable.
+	 */
+	if (!cu_ctx->hw_ctx) {
+		kds_err(client, "Client pid(%d) Domain(%d) CU(%d) has no hw context",
+			pid_nr(client->pid), domain, cu_idx);
+		return -EINVAL;
+	}
+
+	hw_ctx = cu_ctx->hw_ctx->hw_ctx_idx;
 
 	cu_mgmt = (domain == DOMAIN_PL) ? &kds->cu_mgmt : &kds->scu_mgmt;
 	if ((cu_idx >= MAX_CUS) || (!cu_mgmt->xcus[cu_idx])) {
@@ -1133,6 +1144,10 @@ _kds_fini_client(struct kds_sched *kds, struct kds_client *client,
 	if (!cctx)
 		return;
 
+	/* Nothing to drain. Keeps this safe to call more than once */
+	if (list_empty(&cctx->cu_ctx_list))
+		return;
+
 	kds_info(client, "Client pid(%d) has open context for %d slot",
 			pid_nr(client->pid), cctx->slot_idx);
 
@@ -1154,31 +1169,64 @@ out:
 	mutex_unlock(&client->lock);
 }
 
-void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
+/*
+ * kds_fini_client_ctxs() - Drain and release every CU context of a client
+ *
+ * Covers both the legacy contexts hanging off client->ctx_list and the
+ * hw_context ones hanging off hw_ctx->cu_ctx_list.
+ *
+ * The hardware contexts must still be alive when this runs.
+ * kds_del_cu_context() dereferences cu_ctx->hw_ctx and resolves the per hw
+ * context percpu counters through client_stat_read() to decide whether
+ * outstanding commands must be aborted. Releasing a hardware context before
+ * this point both dangles cu_ctx->hw_ctx and makes those counters read back
+ * zero, which silently skips the abort and leaves commands referencing a
+ * client that is about to be freed.
+ *
+ * Safe to call twice; the second call finds every list empty and does
+ * nothing.
+ */
+void kds_fini_client_ctxs(struct kds_sched *kds, struct kds_client *client)
 {
 	struct kds_client_hw_ctx *curr = NULL;
 	struct kds_client_ctx *c_curr = NULL;
 
 	/* Release legacy client's resources */
+	_kds_fini_client(kds, client, client->ctx);
+
+	list_for_each_entry(c_curr, &client->ctx_list, link)
+		_kds_fini_client(kds, client, c_curr);
+
+	/* release new hw client's resources */
+	list_for_each_entry(curr, &client->hw_ctx_list, link)
+		kds_fini_hw_ctx_client(kds, client, curr);
+}
+
+/*
+ * kds_fini_client() - Release client level state
+ *
+ * Destroys client->lock, so the caller must already have released its
+ * hardware contexts. Callers that manage hardware contexts themselves run
+ * kds_fini_client_ctxs() first, release those contexts, then call this.
+ */
+void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
+{
+	struct kds_client_hw_ctx *curr = NULL;
+
+	kds_fini_client_ctxs(kds, client);
+
+	/* Release the legacy client's default hw context. This must stay
+	 * here rather than move into the shims: a shim's own hw_ctx_list walk
+	 * may share xclbin_id with client->ctx, and a pure hw_context
+	 * client's first context is also index 0 and must not be freed by
+	 * this path.
+	 */
 	if ((client->ctx) || !list_empty(&client->ctx_list)) {
-		_kds_fini_client(kds, client, client->ctx);
-
-		if(!list_empty(&client->ctx_list))
-			list_for_each_entry(c_curr, &client->ctx_list, link)
-				_kds_fini_client(kds, client, c_curr);
-
 		mutex_lock(&client->lock);
 		curr = kds_get_hw_ctx_by_id(client, DEFAULT_HW_CTX_ID);
 		if (curr)
 			kds_free_hw_ctx(client, curr);
 		mutex_unlock(&client->lock);
-	}
-
-	if(!list_empty(&client->hw_ctx_list)) {
-		list_for_each_entry(curr, &client->hw_ctx_list, link) {
-			/* release new hw client's resources */
-			kds_fini_hw_ctx_client(kds, client, curr);
-		}
 	}
 
 	mutex_lock(&client->lock);

--- a/src/runtime_src/core/common/drv/kds_hwctx.c
+++ b/src/runtime_src/core/common/drv/kds_hwctx.c
@@ -132,6 +132,13 @@ void kds_fini_hw_ctx_client(struct kds_sched *kds, struct kds_client *client,
 	if (!hw_ctx)
 		return;
 
+	/* Nothing to drain. A legacy client's default hw context reaches
+	 * here with an empty list, since its CU contexts live on
+	 * kds_client_ctx::cu_ctx_list instead.
+	 */
+	if (list_empty(&hw_ctx->cu_ctx_list))
+		return;
+
 	kds_info(client, "Client pid(%d) has open context for %d slot",
 			pid_nr(client->pid), hw_ctx->slot_idx);
 

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
@@ -289,11 +289,13 @@ out:
 /*
  * Release hw contexts on client exit. Legacy apps use ctx_list for
  * bitstream unlock; hw_context API apps need unlock here.
+ *
+ * The caller must have run kds_fini_client_ctxs() first, since a hw context
+ * cannot be freed while CU contexts still reference it.
  */
 static void zocl_fini_client_hw_ctxs(struct drm_zocl_dev *zdev,
 				     struct kds_client *client)
 {
-	struct kds_sched *kds = &zdev->kds;
 	struct kds_client_hw_ctx *hw_ctx, *next;
 	struct zocl_hw_graph_ctx *graph_ctx;
 	struct list_head *gptr, *gnext;
@@ -301,9 +303,6 @@ static void zocl_fini_client_hw_ctxs(struct drm_zocl_dev *zdev,
 	uuid_t *xclbin_id;
 	u32 s_id;
 	bool unlock = list_empty(&client->ctx_list);
-
-	list_for_each_entry_safe(hw_ctx, next, &client->hw_ctx_list, link)
-		kds_fini_hw_ctx_client(kds, client, hw_ctx);
 
 	mutex_lock(&client->lock);
 	list_for_each_entry_safe(hw_ctx, next, &client->hw_ctx_list, link) {
@@ -356,12 +355,14 @@ void zocl_destroy_client(void *client_hdl)
 
 	kds = &zdev->kds;
 
-	/* kds_fini_client should released resources hold by the client.
-	 * release xclbin_id and unlock bitstream if needed.
+	/* Teardown runs in three ordered phases. A kds_client_hw_ctx must
+	 * outlive every kds_client_cu_ctx that references it, and
+	 * kds_fini_client() destroys client->lock, which phase 2 needs.
 	 */
 	zocl_aie_kds_del_graph_context_all(client);
-	zocl_fini_client_hw_ctxs(zdev, client);
-	kds_fini_client(kds, client);
+	kds_fini_client_ctxs(kds, client);	/* drain and free CU contexts */
+	zocl_fini_client_hw_ctxs(zdev, client);	/* unlock and free hw contexts */
+	kds_fini_client(kds, client);		/* destroy the client */
 
 	/* Delete all the existing context associated to this device for this
 	 * client.

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_edge_kds.c
@@ -168,7 +168,8 @@ zocl_add_context(struct drm_zocl_dev *zdev, struct kds_client *client,
         if (!hw_ctx) {
                 DRM_ERROR("No valid HW context is open");
 		zocl_remove_client_context(zdev, client, cctx);
-                return -EINVAL;
+			ret = -EINVAL;
+			goto out;
         }
 
         cu_ctx->hw_ctx = hw_ctx;


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1278833

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Killing an app that still holds a CU context caused a use-after-free in zocl client teardown. On edge this oopsed when the process was killed at reboot, leaving the board needing a hard power cycle. The issue was reproducible even when if we kill without reboot. The issue was with the recet teardown changes.

zocl_destroy_client() released the hardware contexts before the CU contexts that reference them. Legacy xrt::device clients keep their CU contexts on client->ctx_list, not hw_ctx->cu_ctx_list, so kds_free_hw_ctx()'s empty-list guard passed and left every cu_ctx->hw_ctx dangling. That both faulted on the freed object and zeroed the drain counters, skipping the abort and letting a command complete into notify_execbuf() on a freed client.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Moved the CU-context teardown into a new kds_fini_client_ctxs(), so teardown runs in three phases: free CU contexts, release hardware contexts, destroy the client. The change on this PR makes sure the teardown happens in phases in right order.

#### Risks (if any) associated the changes in the commit

Low

#### What has been tested and how, request additional testing if necessary

Tested on VCK190 EDF with legacy xrt::device application by multiple run+reboot and run+kill -9 iterations with no oops and the board always recovering.
I've also tested below usecases:
- AIE only, multiple AIE only
- PL+AIE only
- I've simulated the "run+kill" and "run+reboot" on above usecases and no crash/oops were observed and incase of reboot the board was rebooting perfectly.

#### Documentation impact (if any)

None.