### PR TITLE
Remove validate tests from PFs

### DIFF
--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -292,6 +292,24 @@ get_aie_architecture_version(hardware_type hw)
 
 bool
 smi_hardware_config::
+is_pf_device(hardware_type hw)
+{
+  switch (hw) {
+  case hardware_type::npu3a_pf:
+  case hardware_type::npu3_B02_pf:
+  case hardware_type::npu7_pf:
+  case hardware_type::npu8_pf:
+  case hardware_type::npu9_pf:
+  case hardware_type::npu10_pf:
+  case hardware_type::npu11_pf:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool
+smi_hardware_config::
 is_aie2_platform(hardware_type hw)
 {
   switch (get_family(hw)) {

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -207,6 +207,11 @@ public:
   // Derived classes must implement this method to define hardware-specific configuration logic.
   virtual subcommand 
   create_configure_subcommand() = 0;
+
+  // Clears the validate test list for devices that expose validate but have no runnable tests.
+  virtual void
+  clear_validate_tests()
+  {}
 };
 
 // class smi_hardware_config
@@ -286,6 +291,10 @@ public:
   XRT_CORE_COMMON_EXPORT
   static bool
   is_aie2_platform(hardware_type hw);
+
+  // True for NPU PF PCIe functions (e.g. npu3a_pf, npu7_pf).
+  static bool
+  is_pf_device(hardware_type hw);
 
   // Validate-runner archive path relative to the platform archive root.
   XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/smi/smi_ryzen.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen.cpp
@@ -176,18 +176,28 @@ config_gen_npu3::create_examine_subcommand()
 }
 
 static std::shared_ptr<config_gen_ryzen>
-create_config_generator(smi_hardware_config::hardware_family family)
+create_config_generator(smi_hardware_config::hardware_type hw)
 {
-  switch (family) {
+  std::shared_ptr<config_gen_ryzen> generator;
+  switch (smi_hardware_config::get_family(hw)) {
   case smi_hardware_config::hardware_family::phoenix:
-    return std::make_shared<config_gen_phoenix>();
+    generator = std::make_shared<config_gen_phoenix>();
+    break;
   case smi_hardware_config::hardware_family::strix:
-    return std::make_shared<config_gen_strix>();
+    generator = std::make_shared<config_gen_strix>();
+    break;
   case smi_hardware_config::hardware_family::npu3:
-    return std::make_shared<config_gen_npu3>();
+    generator = std::make_shared<config_gen_npu3>();
+    break;
   default:
-    return std::make_shared<config_gen_strix>();
+    generator = std::make_shared<config_gen_strix>();
+    break;
   }
+
+  if (smi_hardware_config::is_pf_device(hw))
+    generator->clear_validate_tests();
+
+  return generator;
 }
 
 void
@@ -195,8 +205,8 @@ populate_smi_instance(xrt_core::smi::smi* smi_instance, const xrt_core::device* 
 {
   smi_hardware_config smi_hrdw;
   const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
-  const auto family = smi_hrdw.get_family(pcie_id);
-  const auto generator = create_config_generator(family);
+  const auto hw = smi_hrdw.get_hardware_type(pcie_id);
+  const auto generator = create_config_generator(hw);
 
   smi_instance->add_subcommand("validate",  generator->create_validate_subcommand());
   smi_instance->add_subcommand("examine",  generator->create_examine_subcommand());

--- a/src/runtime_src/core/common/smi/smi_ryzen.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen.h
@@ -13,11 +13,18 @@ namespace xrt_core::smi::ryzen {
 
 // Ryzen / NPU xrt-smi JSON config generators (shared by XDNA shim, MCDM, etc.).
 class config_gen_ryzen : public xrt_core::smi::config_generator {
+protected:
   std::vector<xrt_core::smi::basic_option> validate_test_desc;
   std::vector<xrt_core::smi::basic_option> examine_report_desc;
 
 public:
   config_gen_ryzen();
+
+  void
+  clear_validate_tests() override
+  {
+    validate_test_desc.clear();
+  }
 
   virtual const std::vector<xrt_core::smi::basic_option>&
   get_validate_test_desc() const
@@ -43,16 +50,8 @@ public:
 };
 
 class config_gen_phoenix : public config_gen_ryzen {
-  std::vector<xrt_core::smi::basic_option> validate_test_desc;
-
 public:
   config_gen_phoenix();
-
-  const std::vector<xrt_core::smi::basic_option>&
-  get_validate_test_desc() const override
-  {
-    return validate_test_desc;
-  }
 };
 
 class config_gen_strix : public config_gen_ryzen {
@@ -60,7 +59,6 @@ class config_gen_strix : public config_gen_ryzen {
 
 class config_gen_npu3 : public config_gen_ryzen {
   std::vector<xrt_core::smi::basic_option> examine_report_desc;
-  std::vector<xrt_core::smi::basic_option> validate_test_desc;
 
 public:
   config_gen_npu3();
@@ -69,12 +67,6 @@ public:
   get_examine_report_desc() const override
   {
     return examine_report_desc;
-  }
-
-  const std::vector<xrt_core::smi::basic_option>&
-  get_validate_test_desc() const override
-  {
-    return validate_test_desc;
   }
 
   xrt_core::smi::subcommand

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -83,11 +83,17 @@ static const std::string test_token_failed = "FAILED";
 static const std::string test_token_passed = "PASSED";
 
 void
-doesTestExist(const std::string& userTestName, std::vector<std::shared_ptr<TestRunner>>& testNames)
+doesTestExist(const std::string& userTestName, const std::vector<std::shared_ptr<TestRunner>>& testNames)
 {
-  const auto iter = std::find_if( testNames.begin(), testNames.end(),
-    [&userTestName](const std::shared_ptr<TestRunner>& testRunner){ 
-      return userTestName == "all" || userTestName == "quick" || userTestName == testRunner->get_name();
+  if (testNames.empty())
+    throw xrt_core::error("No validate tests are available for this device");
+
+  if (userTestName == "all" || userTestName == "quick")
+    return;
+
+  const auto iter = std::find_if(testNames.begin(), testNames.end(),
+    [&userTestName](const std::shared_ptr<TestRunner>& testRunner) {
+      return userTestName == testRunner->get_name();
     });
 
   if (iter == testNames.end())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR removes all validate tests from the list of runnable tests for PF devices. Currently, none of the tests are applicable to be run on a PF device and the user should not be able to run them when specifically running on PF devices. This PR adds a new API to check for PF device types and clears the tests list. In future, we might add new tests for PFs, at which point we'll need to maintain a separate list. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-43828

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via introducing a PF device checker and clearing out the validate tests list in case the selected device is PF.

#### Risks (if any) associated the changes in the commit
None. Should not affect existing device types.

#### What has been tested and how, request additional testing if necessary
Tested on a PF device : 
```
aktondak@xsjmedusap-14:/proj/rdi/staff/aktondak/xdna/xdna-driver/xrt$ xrt-smi validate --help -d 0000:c5:00.1
***********************************************************
*        WARNING          WARNING          WARNING        *
* Did not find Has fpt label within VMR status: Invalid a *
*                         rgument                         *
* Did not find Boot on default label within VMR status: I *
*                     nvalid argument                     *
***********************************************************
***********************************************************
*        WARNING          WARNING          WARNING        *
* Did not find Has fpt label within VMR status: Invalid a *
*                         rgument                         *
* Did not find Boot on default label within VMR status: I *
*                     nvalid argument                     *
***********************************************************

COMMAND: validate

DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xrt-smi validate [-h] [-d arg] [-o arg] [-r arg] [--json arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -h, --help         - Help to use this sub-command
  --json             - JSON ABI version for file output. Valid values are:
                        default - Latest JSON schema (default)
  -o, --output       - Direct the output to the given file
  -r, --run          - Run a subset of the test suite. Valid options are:

```

#### Documentation impact (if any)
None
