### PR TITLE
[AIESW-28579] : Sub Buffer export-import handling

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -369,13 +369,21 @@ public:
     throw xrt_core::error("buffer is not mapped");
   }
 
-  export_handle
+  virtual export_handle
   export_buffer() const
   {
     if (!shared_handle)
       shared_handle = handle->share();
 
     return shared_handle->get_export_handle();
+  }
+
+  // Returns the underlying allocation for this BO.
+  // For a regular BO this is itself; buffer_sub overrides to walk to the backing allocation.
+  virtual std::shared_ptr<bo_impl>
+  get_allocation()
+  {
+    return shared_from_this();
   }
 
   virtual void
@@ -970,6 +978,22 @@ public:
     return true;
   }
 
+  export_handle
+  export_buffer() const override
+  {
+    throw xrt_core::error(-EINVAL,
+      "Export of a sub-buffer is not supported. "
+      "Call get_allocation() to obtain the underlying buffer, export that, "
+      "then recreate the sub-buffer on the import side using the original offset and size.");
+  }
+
+  std::shared_ptr<bo_impl>
+  get_allocation() override
+  {
+    // Walk to the backing allocation, handling nested sub-buffers.
+    return m_parent->get_allocation();
+  }
+
   size_t
   get_offset() const override
   {
@@ -1561,6 +1585,13 @@ export_buffer()
   return xdp::native::profiling_wrapper("xrt::bo::export_buffer", [this]{
     return handle->export_buffer();
   });
+}
+
+bo
+bo::
+get_allocation()
+{
+  return bo{handle->get_allocation()};
 }
 
 void

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -553,6 +553,26 @@ public:
   export_buffer();
 
   /**
+   * get_allocation() - Get the underlying allocation for this buffer
+   *
+   * @return
+   *  For a regular buffer, returns this buffer itself.
+   *  For a sub-buffer, returns the backing buffer that owns the actual DRM
+   *  allocation, unwinding any chain of nested sub-buffers.
+   *
+   * Use this when you need to export a sub-buffer:
+   *  1. Call get_allocation() to obtain the backing buffer.
+   *  2. Export the backing buffer via export_buffer().
+   *  3. Transfer the export handle, sub-buffer offset and
+   *     sub-buffer size to the remote side via an IPC mechanism.
+   *  4. On the remote side, import the backing buffer and recreate the
+   *     sub-buffer using the received offset and size.
+   */
+  XCL_DRIVER_DLLESPEC
+  bo
+  get_allocation();
+
+  /**
    * async() - Start buffer content txfer with device side
    *
    * @param dir


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix sub buffer export import handling.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
It was discovered in local testing by VART team

#### How problem was solved, alternative solutions (if any) and why they were rejected
class buffer_sub inherits class bo_impl which is base impl class for xrt::bo and export_buffer() function is not virtual so buffer_sub uses same function which is incorrect.
Made export_buffer() as virtual and implemented it in sub buffer which throws exception. Users can export parent buffer and send fd, offset, size to importer and it can import parent and recreate sub buffer using offset, size.

Fix can also come from driver but it is tedious so following this approach

#### Risks (if any) associated the changes in the commit
Low

#### What has been tested and how, request additional testing if necessary
Tested on Telluride hw and things work as expected 
Checked in the test case to Telluride repo - https://gitenterprise.xilinx.com/XRT/Telluride/pull/808

#### Documentation impact (if any)
Added inline comments and doxygen comments