### PR TITLE
Security fixes: trace buffer, exec buffer, debug IP layout (leet audit)

### DIFF
--- a/src/runtime_src/core/pcie/linux/debug.cpp
+++ b/src/runtime_src/core/pcie/linux/debug.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2015-2017 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "pcidev.h"
 #include "shim.h"
@@ -76,9 +76,21 @@ namespace xocl {
     if( ifs ) {
       //debug_ip_layout max size is 65536
       ifs.read(buffer, 65536);
-      if (ifs.gcount() > 0) {
+      auto bytes_read = static_cast<size_t>(ifs.gcount());
+      // debug_ip_layout is: uint16_t m_count followed by debug_ip_data m_debug_ip_data[]
+      // offsetof() gives the byte offset to the array, i.e. the header size.
+      // We need at least that many bytes before we can safely read m_count and
+      // index into m_debug_ip_data[].
+      if (bytes_read > offsetof(debug_ip_layout, m_debug_ip_data)) {
         map = (debug_ip_layout*)(buffer);
-        for( unsigned int i = 0; i < map->m_count; i++ ) {
+        // Derive how many complete debug_ip_data entries fit in the bytes we
+        // actually read, then clamp m_count (from the xclbin) to that limit.
+        // This prevents walking off the end of the stack buffer when the xclbin
+        // supplies an inflated m_count.
+        auto max_entries = (bytes_read - offsetof(debug_ip_layout, m_debug_ip_data))
+                           / sizeof(debug_ip_data);
+        auto entry_count = std::min(static_cast<size_t>(map->m_count), max_entries);
+        for( unsigned int i = 0; i < entry_count; i++ ) {
           if (count >= size) break;
           if (map->m_debug_ip_data[i].m_type == type) {
             if(baseAddress)baseAddress[count] = map->m_debug_ip_data[i].m_base_address;

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2225,7 +2225,7 @@ int shim::xclGetTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint3
   uint32_t bytesPerSample = (xdp::TRACE_FIFO_WORD_WIDTH / 8);
 
   traceBufSz = xdp::MAX_TRACE_NUMBER_SAMPLES_FIFO * bytesPerSample;   /* Buffer size in bytes */
-  traceSamples = std::min(nSamples, xdp::MAX_TRACE_NUMBER_SAMPLES_FIFO);
+  traceSamples = std::min(nSamples, static_cast<uint32_t>(xdp::MAX_TRACE_NUMBER_SAMPLES_FIFO));
 
   return 0;
 }

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2016-2022 Xilinx, Inc
-// Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "shim.h"  // This file implements shim.h
 #include "xrt.h"   // This file implements xrt.h
@@ -2225,7 +2225,7 @@ int shim::xclGetTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint3
   uint32_t bytesPerSample = (xdp::TRACE_FIFO_WORD_WIDTH / 8);
 
   traceBufSz = xdp::MAX_TRACE_NUMBER_SAMPLES_FIFO * bytesPerSample;   /* Buffer size in bytes */
-  traceSamples = nSamples;
+  traceSamples = std::min(nSamples, xdp::MAX_TRACE_NUMBER_SAMPLES_FIFO);
 
   return 0;
 }
@@ -2239,6 +2239,8 @@ int shim::xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamp
 
     wordsPerSample = (xdp::TRACE_FIFO_WORD_WIDTH / 32);
     uint32_t numWords = numSamples * wordsPerSample;
+    if (numWords > static_cast<uint32_t>(traceBufWordSz))
+      numWords = traceBufWordSz;
 
 //    alignas is defined in c++11
 #if GCC_VERSION >= 40800

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
-// Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 #include "xrtexec.hpp"
 #include "xrt/device/device.h"
 #include "core/common/bo_cache.h"
@@ -278,8 +278,12 @@ exec_cu_command::
 add(index_type idx, value_type value)
 {
   const auto skip = 1 + 1 + m_impl->ert_cu->extra_cu_masks; // header, cumask, extra cu
+  constexpr auto max_words = xrt_core::bo_cache::bo_size / sizeof(uint32_t);
+  if (skip + idx >= max_words)
+    throw std::runtime_error("exec_cu_command: register index out of range");
+
   (*m_impl)[skip+idx] = value;
-  m_impl->ert_pkt->count = std::max(m_impl->ert_pkt->count,skip+idx);
+  m_impl->ert_pkt->count = std::max(m_impl->ert_pkt->count, skip + idx);
 }
 
 exec_write_command::

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -317,7 +317,7 @@ exec_write_command::
 add(addr_type addr, value_type value)
 {
   constexpr auto max_words = xrt_core::bo_cache::bo_size / sizeof(uint32_t);
-  if (m_impl->ert_pkt->count + 2 >= max_words)
+  if (static_cast<size_t>(m_impl->ert_pkt->count) + 2 >= max_words)
     throw std::runtime_error("exec_write_command: exec buffer full");
 
   (*m_impl)[++m_impl->ert_pkt->count] = addr;

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -316,6 +316,10 @@ void
 exec_write_command::
 add(addr_type addr, value_type value)
 {
+  constexpr auto max_words = xrt_core::bo_cache::bo_size / sizeof(uint32_t);
+  if (m_impl->ert_pkt->count + 2 >= max_words)
+    throw std::runtime_error("exec_write_command: exec buffer full");
+
   (*m_impl)[++m_impl->ert_pkt->count] = addr;
   (*m_impl)[++m_impl->ert_pkt->count] = value;
 }


### PR DESCRIPTION
#### Problem solved by the commit

Four security vulnerabilities identified by internal AI-assisted security
audit (leet campaign, reporter: obittner).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

- **AIESW-42831** `xrt/xrt++/xrtexec.cpp`: `exec_cu_command::add()` wrote
  past a fixed 4096-byte exec BO when `idx >= ~1019` — no bounds check on
  the caller-supplied register index.
- **AIESW-42830** `xrt/xrt++/xrtexec.cpp`: `exec_write_command::add()`
  pre-incremented `ert_pkt->count` past the 1024-word exec buffer after
  512 calls — no check that two more words fit before writing.
- **AIESW-42778** `core/pcie/linux/shim.cpp`: `xclReadTraceData()` used a
  fixed-size stack VLA but iterated `numSamples * wordsPerSample` words
  with no bound against the buffer capacity; `xclGetTraceBufferInfo()`
  passed the device-supplied sample count unclamped.
- **AIESW-42777** `core/pcie/linux/debug.cpp`: `getIPCountAddrNames()`
  iterated `map->m_count` entries (xclbin-controlled `uint16_t`) from a
  64 KiB stack buffer with no check against actual bytes read from sysfs.

#### How problem was solved, alternative solutions (if any) and why they were rejected

- **42831/42830**: Throw before writing when the exec buffer is full, using
  `bo_cache::bo_size` to derive the word limit at compile time.
- **42778**: Clamp `traceSamples` to `MAX_TRACE_NUMBER_SAMPLES_FIFO` in
  `xclGetTraceBufferInfo()` and clamp `numWords` to `traceBufWordSz` in
  `xclReadTraceData()`. Note: the primary caller already clamps upstream;
  these are defence-in-depth guards at the shim boundary.
- **42777**: Derive `max_entries` from `bytes_read` using `offsetof()` and
  `sizeof(debug_ip_data)`; clamp loop to `min(m_count, max_entries)`.

#### Risks (if any) associated the changes in the commit

Low. All changes add guards on paths that are either off by default
(trace profiling) or require a crafted xclbin to trigger. Happy paths
are unaffected.

#### What has been tested and how, request additional testing if necessary

Compile-verified. Please run exec command tests and debug IP status
tests (`xclDebugReadIPStatus`) on PCIe devices.

#### Documentation impact (if any)

None.