### PR TITLE
info_platform: report the AIE architecture version for Ryzen devices

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -71,8 +71,8 @@ add_static_region_info(const xrt_core::device* device, ptree_type& pt)
         (smi_hw.get_hardware_type(xrt_core::device_query<xq::pcie_id>(device)));
       static_region.add("aie_architecture_version", arch.value_or("N/A"));
     }
-    catch (const xq::exception&) {
-      // No PCIe identity to resolve; leave the key out rather than guess.
+    catch (...) {
+      static_region.add("aie_architecture_version", "N/A");
     }
     break;
   }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE
 #include "info_platform.h"
+#include "core/common/smi/smi.h"
 #include "query_requests.h"
 #include "sensor.h"
 #include "utils.h"
@@ -63,6 +64,16 @@ add_static_region_info(const xrt_core::device* device, ptree_type& pt)
     static_region.add("name", xrt_core::device_query<xq::rom_vbnv>(device));
     const auto total_cols = xrt_core::device_query_default<xq::total_cols>(device, 0);
     static_region.add("total_columns", total_cols);
+
+    try {
+      const xrt_core::smi::smi_hardware_config smi_hw;
+      const auto arch = xrt_core::smi::smi_hardware_config::get_aie_architecture_version
+        (smi_hw.get_hardware_type(xrt_core::device_query<xq::pcie_id>(device)));
+      static_region.add("aie_architecture_version", arch.value_or("N/A"));
+    }
+    catch (const xq::exception&) {
+      // No PCIe identity to resolve; leave the key out rather than guess.
+    }
     break;
   }
   }

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -282,7 +282,7 @@ public:
     return get_family(get_hardware_type(dev));
   }
 
-  // AIE architecture version string for examine JSON; nullopt when unknown.
+  // AIE architecture version string for the examine and platform reports; nullopt when unknown.
   XRT_CORE_COMMON_EXPORT
   static std::optional<std::string>
   get_aie_architecture_version(hardware_type hw);

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -54,6 +54,10 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "Power Mode" % pt_status.get<std::string>("power_mode");
     _output << boost::format("  %-23s: %s \n") % "Total Columns" % pt_static_region.get<std::string>("total_columns");
 
+    const auto aie_arch = pt_static_region.get<std::string>("aie_architecture_version", "");
+    if (!aie_arch.empty())
+      _output << boost::format("  %-23s: %s \n") % "AIE Architecture" % aie_arch;
+
     auto watts = pt_platform.get<std::string>("electrical.power_consumption_watts", "N/A");
     if (watts != "N/A")
       _output << std::endl << boost::format("%-23s  : %s Watts\n") % "Estimated Power" % watts;


### PR DESCRIPTION

## Problem

`xrt-smi examine` reports `aie_architecture_version` (`aie2`, `aie2p`, `aie4`, `aie2ps`), resolved
from `query::pcie_id` through `smi_hardware_config` (#9861). The same fact is not reachable from the
library: `xrt::device::get_info<xrt::info::device::platform>()` puts only `name` and `total_columns`
in the Ryzen static region, so a program linked against XRT -- including pyxrt consumers -- has to
run `xrt-smi` and parse its output to learn which AIE architecture it is on.

The `name` field is not a substitute. It is the driver's vbnv string, resolved at runtime from a
firmware revision query, so it carries the SKU name and falls back to a different naming scheme when
that query fails. On this host `{0x17f0, 0x10}` reports `NPU Gorgon Point 1`, while the same pair is
`stxB0` in `hardware_map`.

## Fix

Add `aie_architecture_version` to the Ryzen branch of `add_static_region_info`, resolved through the
same `smi_hardware_config` helper and stored under the same key as the examine report, with `N/A`
when the identity cannot be resolved -- so the key is always present, as it already is in the alveo
branch of the same function. `ReportRyzenPlatform` prints it.

No new query and no new API surface: there is no added `xrt::info::device` enumerator and no
signature change. It is additive to the JSON that `xrt::device::get_info<xrt::info::device::platform>()`
already returns, which is a change to that output's shape, not to the API itself.

## Test

Built Release with `-DXRT_NPU=1 -DXRT_ENABLE_WERROR=1`; `xrt-smi` links clean.

The NPU on this host is `{device 0x17f0, revision 0x10}` (`/sys/class/accel/accel0/device/`), vbnv
`NPU Gorgon Point 1`. Calling the resolver this patch uses, in the library built from this branch:

```
17f0:10   family=strix   get_aie_architecture_version=aie2p
```

so the Ryzen platform report gains `aie_architecture_version: aie2p` next to the existing `name` and
`total_columns`.

## Scope

I could not run the built `xrt-smi` against the device on this host: the tree is 2.26.0 while the
installed NPU driver plugin is 2.21.75, and the core-to-plugin interface is not versioned across that
gap. The rendering path is covered by construction rather than by a device run.
