### PR TITLE
smi: handle aie2ps explicitly and make the family switches exhaustive

### DIFF
--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -321,11 +321,10 @@ is_aie2_platform(hardware_type hw)
   switch (get_family(hw)) {
   case hardware_family::phoenix:
   case hardware_family::strix:
+  case hardware_family::aie2ps:
     return true;
   case hardware_family::npu3:
     return false;
-  case hardware_family::aie2ps:
-    throw std::runtime_error("is_aie2_platform is not defined for the aie2ps family");
   case hardware_family::unknown:
     throw std::runtime_error("Unsupported hardware type");
   }
@@ -341,11 +340,10 @@ get_validate_archive_path(hardware_type hw)
   case hardware_family::phoenix:
     return "Runner/xrt_smi_phx.a";
   case hardware_family::strix:
+  case hardware_family::aie2ps:
     return "Runner/xrt_smi_strx.a";
   case hardware_family::npu3:
     return "Runner/xrt_smi_npu3.a";
-  case hardware_family::aie2ps:
-    throw std::runtime_error("No validate archive is built for the aie2ps family");
   case hardware_family::unknown:
     throw std::runtime_error("Unsupported hardware type");
   }

--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -267,9 +267,13 @@ get_family(hardware_type hw)
   case hardware_type::aie2ps:
     return hardware_family::aie2ps;
   case hardware_type::unknown:
-  default:
     return hardware_family::unknown;
   }
+
+  // -Wreturn-type requires a statement here even though the switch covers every
+  // enumerator, because a value cast in from outside the enum matches no case.
+  // Not a default: label, which would also hide the next enumerator from -Wswitch.
+  return hardware_family::unknown;
 }
 
 std::optional<std::string>
@@ -285,9 +289,11 @@ get_aie_architecture_version(hardware_type hw)
     return "aie4";
   case hardware_family::aie2ps:
     return "aie2ps";
-  default:
+  case hardware_family::unknown:
     return std::nullopt;
   }
+
+  return std::nullopt;
 }
 
 bool
@@ -318,9 +324,13 @@ is_aie2_platform(hardware_type hw)
     return true;
   case hardware_family::npu3:
     return false;
-  default:
+  case hardware_family::aie2ps:
+    throw std::runtime_error("is_aie2_platform is not defined for the aie2ps family");
+  case hardware_family::unknown:
     throw std::runtime_error("Unsupported hardware type");
   }
+
+  throw std::runtime_error("Unsupported hardware type");
 }
 
 std::string
@@ -334,9 +344,13 @@ get_validate_archive_path(hardware_type hw)
     return "Runner/xrt_smi_strx.a";
   case hardware_family::npu3:
     return "Runner/xrt_smi_npu3.a";
-  default:
+  case hardware_family::aie2ps:
+    throw std::runtime_error("No validate archive is built for the aie2ps family");
+  case hardware_family::unknown:
     throw std::runtime_error("Unsupported hardware type");
   }
+
+  throw std::runtime_error("Unsupported hardware type");
 }
 
 tuple_vector

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -189,10 +189,19 @@ create_config_generator(smi_hardware_config::hardware_type hw)
   case smi_hardware_config::hardware_family::npu3:
     generator = std::make_shared<config_gen_npu3>();
     break;
-  default:
+  case smi_hardware_config::hardware_family::aie2ps:
+  case smi_hardware_config::hardware_family::unknown:
+    // No aie2ps generator exists, so these keep the strix config they already
+    // got. Stated rather than left to default:, which would silently absorb the
+    // next family as well.
     generator = std::make_shared<config_gen_strix>();
     break;
   }
+
+  // The switch covers every enumerator, but a value cast in from outside the
+  // enum matches no case, so keep the strix fallback default: used to give it.
+  if (!generator)
+    generator = std::make_shared<config_gen_strix>();
 
   if (smi_hardware_config::is_pf_device(hw))
     generator->clear_validate_tests();

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -184,16 +184,15 @@ create_config_generator(smi_hardware_config::hardware_type hw)
     generator = std::make_shared<config_gen_phoenix>();
     break;
   case smi_hardware_config::hardware_family::strix:
+  case smi_hardware_config::hardware_family::aie2ps:
     generator = std::make_shared<config_gen_strix>();
     break;
   case smi_hardware_config::hardware_family::npu3:
     generator = std::make_shared<config_gen_npu3>();
     break;
-  case smi_hardware_config::hardware_family::aie2ps:
   case smi_hardware_config::hardware_family::unknown:
-    // No aie2ps generator exists, so these keep the strix config they already
-    // got. Stated rather than left to default:, which would silently absorb the
-    // next family as well.
+    // Kept on the strix config, which is what default: gave it before. Stated
+    // rather than left to default:, which would silently absorb the next family.
     generator = std::make_shared<config_gen_strix>();
     break;
   }


