### PR TITLE
xrt-smi: write clocks report to output stream instead of stdout

### DIFF
--- a/src/runtime_src/core/tools/common/reports/ReportClocks.cpp
+++ b/src/runtime_src/core/tools/common/reports/ReportClocks.cpp
@@ -51,5 +51,5 @@ ReportClocks::writeReport(const xrt_core::device* /*_pDevice*/,
     ss << boost::format("  %-23s: %3s MHz\n") % pt_clock.get<std::string>("id") 
                                               % pt_clock.get<std::string>("freq_mhz");
   }
-  std::cout << ss.str();
+  _output << ss.str();
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
ReportClocks printed clock frequencies to std::cout while the section header went to the report buffer, so buffered examine output showed clock values before the trailing "Clocks" header.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-43912
The bug was introduced in Feb 2025 with PR #8749 (Move preemption and clocks to examine as advanced reports), which added ReportClocks.cpp. From the start, clock frequencies were written to std::cout while the "Clocks" header went to the report’s _output stream.

That mismatch stayed mostly hidden because produce_reports() wrote reports directly to the console stream, so the header usually appeared before the clock lines.

It became visible around Aug 13, 2026 with PR #9972 (AIESW-33855), which buffered each report in an ostringstream before flushing it. Clock lines still went to std::cout immediately (right after the device banner), while "Clocks" stayed in the buffer and was printed afterward — producing the stray Clocks line at the end.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via correctly adding to buffer stream

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on Linux : 
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/xrt/build$ xrt-smi examine --advanced -r clocks
-------------------------------------------------------------------------
                    DISCLAIMER  (xrt-smi --advanced)                     
You are running a developer command that may change system configuration.
                Continue only if you understand the risks.               
-------------------------------------------------------------------------

---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Clocks
  MP-NPU Clock           : 396 MHz
  H Clock                : 792 MHz
```

#### Documentation impact (if any)
None