### PR TITLE
zocl: fix oops on rmmod after failed AIE partition request

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_aie.c
@@ -384,12 +384,12 @@ zocl_aie_slot_reset(struct drm_zocl_slot* slot)
 void
 zocl_destroy_aie(struct drm_zocl_slot* slot)
 {
-	if (!slot->aie_information)
-		return;
-
 	mutex_lock(&slot->aie_lock);
-	vfree(slot->aie_information);
-	slot->aie_information = NULL;
+
+	if (slot->aie_information) {
+		vfree(slot->aie_information);
+		slot->aie_information = NULL;
+	}
 
 	if (!slot->aie) {
 		mutex_unlock(&slot->aie_lock);
@@ -425,7 +425,7 @@ zocl_cleanup_aie(struct drm_zocl_slot *slot)
 		 */
 		if( !slot->aie->aie_reset) {
 			ret = zocl_aie_slot_reset(slot);
-			if (ret)
+			if (ret && ret != -ENODEV)
 				return ret;
 		}
 
@@ -504,6 +504,7 @@ zocl_create_aie(struct drm_zocl_slot *slot, struct axlf *axlf, char __user *xclb
 	uint64_t offset;
 	uint64_t size;
 	struct aie_partition_req req;
+	struct device *aie_dev;
 	int rval = 0;
 
 	rval = xrt_xclbin_section_info(axlf, AIE_METADATA, &offset, &size);
@@ -563,16 +564,16 @@ zocl_create_aie(struct drm_zocl_slot *slot, struct axlf *axlf, char __user *xclb
 		goto done;
 	}
 
-	slot->aie->aie_dev = aie_partition_request(&req);
-
-
-	if (IS_ERR(slot->aie->aie_dev)) {
-		rval = PTR_ERR(slot->aie->aie_dev);
+	aie_dev = aie_partition_request(&req);
+	if (IS_ERR(aie_dev)) {
+		rval = PTR_ERR(aie_dev);
+		slot->aie->aie_dev = NULL;
 		DRM_ERROR("Request AIE partition %d, %d\n",
 		    req.partition_id, rval);
 		goto done;
 	}
 
+	slot->aie->aie_dev = aie_dev;
 	slot->aie->partition_id = req.partition_id;
 	slot->aie->uid = req.uid;
 


### PR DESCRIPTION
#### Problem solved by the commit

`rmmod zocl` oopses after an AIE partition request fails. `zocl_create_aie()`
stores the `ERR_PTR` from a failed `aie_partition_request()` into
`slot->aie->aie_dev`. Every other user tests that field with a plain NULL
check, which an `ERR_PTR` passes, so the bad handle reaches the AIE driver.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Pre-existing in `zocl_create_aie()`, not from a recent PR. Found on VEK385
revB: a PL+AIE test failed because partition 2058 was already in use, and a
later `rmmod zocl` crashed in `aie_partition_release()` with
`x0 = fffffffffffffff0`, i.e. `ERR_PTR(-EBUSY)`.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Request into a local and publish it only once valid, so `aie_dev` is always
NULL or a real device.

Two teardown paths needed fixing too, otherwise the crash is only traded for
a leaked `aie-workq` kthread: `zocl_destroy_aie()` returned early on
`!aie_information` (set on the success path only, after the workqueue is
created), and `zocl_cleanup_aie()` aborted on the `-ENODEV` the reset now
correctly returns.

#### Risks (if any) associated the changes in the commit

Low.

#### What has been tested and how, request additional testing if necessary

Reproduced on VE2 revB with partition 2058 held by another client. After
the fix the test fails cleanly with the same `ENODEV`, dmesg reports
`No available AIE partition`, and `rmmod zocl` unloads with no oops.


#### Documentation impact (if any)

None.