### PR TITLE
Add RHEL 9.8, RHEL 10.2, Ubuntu 26.04 to build matrix

### DIFF
--- a/.github/workflows/xrt_master_2026.2.yml
+++ b/.github/workflows/xrt_master_2026.2.yml
@@ -24,15 +24,24 @@ jobs:
           - os: rhel8.10      
             packageType: rpm
             os_ver: rhel_8.10  
-          - os: rhel10.0      
+          - os: rhel10.0
             packageType: rpm
-            os_ver: rhel_10.0      
+            os_ver: rhel_10.0
+          - os: rhel9.8
+            packageType: rpm
+            os_ver: rhel_9.8
+          - os: rhel10.2
+            packageType: rpm
+            os_ver: rhel_10.2
           - os: hip      
             packageType: deb
             os_ver: ubuntu_22.04
-          - os: ubuntu2404      
+          - os: ubuntu2404
             packageType: deb
-            os_ver: ubuntu_24.04  
+            os_ver: ubuntu_24.04
+          - os: ubuntu2604
+            packageType: deb
+            os_ver: ubuntu_26.04
           - os: npu      
             packageType: deb
             os_ver: ubuntu_22.04    


### PR DESCRIPTION
Adding new 2026.2 OS targets to the nightly build matrix per APRO-7760 Host OS Support requirements. Docker images and setenv-XRT changes are in separate PRs.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
