### PR TITLE
Align npu_load platform reporting with power and temperature fields

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -166,10 +166,11 @@ void
 add_npu_load_info(const xrt_core::device* device, ptree_type& pt)
 {
   try {
-    pt.put("npu_load", xrt_core::device_query<xq::npu_load>(device));
+    const auto load = xrt_core::device_query<xq::npu_load>(device);
+    pt.put("npu_load", std::to_string(load));
   }
   catch (const xq::exception&) {
-    // Query not supported on this device
+    pt.put("npu_load", "N/A");
   }
 }
 

--- a/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
+++ b/src/runtime_src/core/tools/common/reports/platform/ReportRyzenPlatform.cpp
@@ -60,10 +60,11 @@ ReportRyzenPlatform::writeReport(const xrt_core::device* /*_pDevice*/,
     else
       _output << std::endl << boost::format("%-23s  : %s\n") % "Estimated Power" % watts;
 
-    if (auto load = pt_platform.get_optional<uint32_t>("npu_load"))
-      _output << boost::format("%-23s  : %u%%\n") % "NPU Load" % *load;
+    auto load = pt_platform.get<std::string>("npu_load", "N/A");
+    if (load != "N/A")
+      _output << boost::format("%-23s  : %s%%\n") % "NPU Load" % load;
     else
-      _output << boost::format("%-23s  : %s\n") % "NPU Load" % "N/A";
+      _output << boost::format("%-23s  : %s\n") % "NPU Load" % load;
 
     auto temp_c = pt_platform.get<std::string>("thermal.temp_C", "N/A");
     _output << boost::format("%-23s  : %s\n") % "Temperature (C)" % temp_c;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Emit npu_load as a string in platform JSON and read it the same way in the Ryzen platform text report so console and JSON stay consistent when the driver query is unsupported.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The CI failed on updating to latest XRT because of a test failure.
The xrt_smi_platform_medusa_default test failed with following error :
```
ERROR: NPU Load value N/A not found in logs/20260901_151733_examine_platform_short.json
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via handling the json output correctly. 

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested 

#### Documentation impact (if any)