### PR DESCRIPTION

## Problem

Five switches dispatch on the two `smi_hardware_config` enums, each carrying its own `default:`, so
each has to be remembered separately when a family is added: `get_family` over `hardware_type`, then
`get_aie_architecture_version`, `is_aie2_platform` and `get_validate_archive_path` over
`hardware_family`, plus `create_config_generator` in `smi_ryzen.cpp`.

`aie2ps` was wired into `hardware_type`, into `hardware_map` (`{0xb052, 0x01}`), into `get_family`
and into `get_aie_architecture_version` -- but not into the other three. Behaviour on master, calling
into a library built from it:

```
pcie_id   family    get_aie_architecture_version   is_aie2_platform   get_validate_archive_path
1502:00   phoenix   aie2                           true               Runner/xrt_smi_phx.a
17f0:10   strix     aie2p                          true               Runner/xrt_smi_strx.a
17f1:15   npu3      aie4                           false              Runner/xrt_smi_npu3.a
b052:01   aie2ps    aie2ps                         THROW              THROW
17f0:99   unknown   <nullopt>                      THROW              THROW
```

So on such a part `xrt-smi examine` answers while everything behind `is_aie2_platform` throws --
`TestGemm`, `TestSanity`, `TestPreeemptionOverhead`, `TestTCTOneColumn`, `TestTCTAllColumn`,
`EventTraceBase` and `OO_ContextHealth`, all of them reaching it through
`XBUtilities::is_strix_hardware`.

`create_config_generator` fails differently and worse: its `default:` returns `config_gen_strix`, so
an aie2ps device is silently given the strix `xrt-smi` subcommand config from `populate_smi_instance`
with no error at all.

In both shapes the `default:` label is what let the omission through. The last two rows of the table
also share one message, so "a family nobody wired up" and "a device not in the map" are
indistinguishable.

## Fix

Drop the `default:` labels and enumerate every enumerator. Behaviour is unchanged: `aie2ps` and
`unknown` still throw from the same two functions, the `unknown` message is byte-identical, aie2ps
still gets the strix generator. Only the two `aie2ps` throw messages become specific about which case
they are.

The trailing statement after each switch is deliberate. It is required -- `-Werror=return-type` fires
on all five without it, since a value cast in from outside the enum matches no case -- and it is not
a `default:` label, which would put the next omission back out of `-Wswitch`'s reach.

## Test

Both files compile clean at `-Wall -Werror`. Same five inputs after the change:

```
pcie_id   family    get_aie_architecture_version   is_aie2_platform   get_validate_archive_path
1502:00   phoenix   aie2                           true               Runner/xrt_smi_phx.a
17f0:10   strix     aie2p                          true               Runner/xrt_smi_strx.a
17f1:15   npu3      aie4                           false              Runner/xrt_smi_npu3.a
b052:01   aie2ps    aie2ps                         THROW (aie2ps)     THROW (aie2ps)
17f0:99   unknown   <nullopt>                      THROW              THROW
```

Every row is what it was; the aie2ps throws now name the case, `unknown` is unchanged.

Adding one enumerator to each enum, as a temporary check, fails the build at all five sites:

```
smi.cpp:237:10:       error: enumeration value 'probe_new_family' not handled in switch [-Werror=switch]
smi.cpp:283:10:       error: enumeration value 'probe_new_family' not handled in switch [-Werror=switch]
smi.cpp:303:10:       error: enumeration value 'probe_new_family' not handled in switch [-Werror=switch]
smi.cpp:322:10:       error: enumeration value 'probe_new_family' not handled in switch [-Werror=switch]
smi_ryzen.cpp:180:10: error: enumeration value 'probe_new_family' not handled in switch [-Werror=switch]
```

## Scope

The build-time check covers GCC and Clang, which get `-Wall` from `XRT_WARN_OPTS`
(`CMake/settings.cmake`) and `-DXRT_ENABLE_WERROR=1`. It does not cover MSVC: the Windows build uses
`/WX /W4` (`src/runtime_src/CMakeLists.txt:86`) and C4061/C4062 are off at `/W4`, so on Windows a
future unhandled enumerator still falls through to the trailing statement silently.

## Open question

I did not change what `aie2ps` resolves to, because I do not know the intended answers and the tree
carries no evidence for them: `is_aie2_platform` splits the strix path from the npu3 path and neither
is obviously right for aie2ps, no `xrt_smi_aie2ps.a` exists for `get_validate_archive_path`, and
whether the strix subcommand config is actually correct for aie2ps or merely what `default:` happened
to give it is not something I can tell from here. If any of the three should resolve rather than
throw or fall back, tell me the values and I will fold them in.
