### PR TITLE
zocl: refresh CU IRQs on DT overlay apply/remove and teardown xclbin

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_drv.c
@@ -1372,6 +1372,123 @@ static void zocl_cu_intc_fini(struct drm_zocl_dev *zdev)
 	zdev->cu_subdev.cu_num = 0;
 }
 
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+static struct notifier_block zocl_overlay_nb;
+static bool zocl_overlay_nb_registered;
+
+static bool zocl_overlay_tree_has_fpga_accel(struct device_node *np)
+{
+	struct device_node *child;
+
+	if (!np)
+		return false;
+
+	if (of_node_cmp(np->name, "fpga_accelerator") == 0 &&
+	    of_property_present(np, "interrupts-extended"))
+		return true;
+
+	for_each_child_of_node(np, child) {
+		if (zocl_overlay_tree_has_fpga_accel(child)) {
+			of_node_put(child);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static int zocl_overlay_notify(struct notifier_block *nb, unsigned long action,
+			       void *data)
+{
+	struct of_overlay_notify_data *nd = data;
+	struct drm_zocl_dev *zdev = zocl_get_zdev();
+
+	if (!zdev || !nd)
+		return NOTIFY_DONE;
+
+	if (!zocl_overlay_tree_has_fpga_accel(nd->overlay))
+		return NOTIFY_DONE;
+
+	switch (action) {
+	case OF_OVERLAY_POST_APPLY:
+		DRM_INFO("fpga_accelerator overlay applied, refresh CU IRQs\n");
+		zocl_cu_irq_update(zdev);
+		break;
+	case OF_OVERLAY_PRE_REMOVE:
+		DRM_INFO("fpga_accelerator overlay removing, refresh CU IRQs\n");
+		zocl_cu_irq_update(zdev);
+		break;
+	default:
+		break;
+	}
+
+	return NOTIFY_DONE;
+}
+
+static int zocl_overlay_notifier_register(void)
+{
+	int ret;
+
+	if (zocl_overlay_nb_registered)
+		return 0;
+
+	zocl_overlay_nb.notifier_call = zocl_overlay_notify;
+	ret = of_overlay_notifier_register(&zocl_overlay_nb);
+	if (ret) {
+		DRM_WARN("Failed to register DT overlay notifier: %d\n", ret);
+		return ret;
+	}
+
+	zocl_overlay_nb_registered = true;
+	return 0;
+}
+
+static void zocl_overlay_notifier_unregister(void)
+{
+	if (!zocl_overlay_nb_registered)
+		return;
+
+	of_overlay_notifier_unregister(&zocl_overlay_nb);
+	zocl_overlay_nb_registered = false;
+}
+#else
+static int zocl_overlay_notifier_register(void)
+{
+	return 0;
+}
+
+static void zocl_overlay_notifier_unregister(void)
+{
+}
+#endif
+
+void zocl_cu_irq_update(struct drm_zocl_dev *zdev)
+{
+	struct drm_zocl_slot *slot;
+	int i, ret;
+
+	if (!zdev)
+		return;
+
+	zocl_cu_intc_refresh(zdev);
+
+	for (i = 0; i < zdev->num_pr_slot; i++) {
+		slot = zdev->pr_slot[i];
+		if (!slot || !slot->slot_xclbin || !slot->ip || !slot->axlf)
+			continue;
+		if (zocl_xclbin_is_aie_only(slot->axlf))
+			continue;
+
+		mutex_lock(&slot->slot_xclbin_lock);
+		zocl_destroy_cu_slot(zdev, slot->slot_idx);
+		ret = zocl_create_cu(zdev, slot);
+		if (ret)
+			DRM_WARN("Failed to recreate CUs after IRQ update on slot %d\n",
+				 slot->slot_idx);
+		mutex_unlock(&slot->slot_xclbin_lock);
+	}
+}
+
 /*
  *
  * Initialization of Xilinx openCL DRM platform device.
@@ -1559,6 +1676,8 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	if (ret)
 		goto err_sched;
 
+	(void)zocl_overlay_notifier_register();
+
 	return 0;
 
 /* error out in exact reverse order of init */
@@ -1592,6 +1711,8 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 {
 	struct drm_zocl_dev *zdev = platform_get_drvdata(pdev);
 	struct drm_device *drm = zdev->ddev;
+
+	zocl_overlay_notifier_unregister();
 
 	/* Cleanup of iommu domain, if exists */
 	if (zdev->domain) {

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_kds.c
@@ -325,6 +325,7 @@ static void zocl_fini_client_hw_ctxs(struct drm_zocl_dev *zdev,
 			if (s_id != 0)
 				zocl_destroy_aie(slot);
 			zdev->slot_mask &= ~(1 << s_id);
+			zocl_slot_remove_xclbin_overlay(zdev, slot);
 		}
 	}
 	mutex_unlock(&client->lock);

--- a/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/common/zocl_xclbin.c
@@ -610,6 +610,47 @@ void zocl_free_sections(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 	write_unlock(&zdev->attr_rwlock);
 }
 
+#if KERNEL_VERSION(5, 4, 0) <= LINUX_VERSION_CODE
+/*
+ * Remove a PARTITION_METADATA overlay that was applied when this slot's
+ * xclbin was loaded. Called when the last hw_context on the slot is destroyed.
+ */
+void zocl_slot_remove_xclbin_overlay(struct drm_zocl_dev *zdev,
+				     struct drm_zocl_slot *slot)
+{
+	int err;
+
+	if (!zdev || !slot || slot->partial_overlay_id == -1)
+		return;
+
+	mutex_lock(&slot->slot_xclbin_lock);
+	if (zocl_bitstream_is_locked(zdev, slot))
+		goto unlock;
+
+	zocl_destroy_cu_slot(zdev, slot->slot_idx);
+
+	err = of_overlay_remove(&slot->partial_overlay_id);
+	if (err < 0) {
+		DRM_WARN("%s: overlay remove failed (%d)\n", __func__, err);
+		goto refresh;
+	}
+
+	slot->partial_overlay_id = -1;
+	DRM_INFO("%s: removed xclbin DT overlay from slot %d\n",
+		 __func__, slot->slot_idx);
+
+refresh:
+	zocl_cu_intc_refresh(zdev);
+unlock:
+	mutex_unlock(&slot->slot_xclbin_lock);
+}
+#else
+void zocl_slot_remove_xclbin_overlay(struct drm_zocl_dev *zdev,
+				     struct drm_zocl_slot *slot)
+{
+}
+#endif
+
 /*
  * Load a bitstream, partial metadata or PDI to the FPGA from userspace pointer.
  *

--- a/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
+++ b/src/runtime_src/core/edge/drm/zocl/edge/zocl_hwctx.c
@@ -6,6 +6,7 @@
 #include "zocl_util.h"
 #include "zocl_hwctx.h"
 #include "zocl_aie.h"
+#include "zocl_xclbin.h"
 #include <drm/drm_print.h>
 
 int zocl_create_hw_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_create_hw_ctx *drm_hw_ctx, struct drm_file *filp, int slot_id)
@@ -86,6 +87,7 @@ int zocl_destroy_hw_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_destroy_hw_ct
             zocl_destroy_aie(slot);
         zdev->slot_mask &= ~(1 << s_id);
         DRM_DEBUG("Released the slot %d", s_id);
+        zocl_slot_remove_xclbin_overlay(zdev, slot);
     }
 
 error_out:

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -349,6 +349,7 @@ int zocl_context_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp);
 struct platform_device *zocl_find_pdev(char *name);
 void zocl_cu_intc_refresh(struct drm_zocl_dev *zdev);
+void zocl_cu_irq_update(struct drm_zocl_dev *zdev);
 int zert_cu_intc_refresh(void);
 
 static inline struct drm_zocl_dev *

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -77,6 +77,8 @@ int zocl_read_sect(enum axlf_section_kind kind, void *sect,
 int zocl_update_apertures(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot);
 void zocl_destroy_cu_slot(struct drm_zocl_dev *zdev, u32 slot_idx);
 int zocl_create_cu(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot);
+void zocl_slot_remove_xclbin_overlay(struct drm_zocl_dev *zdev,
+				     struct drm_zocl_slot *slot);
 inline bool zocl_xclbin_same_uuid(struct drm_zocl_slot *slot, xuid_t *uuid);
 int zocl_load_sect(struct drm_zocl_dev *zdev, struct axlf *axlf, char __user *xclbin,
 		   enum axlf_section_kind kind, struct drm_zocl_slot *slot);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Register an OF overlay notifier so fpgautil DTBO apply and remove update CU interrupt routing. Handle overlay removal in OF_OVERLAY_PRE_REMOVE before the kernel reverts the changeset, and remove zocl-applied PARTITION_METADATA overlays when the last hw_context on a slot is destroyed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Register OF overlay notifier when overlay has fpga_accelerator + interrupts-extended.
POST_APPLY: zocl_cu_irq_update() (refresh INTC + recreate CUs).
PRE_REMOVE (not POST_REMOVE): same on fpgautil -R before kernel reverts overlay.

#### Risks (if any) associated the changes in the commit
low. Changes are backward compatible

#### What has been tested and how, request additional testing if necessary
Tested on VEK385 with the updated zocl.ko
Legacy flow: embedded_exec.sh (8 CU vadd): PASS
fpgautil -o vadd_fpga_accel.dtbo: apply notifier PASS
fpgautil -R -n full: remove notifier PASS

#### Documentation impact (if any)
NA