### PR TITLE
AIESW-36809 Remove mentions of Xilinx Runtime in xrt-smi output

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportHost.cpp
@@ -145,7 +145,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << xrt_version_ss.str();
   }
   catch (const boost::property_tree::ptree_error &ex) {
-    throw xrt_core::error(boost::str(boost::format("%s. Please contact your Xilinx representative to fix the issue")
+    throw xrt_core::error(boost::str(boost::format("%s. Please contact your representative to fix the issue")
          % ex.what()));
   }
   _output << std::endl << "Device(s) Present\n";


### PR DESCRIPTION
#### Problem solved by the commit
https://jira.xilinx.com/browse/AIESW-36809 Remove mentions of Xilinx Runtime in xrt-smi output, replace with FleXible Runtime as applicable
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Internal request
#### How problem was solved, alternative solutions (if any) and why they were rejected
Scanned xrt-smi output for mentions of "Xilinx" or "Xilinx Runtime", could only find one such place in error output. Scanned through xrt-smi rst documentation as well. Other locations mention XRT, which have been left alone.
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Tested on STX
#### Documentation impact (if any)
N/A