### PR TITLE
xrt_bo: compose a nested sub-buffer's device address through its parent

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -979,7 +979,12 @@ public:
   uint64_t
   get_address() const override
   {
-    return bo_impl::get_address() + m_offset;
+    // Compose through the parent, which may itself be a sub-buffer.  The
+    // base implementation resolves the address from the shim handle, and
+    // bo_impl(parent, size) copies that handle transitively, so it yields
+    // the root buffer's address and drops any intermediate offset.  This
+    // matches how m_hbuf and sync() already recurse through m_parent.
+    return m_parent->get_address() + m_offset;
   }
 
   void


### PR DESCRIPTION
## Problem

`buffer_sub` resolves three views of the same sub-buffer, and two of them compose through the parent
while the third does not:

```cpp
m_hbuf       = static_cast<char*>(m_parent->get_hbuf()) + m_offset;   // composes
sync(...)    -> m_parent->sync(dir, sz, offset + m_offset);           // composes
get_address() -> bo_impl::get_address() + m_offset;                   // does not
```

`bo_impl::get_address()` resolves the address from the shim handle, and `bo_impl(parent, size)`
copies that handle transitively, so it yields the root buffer's address no matter how deep the
nesting. A sub-buffer of a sub-buffer therefore drops the intermediate offset and reports a host
pointer and a device address that disagree.

The public constructor documents the parameter only as "Parent buffer", with no restriction against
passing a sub-buffer, so this fails silently rather than being a stated limitation.

## Fix

Compose through `m_parent`, matching what `m_hbuf` and `sync()` already do. `get_address()` is
virtual, so a parent that is itself a sub-buffer recurses correctly.

## Test / Evidence

Modelling the class structure (root at `0x40000000`, parent offset `0x100`, child offset `0x40`):

| | 1-level | 2-level | hbuf delta |
|---|---|---|---|
| before | `0x40000100` | `0x40000040` | `0x140` |
| after  | `0x40000100` | `0x40000140` | `0x140` |

The single-level case is unchanged, so no existing caller moves. In the nested case the host pointer
already composed to `+0x140` while the device address reported `+0x40`.

## Scope

I have not found an in-tree test that nests sub-buffers, which is consistent with this never having
been hit: `xrt::bo::bo(parent, size, offset)` callers I can see all derive from a root buffer. Happy
to add a test if you can point me at the right home for it.
