### PR TITLE
AIESW-42781 SubCmdReset: fix OOB read parsing mem_topology in reset_ecc

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2019-2022 Xilinx, Inc
-// Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
@@ -19,6 +19,7 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+#include <cstring>
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
@@ -33,24 +34,46 @@ pretty_print_action_list(xrt_core::device* device, xrt_core::query::reset_type& 
     std::cout << "WARNING: " << reset.get_warning() << std::endl;
 }
 
-static void 
+static void
 reset_ecc(const std::shared_ptr<xrt_core::device>& dev, xrt_core::query::reset_type& reset)
 {
   auto raw_mem = xrt_core::device_query<xrt_core::query::mem_topology_raw>(dev);
   const mem_topology *map = (mem_topology *)raw_mem.data();
-    if(raw_mem.empty() || map->m_count == 0) {
-      std::cout << "WARNING: 'mem_topology' not found, "
-        << "unable to query ECC info. Has the xclbin been loaded? "
-        << "See 'xbmgmt status'." << std::endl;
-      return;
-    }
 
-    for(int32_t i = 0; i < map->m_count; i++) {
-      if(!map->m_mem_data[i].m_used)
-        continue;
-      reset.set_subdev(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag));
-      dev->reset(reset);
-    }
+  if (raw_mem.empty()) {
+    std::cout << "WARNING: 'mem_topology' not found, "
+      << "unable to query ECC info. Has the xclbin been loaded? "
+      << "See 'xbmgmt status'." << std::endl;
+    return;
+  }
+
+  // Ensure the blob is large enough to read m_count before dereferencing it.
+  if (raw_mem.size() < sizeof(map->m_count)) {
+    std::cout << "WARNING: 'mem_topology' section is malformed, skipping ECC reset." << std::endl;
+    return;
+  }
+
+  if (map->m_count == 0)
+    return;
+
+  // Validate blob is large enough to hold all claimed mem_data entries.
+  const size_t min_size = sizeof(mem_topology) + (map->m_count - 1) * sizeof(mem_data);
+  if (raw_mem.size() < min_size) {
+    std::cout << "WARNING: 'mem_topology' blob too small for m_count=" << map->m_count
+      << ", skipping ECC reset." << std::endl;
+    return;
+  }
+
+  for (int32_t i = 0; i < map->m_count; i++) {
+    if (!map->m_mem_data[i].m_used)
+      continue;
+
+    // m_tag is 16 bytes and may not be NUL-terminated in externally-produced xclbins.
+    const auto& tag = map->m_mem_data[i].m_tag;
+    reset.set_subdev(std::string(reinterpret_cast<const char *>(tag),
+                                 strnlen(reinterpret_cast<const char *>(tag), sizeof(tag))));
+    dev->reset(reset);
+  }
 }
 
 static void


### PR DESCRIPTION
#### Problem solved by the commit
Fix logic checks to match up with messages, and fix string ctor

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
AIESW-42871

#### How problem was solved, alternative solutions (if any) and why they were rejected
- raw_mem.empty() — section not found, user-facing diagnostic with xclbin hint
- size < sizeof(m_count) — section present but malformed, can't safely read the header
- m_count == 0 — silent return, nothing to do
- size < min_size — header readable but blob truncated relative to claimed entry count

Fix std::string construction to not pad with 0 up to 16 bytes. Padding is not the same as null terminating.
