### PR TITLE
ELFIO migration: replace XRT's direct ELFIO dependency with aiebu::elf (Phase 1)

### DIFF
--- a/docs/design/elf-aiebu-migration.md
+++ b/docs/design/elf-aiebu-migration.md
@@ -177,6 +177,89 @@ public:
 **Exit criterion:** `aiebu::elf` builds, parses an AIE ELF, and its unit tests
 cover all getter methods.
 
+#### Implementation notes (step 1.1)
+
+**Files:** `aiebu/src/cpp/include/aiebu/elf.h`,
+`aiebu/src/cpp/elf/elf_reader.cpp`, `aiebu/src/cpp/CMakeLists.txt`
+
+**Internal structure — base + subclass pattern:**  
+The implementation uses a non-public `elf_reader` abstract base with two
+concrete subclasses: `elf_reader_aie2p` (AIE2P / gen2) and
+`elf_reader_gen2plus` (AIE2PS, AIE4 family).  This mirrors XRT's
+`elf_impl` / `elf_aie_gen2` / `elf_aie_gen2_plus` hierarchy.  `aiebu::elf`
+holds a `unique_ptr<elf_reader>` and delegates all calls to it.
+
+**API additions vs. spec:**
+
+- `get_ctrl_scratch_pad_mem_size() const → size_t` — added as a public
+  getter.  The value was parsed from `.dynsym` in XRT but only surfaced
+  inside `module_config_aie_gen2`.  Exposing it here avoids re-parsing
+  in Step 1.2.
+
+- `elf::arg` has an extra `bool is_global` field beyond the spec's
+  `{name, data_type, index}`.  This mirrors the `argtype::global` flag in
+  XRT's `kernel_argument` and is needed for Step 1.2 to reconstruct the
+  XRT `xarg` without re-parsing.
+
+**API deviations vs. spec:**
+
+- `patch_schema` enumerator spelling: spec says `scaler_32` / `offset_64`;
+  implementation uses `scalar_32bit` / `offset_64bit` to match
+  `xrt_core::elf_patcher::symbol_type` names exactly.  The underlying
+  integer values are the same.
+
+- `patch_point` has an extra `uint32_t mask` field (register-value mask for
+  `scalar_32bit` patches, zero otherwise).  Needed to carry the `st_size`
+  field from the `.dynsym` entry that XRT uses when constructing
+  `patch_config`.
+
+- `buf_type` has an extra enumerator `buf_type_count` used as a
+  sentinel during gen2plus patcher init.
+
+**Internal additions not in spec:**
+
+- `detect_platform()` — validates the OS/ABI byte and throws on unknown
+  values.  XRT's factory did a bare `static_cast` without validation.
+
+- `resolve_ctrlcode_id(lambda)` on the base class — refactors the
+  duplicated `get_ctrlcode_id` body from XRT's two derived classes into one
+  parameterised helper.
+
+- `section_buf` (internal) — a stripped-down version of XRT's `buf`:
+  retains `append`, `pad_to`, `size`, `copy_to`.  The `to_bytes()`
+  materialisation helper that was present in an earlier draft was removed
+  (see memory note below).
+
+**PDI / ctrlpkt_pm API — size+copy instead of span:**  
+The spec showed `get_pdi()` / `get_ctrlpkt_pm_buf()` returning
+`span<const std::byte>`.  The implementation instead exposes size+copy
+pairs (`get_pdi_size` / `copy_pdi` and `get_ctrlpkt_pm_buf_size` /
+`copy_ctrlpkt_pm_buf`).  Every caller in `xrt_module.cpp` allocates a BO
+of the reported size and immediately copies into it; a `span` would have
+required an intermediate heap allocation to coalesce the multi-view
+`section_buf` into contiguous memory before the copy.  The size+copy API
+eliminates that allocation: `copy_to()` streams directly from ELFIO memory
+into the BO mapping.  Consequently `m_byte_cache` and `materialise()` are
+absent from the implementation entirely.
+
+**Memory footprint — identical to XRT:**  
+- All section buffer maps use zero-copy `string_view`s into ELFIO memory,
+  exactly as XRT's `buf` does.
+- Custom sections are stored as zero-copy spans into ELFIO memory (same as
+  XRT's `parse_custom_sections`).
+- `get_section()` returns a direct span into ELFIO memory; no copy is made.
+- PDI and ctrlpkt_pm data is copied once, directly into the caller-supplied
+  BO mapping via `copy_to()`; no intermediate buffer exists.
+
+**Parsing fidelity:**  
+All section-parsing logic (`init_legacy_section_maps`,
+`parse_single_group_section`, `parse_sections`, both `.rela.dyn` walkers,
+`init_column_ctrlcode`) is a direct port from XRT with no behavioural
+changes.  The addend-decode constants (`addend_shift`, `addend_mask`,
+`schema_mask`) and the key-string format for patch-point lookup are
+intentionally identical to `xrt_core::elf_patcher` so Step 1.2 can consume
+`get_patch_points()` without changing `xrt_module.cpp`.
+
 ---
 
 ### Step 1.2 — Replace `ELFIO::elfio m_elfio` in `elf_impl` with `aiebu::elf`

--- a/docs/design/elf-aiebu-migration.md
+++ b/docs/design/elf-aiebu-migration.md
@@ -1,0 +1,389 @@
+# ELF Representation Migration: XRT → AIEBU
+
+## Background
+
+`xrt::elf` is a first-class XRT object exposing ELF-based AI Engine binaries
+to users.  Its internal implementation (`elf_impl`, `elf_int.h`, `xrt_elf.cpp`)
+owns an `ELFIO::elfio` object and does all ELF parsing directly in XRT.  AIEBU
+already owns a copy of ELFIO and has ELF *writing* infrastructure; it is the
+natural owner of all ELF knowledge long-term.
+
+This spec describes the phased migration from "XRT owns the ELF representation"
+to "AIEBU owns the ELF representation and XRT wraps it."
+
+---
+
+## Guiding Principles
+
+- **Zero public ABI impact** — `xrt::elf` and its nested types are unchanged
+  throughout all phases.
+- **`elf_impl` stays** — it is too widely referenced inside XRT to remove in
+  phase 1; it becomes a thin delegation shell rather than the ELF parsing core.
+- **No ELFIO in XRT** is the measurable exit criterion for phase 1.
+- **Incremental** — each step compiles and passes tests independently.
+
+---
+
+## Phase 1 — Eliminate ELFIO from XRT
+
+**Goal:** `#include <elfio/elfio.hpp>` appears nowhere in XRT source. `elf_impl`
+delegates all ELF operations to an `aiebu::elf` object. `xrt::elf` public API
+is unchanged.
+
+### Step 1.1 — Add `aiebu::elf` reader to AIEBU
+
+**Where:** AIEBU repo (`aiebu/src/cpp/include/aiebu/elf.h` +
+`aiebu/src/cpp/elf/elf_reader.cpp`)
+
+AIEBU currently has only ELF *writers*. This step adds a read-side class.
+The API must be sufficient to replace every `m_elfio` call site in
+`elf_impl`.
+
+**Required `aiebu::elf` API (phase 1 scope only):**
+
+```cpp
+namespace aiebu {
+
+class elf {
+public:
+  // Construction — mirrors xrt::elf constructors
+  explicit elf(const std::string& filename);
+  explicit elf(std::istream&);
+  elf(const void* data, size_t size);
+  explicit elf(std::string_view data);
+
+  // ---- Platform identity ----
+
+  // Canonical source for AIE platform identification.
+  // Replaces both xrt::elf::platform and the aiebu::osabi_* constants.
+  // Values match ELF e_ident[EI_OSABI].
+  enum class platform : uint8_t {
+    aie2p         = 69,
+    aie2ps_legacy = 70,
+    aie2ps        = 64,
+    aie4          = 75,
+    aie4a         = 86,
+    aie4z         = 105
+  };
+  platform get_platform() const;
+  uint8_t  get_os_abi() const;   // raw byte, for cases that need it
+
+  // ABI version encoded in e_ident[EI_ABIVERSION]
+  // Returns (major, minor): upper nibble = major, lower nibble = minor
+  std::pair<uint8_t, uint8_t> get_abi_version() const;
+
+  // ---- Shape queries ----
+  bool is_full_elf() const;    // has .ctrltext — can replace xclbin
+  bool is_group_elf() const;   // uses .group sections (version-dependent)
+
+  // ---- Metadata embedded in the ELF ----
+  std::array<uint8_t, 16> get_cfg_uuid() const;
+  uint32_t                get_partition_size() const;
+
+  // ---- Kernel metadata (semantic, not section-walking) ----
+  struct arg {
+    std::string name;
+    std::string data_type;
+    uint32_t    index;
+  };
+  struct kernel {
+    std::string              name;
+    std::vector<arg>         args;
+    std::vector<std::string> instances;
+  };
+  std::vector<kernel> get_kernels() const;
+
+  // ---- Section access ----
+
+  // Named access for sections AIEBU does not model explicitly.
+  // Backing memory is owned by this elf object — span valid for
+  // the lifetime of the elf.
+  std::span<const std::byte> get_section(std::string_view name) const;
+
+  // Serialise the ELF to a stream (replaces elfio.save() call sites
+  // in xdp elf_helper.cpp and xrt_kernel.cpp AIEDebug).
+  void save(std::ostream&) const;
+
+  // ---- Patch-point access (transitional — see Phase 2) ----
+
+  // Schema values match the addend encoding used in the .rela sections.
+  enum class patch_schema : uint32_t { scaler_32, offset_64 /* ... */ };
+
+  // buf_type identifies which section a patch point targets.
+  // Values and names mirror xrt_core::elf_patcher::buf_type — they are
+  // kept in sync until elf_patcher.h is retired in Phase 2.
+  enum class buf_type : uint32_t {
+    ctrltext = 0, ctrldata = 1, preempt_save = 2,
+    preempt_restore = 3, pdi = 4, ctrlpkt_pm = 5,
+    pad = 6, dump = 7, ctrlpkt = 8
+  };
+
+  struct patch_point {
+    std::string  arg_name;
+    patch_schema schema;
+    buf_type     target_buf;
+    uint64_t     section_offset;
+    uint64_t     base_bo_offset;  // upper bits of rela addend
+  };
+
+  // Returns all relocation-based patch points in the ELF.
+  // Grouped by ctrl-code-id (group index / UINT32_MAX for legacy ELFs).
+  // This method is TRANSITIONAL — it exists only while patching lives in XRT.
+  // It will be removed in Phase 2 when patching moves to AIEBU.
+  std::map<uint32_t, std::map<std::string, std::vector<patch_point>>>
+  get_patch_points() const;
+
+  // ---- Group / ctrl-code navigation ----
+
+  // Maps needed by elf_impl to preserve its existing internal structure
+  // during the transition.  These are intentionally low-level; they will
+  // be absorbed into AIEBU's own data model in a later phase.
+  std::map<uint32_t, uint32_t>              get_section_to_group_map() const;
+  std::map<uint32_t, std::vector<uint32_t>> get_group_to_sections_map() const;
+  std::map<std::string, uint32_t>           get_kernel_name_to_id_map() const;
+
+  // Ctrl-code id for a named kernel/subkernel (UINT32_MAX = legacy)
+  uint32_t get_ctrlcode_id(const std::string& name) const;
+
+  // PDI symbol lookup (AIE gen2 only)
+  // Returns empty span if symbol not found.
+  std::span<const std::byte> get_pdi(const std::string& symbol_name) const;
+
+  // Preemption control-packet dynamic symbol set (AIE gen2 only)
+  std::set<std::string> get_ctrlpkt_pm_dynsyms() const;
+
+  // Per-symbol preemption ctrl-pkt buffer (AIE gen2 only)
+  // Span lifetime tied to this elf object.
+  std::span<const std::byte>
+  get_ctrlpkt_pm_buf(const std::string& symbol_name) const;
+};
+
+} // namespace aiebu
+```
+
+**Notes on this API:**
+- `save()` replaces the two `elfio_ref.save(ss)` call sites in
+  `xdp/profile/plugin/aie_dtrace/ve2/elf_helper.cpp` and
+  `xdp/profile/plugin/aie_profile/ve2/elf_helper.cpp` without exposing the
+  raw `ELFIO::elfio`.
+- `get_patch_points()` is explicitly transitional (see comment above).  It
+  encodes the same information currently derived from `.rela` + `.symtab`
+  sections in `xrt_elf.cpp`, but using AIEBU-owned types so `elf_impl` no
+  longer needs ELFIO at the call site.
+- The group / ctrl-code maps are low-level scaffolding to keep `elf_impl`'s
+  existing internal structure intact during phase 1.  They will be hidden
+  behind a higher-level API in a later phase.
+
+**Exit criterion:** `aiebu::elf` builds, parses an AIE ELF, and its unit tests
+cover all getter methods.
+
+---
+
+### Step 1.2 — Replace `ELFIO::elfio m_elfio` in `elf_impl` with `aiebu::elf`
+
+**Where:** `elf_int.h`, `xrt_elf.cpp`
+
+Replace the protected member:
+
+```cpp
+// before
+ELFIO::elfio m_elfio;
+
+// after
+aiebu::elf m_elf;
+```
+
+Change the `elf_impl` constructor from taking `ELFIO::elfio&&` to taking
+`aiebu::elf&&`:
+
+```cpp
+// before
+elf_impl(ELFIO::elfio&& elfio, elf::platform platform, std::string path);
+
+// after
+elf_impl(aiebu::elf&& elf, std::string path);
+// platform is now derived from m_elf.get_platform()
+```
+
+The four `xrt::elf` constructors in `xrt_elf.cpp` currently construct an
+`ELFIO::elfio`, detect the platform, then call `make_elf_impl(elfio, platform,
+path)`.  They instead construct an `aiebu::elf`, then call
+`make_elf_impl(aiebu_elf, path)`.
+
+All methods on `elf_impl` that currently access `m_elfio` are rewritten to
+call the corresponding `aiebu::elf` accessor.  For example:
+
+| Before | After |
+|--------|-------|
+| `m_elfio.get_os_abi()` | `m_elf.get_os_abi()` |
+| `m_elfio.sections[...]->get_data()` | `m_elf.get_section(name)` |
+| `m_elfio.get_os_abi()` in `get_elfio()` | removed — see Step 1.3 |
+| `parse_sections()` body | replaced by calls to `m_elf.get_*_map()` |
+
+`parse_sections()` currently walks `m_elfio.sections` to build the group maps,
+kernel maps, custom section map, and patcher map.  After this step,
+`parse_sections()` calls the map accessors from `aiebu::elf` and populates the
+same `elf_impl` members.  This keeps `xrt_module.cpp` and other consumers of
+`elf_impl` unchanged.
+
+`m_platform` is set from `m_elf.get_platform()` and cast to `xrt::elf::platform`
+(same numeric values, so a `static_cast<uint8_t>` round-trip is safe).
+
+**`buf` struct in `elf_int.h`:** Currently `buf::append_section_data()` takes
+`const ELFIO::section*`.  After this step it takes `std::span<const std::byte>`
+from `aiebu::elf::get_section()`.  The ELFIO-typed overloads are removed.
+
+**Exit criterion:** `xrt_elf.cpp` and `elf_int.h` no longer include
+`<elfio/elfio.hpp>`.  XRT builds and existing tests pass.
+
+---
+
+### Step 1.3 — Remove `get_elfio()` from `elf_impl`; fix its two call sites
+
+**Where:** `elf_int.h`, `xrt_kernel.cpp`, `xdp/.../aie_dtrace/ve2/elf_helper.cpp`,
+`xdp/.../aie_profile/ve2/elf_helper.cpp`
+
+`get_elfio()` is currently the only method that leaks `ELFIO::elfio` outside
+`elf_impl`.  It has exactly two call sites:
+
+1. **`xrt_kernel.cpp:5199`** — `aiebu::AIEDebug dbg(elf_impl_ptr->get_elfio())`  
+   Fix: change `aiebu::AIEDebug` to accept `const aiebu::elf&` instead of
+   `const ELFIO::elfio&`.  The constructor change is in AIEBU.  The XRT call
+   site becomes `aiebu::AIEDebug dbg(elf_impl_ptr->get_aiebu_elf())` where
+   `get_aiebu_elf()` returns `const aiebu::elf&`.  
+   Alternatively, once AIEBU controls the ELF, `AIEDebug` can be constructed
+   from the `aiebu::elf` handle directly without going through `elf_impl` at
+   all.
+
+2. **`xdp/.../elf_helper.cpp` (both dtrace and aie_profile)**  
+   Both files do:
+   ```cpp
+   auto* impl = static_cast<xrt::elf_impl*>(elf_handle);
+   auto& elfio_ref = impl->get_elfio();
+   const_cast<ELFIO::elfio&>(elfio_ref).save(ss);
+   ```
+   Fix: add `void save(std::ostream&) const` to `elf_impl` (delegates to
+   `m_elf.save()`).  The xdp call sites become:
+   ```cpp
+   auto* impl = static_cast<xrt::elf_impl*>(elf_handle);
+   impl->save(ss);
+   ```
+   The ELFIO `const_cast` disappears.
+
+After these changes, remove `get_elfio()` from `elf_impl` and its declaration
+in `elf_int.h`.
+
+**Exit criterion:** `get_elfio()` does not exist anywhere in XRT.  
+`<elfio/elfio.hpp>` does not appear in any XRT source file.
+
+---
+
+### Step 1.4 — Remove XRT's bundled ELFIO copy
+
+**Where:** CMakeLists files, XRT's ELFIO source tree
+
+With no remaining `#include <elfio/elfio.hpp>` in XRT, the bundled ELFIO copy
+can be removed from the XRT source tree.  AIEBU's own ELFIO copy is the sole
+remaining instance.
+
+Check that no CMakeLists target in XRT adds XRT's ELFIO include path.  Remove
+the XRT ELFIO source directory.
+
+**Exit criterion:** XRT source tree contains no copy of ELFIO.  AIEBU source
+tree retains its copy and XRT links against AIEBU to get ELF services.
+
+---
+
+### Phase 1 — Summary of changed files
+
+| File | Change |
+|------|--------|
+| `aiebu/src/cpp/include/aiebu/elf.h` | New: `aiebu::elf` reader class |
+| `aiebu/src/cpp/elf/elf_reader.cpp` | New: implementation |
+| `core/common/api/elf_int.h` | Replace `ELFIO::elfio m_elfio` with `aiebu::elf m_elf`; remove ELFIO includes; update `buf`; add `save()`, `get_aiebu_elf()`; remove `get_elfio()` |
+| `core/common/api/xrt_elf.cpp` | Rewrite factory + `parse_sections()` to use `aiebu::elf`; remove ELFIO includes |
+| `xdp/.../aie_dtrace/ve2/elf_helper.cpp` | Replace `get_elfio()` + `elfio.save()` with `elf_impl::save()` |
+| `xdp/.../aie_profile/ve2/elf_helper.cpp` | Same |
+| `core/common/api/xrt_kernel.cpp` | Replace `AIEDebug(get_elfio())` with `AIEDebug(get_aiebu_elf())` |
+| AIEBU: `aiebu/src/cpp/aiebu_debug.h/.cpp` | Change `AIEDebug` constructor to accept `const aiebu::elf&` |
+| CMakeLists (XRT) | Remove XRT ELFIO include paths and source dir |
+
+`xrt_module.cpp`, `module_int.h`, `xrt_hw_context.cpp`, `xrt_kernel.cpp`
+(other than the `AIEDebug` line), and all xdp profiling code that references
+`elf_impl*` opaquely — **no changes required**.  `elf_impl`'s public interface
+for those callers is unchanged.
+
+---
+
+## Phase 2 — Remove ELF section details from XRT
+
+**Goal:** XRT no longer references section names (`.ctrltext`, `.ctrldata`,
+etc.) or understands ELF relocation encoding.  `elf_patcher.h` is retired.
+Patching moves to AIEBU.
+
+This phase is contingent on the patching-in-AIEBU work being ready and is
+intentionally left at a higher level.
+
+### 2.1 — Move patching to AIEBU
+
+AIEBU exposes a push-style patching API:
+
+```cpp
+// Push runtime values; AIEBU applies patches internally.
+void elf::patch(std::string_view arg_name, uint64_t address);
+
+// Return finalized, submission-ready payload after all patches applied.
+std::span<const std::byte> elf::get_patched_payload() const;
+```
+
+`xrt_module.cpp`'s patching loop replaces `symbol_patcher::patch_symbol()` +
+per-arg `xrt::bo` address extraction with `m_elf.patch(name, address)`.
+
+`elf_patcher.h`, `elf_patcher.cpp`, `symbol_patcher`, `patcher_config` are
+removed from XRT.
+
+`get_patch_points()` is removed from `aiebu::elf` (it was explicitly
+transitional).
+
+### 2.2 — Remove `module_config_aie_gen2` / `module_config_aie_gen2_plus`
+
+The `module_config` variant and associated `buf`/`ctrlcode`/`instr_buf`
+scaffolding in `elf_int.h` exist because `xrt_module.cpp` manually assembles
+control buffers from named ELF sections.  Once AIEBU owns patching and payload
+assembly, `module_run` objects receive a finalized payload from AIEBU rather
+than constructing it from raw section views.  The `buf` struct and its
+zero-copy scaffolding are removed.
+
+### 2.3 — `xrt::elf::platform` becomes a type alias
+
+With `aiebu::elf::platform` as the canonical type, `xrt::elf::platform` is
+declared as:
+
+```cpp
+using platform = aiebu::elf::platform;
+```
+
+or mapped one-to-one.  The numeric values are identical so no existing user
+code breaks.
+
+### 2.4 — `elf_impl` is reduced to an adapter
+
+After phases 2.1–2.3, `elf_impl` retains only:
+
+- `get_ert_opcode()` — maps `aiebu::elf::platform` to `ert_cmd_opcode` (XRT
+  driver ABI, cannot move to AIEBU)
+- `get_kernel_properties_and_args()` — bridges `aiebu::elf::kernel` to
+  `xrt_core::xclbin::kernel_properties` (xclbin type, cannot move to AIEBU)
+- Construction and forwarding to `aiebu::elf`
+
+At this point `elf_impl` is ~50 lines.
+
+---
+
+## Phase 3 — `xrt::elf = aiebu::elf` (optional / long-term)
+
+Once `elf_impl` is only an adapter for `ert_cmd_opcode` and the xclbin bridge,
+evaluate whether `xrt::elf` can become a direct type alias for `aiebu::elf` with
+the two XRT-specific concerns handled at the `xrt_kernel.cpp` / `xrt_module.cpp`
+call sites directly.  This phase requires AIEBU to commit to a stable ABI for
+`aiebu::elf`, which is a separate AIEBU decision.

--- a/docs/design/elf-aiebu-migration.md
+++ b/docs/design/elf-aiebu-migration.md
@@ -303,21 +303,258 @@ call the corresponding `aiebu::elf` accessor.  For example:
 | `m_elfio.get_os_abi()` in `get_elfio()` | removed — see Step 1.3 |
 | `parse_sections()` body | replaced by calls to `m_elf.get_*_map()` |
 
+**`parse_sections()` and group/kernel maps:**  
 `parse_sections()` currently walks `m_elfio.sections` to build the group maps,
-kernel maps, custom section map, and patcher map.  After this step,
-`parse_sections()` calls the map accessors from `aiebu::elf` and populates the
-same `elf_impl` members.  This keeps `xrt_module.cpp` and other consumers of
-`elf_impl` unchanged.
+kernel maps, and custom section map.  After this step it is replaced by three
+direct assignments from `aiebu::elf`:
+
+```cpp
+m_section_to_group_map   = m_elf.get_section_to_group_map();
+m_group_to_sections_map  = m_elf.get_group_to_sections_map();
+m_kernel_name_to_id_map  = m_elf.get_kernel_name_to_id_map();
+```
+
+`m_kernels` is populated from `m_elf.get_kernels()`, translating each
+`aiebu::elf::kernel` (plain struct with `name`, `args`, `instances`) into the
+existing `xrt::elf::kernel` pimpl objects.  The `aiebu::elf::arg::is_global`
+field drives the `xrt::xarg::argtype` discriminant without re-parsing.
+
+`m_custom_section_map` is populated by iterating `m_elf.get_section()` for
+each key already known to `elf_impl`; alternatively, the map can be dropped
+from `elf_impl` entirely and `get_custom_section()` can delegate to
+`m_elf.get_section()` directly.
+
+`m_kernel_args_map`, `m_kernel_to_subkernels_map`, and all the private parsing
+helpers (`get_symbol_from_symtab`, `get_kernel_subkernel_from_symtab`,
+`init_legacy_section_maps`, `parse_single_group_section`,
+`parse_custom_sections`, `finalize_kernels`) are removed from `elf_impl` —
+this logic now lives exclusively in `aiebu::elf`.
+
+**`m_arg2patcher` — translation from `aiebu::elf::get_patch_points()`:**  
+The patcher table is the most important member to get right because
+`get_patcher_configs()` is called at `module_run` construction and
+`m_patcher_configs` is used on every `set_arg_value()` call on the hot path.
+The structure of `m_arg2patcher` is unchanged — it remains a
+`map<ctrl_code_id, map<key_string, patcher_config>>` owned by `elf_impl` with
+`module_run` holding a raw `const*` pointer into it.  Only the population
+changes: instead of the `.rela.dyn` walking loop, `initialize_arg_patchers()`
+translates from `m_elf.get_patch_points()`:
+
+```cpp
+for (const auto& [grp_idx, key_map] : m_elf.get_patch_points()) {
+  for (const auto& [key, pts] : key_map) {
+    std::vector<patch_config> configs;
+    for (const auto& pp : pts)
+      configs.push_back({pp.section_offset, pp.base_bo_offset, pp.mask});
+    m_arg2patcher[grp_idx].emplace(
+      key,
+      patcher_config{static_cast<patcher_symbol_type>(pp.schema), configs,
+                     static_cast<patcher_buf_type>(pp.target_buf)});
+  }
+}
+```
+
+The key-string format and the `patcher_config` / `patch_config` field layout
+are intentionally identical to what the old parsing code produced (verified
+during step 1.1 implementation), so `module_run`'s hot-path map lookup and
+`symbol_patcher::patch_symbol()` are completely unchanged.
+
+**Critical path — no runtime impact:**  
+`get_patcher_configs()` returns a raw `const*` into `m_arg2patcher` exactly as
+before.  `symbol_patcher` holds a raw `const patcher_config*` and writes
+directly into BO mappings.  The data layout and pointer relationships are
+identical; only the construction-time code that fills `m_arg2patcher` changes.
+Memory footprint of `m_arg2patcher` is identical — same map structure, same
+`patcher_config` objects with the same `patch_config` vectors.
+
+**Section buffer maps (`m_instr_buf_map`, `m_ctrlcodes_map`, etc.):**  
+`aiebu::elf` does not expose its internal `section_buf` maps — these remain
+owned by `elf_aie_gen2` and `elf_aie_gen2_plus` in XRT.  The buffer init
+functions (`initialize_section_buf_map`, `initialize_column_ctrlcode`, etc.)
+are rewritten to iterate the group/section maps obtained from `aiebu::elf`
+rather than walking `m_elfio.sections` directly:
+
+```cpp
+// before: iterating m_elfio.sections
+for (const auto& sec : m_elfio.sections) { ... sec->get_data() ... }
+
+// after: iterating via aiebu::elf maps + get_section()
+for (const auto& [grp_idx, sec_ids] : m_elf.get_group_to_sections_map()) {
+  for (auto sec_idx : sec_ids) {
+    // resolve section name from the index — requires a new
+    // get_section_name(uint32_t index) accessor on aiebu::elf,
+    // or alternatively the section names are stored in the
+    // group map during aiebu::elf parsing (preferred).
+  }
+}
+```
+
+This reveals a missing accessor: `aiebu::elf` must expose section names by
+index so `elf_aie_gen2` / `elf_aie_gen2_plus` can identify which buffer type
+each section belongs to without holding `m_elfio` themselves.  Add to
+`aiebu::elf`:
+
+```cpp
+// Returns the name of section at index, or empty string if not found.
+std::string get_section_name(uint32_t index) const;
+```
+
+Alternatively, the buffer maps can be built during `aiebu::elf` parsing and
+exposed through typed accessors — but that is Phase 2 scope.  For Step 1.2,
+`get_section_name(uint32_t)` is the minimal addition required.
+
+**`buf::append_section_data()` signature:**  
+Currently takes `const ELFIO::section*`.  After this step it takes
+`aiebu::detail::span<const std::byte>` (from `m_elf.get_section(name)`).
+The `unique_ptr<ELFIO::section>` overload is also removed.  `buf` itself
+(`elf_int.h`) gains no ELFIO dependency.
+
+**`get_pdi()` on `elf_impl` / `module_config_aie_gen2::elf_parent`:**  
+Currently `elf_aie_gen2::get_pdi()` returns `const buf&` — a zero-copy
+reference into its own `m_pdi_buf_map`.  After Step 1.2, PDI data lives
+inside `aiebu::elf`.  Replace the `get_pdi()` virtual with a size+copy pair
+on `elf_impl` that forwards to `m_elf`:
+
+```cpp
+size_t get_pdi_size(const std::string& symbol) const;
+void   copy_pdi(const std::string& symbol, aiebu::detail::span<std::byte> dest) const;
+```
+
+`xrt_module.cpp` call sites change from:
+```cpp
+const auto& pdi_data = m_config.elf_parent->get_pdi(symbol);
+auto pdi_bo = xbi::create_bo(m_hwctx, pdi_data.size(), ...);
+fill_bo_with_data(pdi_bo, pdi_data);
+```
+to:
+```cpp
+auto sz = m_config.elf_parent->get_pdi_size(symbol);
+auto pdi_bo = xbi::create_bo(m_hwctx, sz, ...);
+m_config.elf_parent->copy_pdi(symbol, {pdi_bo.map<std::byte*>(), sz});
+```
+
+The `elf_parent` back-pointer in `module_config_aie_gen2` is retained for
+this step and removed in Step 2 when `module_config` is retired.  Similarly,
+`get_ctrlpkt_pm_buf_size()` / `copy_ctrlpkt_pm_buf()` replace the
+`m_ctrlpkt_pm_bufs` map reference in `module_config_aie_gen2`.
 
 `m_platform` is set from `m_elf.get_platform()` and cast to `xrt::elf::platform`
 (same numeric values, so a `static_cast<uint8_t>` round-trip is safe).
 
 **`buf` struct in `elf_int.h`:** Currently `buf::append_section_data()` takes
-`const ELFIO::section*`.  After this step it takes `std::span<const std::byte>`
-from `aiebu::elf::get_section()`.  The ELFIO-typed overloads are removed.
+`const ELFIO::section*`.  After this step it takes
+`aiebu::detail::span<const std::byte>` from `m_elf.get_section()`.
+The ELFIO-typed overloads are removed.  `buf` gains no ELFIO dependency.
+
+**Missing `aiebu::elf` accessor — `get_section_name(uint32_t)`:**  
+As noted above, this must be added to `aiebu::elf` and `elf_reader` before
+Step 1.2 can proceed.  It is a trivial addition: `m_elfio.sections[index]`
+returns the section; return its name or empty string.  This should be
+committed to the aiebu `elfio_migration` branch as a preparatory step.
 
 **Exit criterion:** `xrt_elf.cpp` and `elf_int.h` no longer include
 `<elfio/elfio.hpp>`.  XRT builds and existing tests pass.
+
+#### Implementation notes (step 1.2)
+
+**Files changed:** `elf_int.h`, `xrt_elf.cpp`, `xrt_module.cpp`,
+`xrt_kernel.cpp`, `aiebu/src/cpp/include/aiebu/elf.h`,
+`aiebu/src/cpp/elf/elf_reader.cpp`
+
+**`elf_impl` — constructor and data members:**  
+`m_elfio` is replaced by `m_elf` (type `aiebu::elf`).  The constructor now
+takes `aiebu::elf&&` and derives `m_platform` from `m_elf.get_os_abi()`.
+`m_kernels` and `m_arg2patcher` are initialised directly in the initializer
+list via two static helpers (`create_kernels`, `create_arg2patcher`) defined
+in the anonymous namespace before `namespace xrt` — required so they are
+visible at the point of use in the initializer list.
+
+**`parse_sections()` eliminated:**  
+The method is removed entirely.  Kernel translation (`create_kernels`) and
+patcher-table construction (`create_arg2patcher`) are now static free
+functions called from the `elf_impl` constructor initializer list.
+
+**Group/section maps not copied:**  
+The spec proposed copying `m_section_to_group_map`, `m_group_to_sections_map`,
+and `m_kernel_name_to_id_map` into `elf_impl`.  These were eliminated — no
+XRT consumer read them after construction; all access goes through
+`aiebu::elf` virtual accessors instead.
+
+**`buf` struct removed from `elf_int.h`:**  
+`struct buf`, `instr_buf`, `control_packet`, `ctrlcode` type aliases, and all
+ELFIO-typed overloads of `append_section_data()` are removed.  The module_run
+buffer creation path now calls `elf_impl::get_instr_buf_size()` /
+`copy_instr_buf()` etc. directly (see buffer accessor section below).
+
+**`elf_aie_gen2` and `elf_aie_gen2_plus` — gutted to shells:**  
+All buffer maps (`m_instr_buf_map`, `m_ctrlcodes_map`, etc.), all buffer
+initialisation methods, all `.rela.dyn` walking, and `get_module_config()`
+are removed.  Each derived class now contains only a constructor (trace point
+only, body empty), `is_group_elf()`, and `get_ert_opcode()`.
+`get_ctrlcode_id()` was promoted to a non-virtual on `elf_impl` since both
+overrides were identical.
+
+**Buffer accessor API on `elf_impl`:**  
+All buffer access uses size+copy pairs forwarding directly to `aiebu::elf`
+virtual methods (`get_instr_buf_size`/`copy_instr_buf`, etc.).  `module_run`
+calls these with the `ctrl_code_id` it already holds, allocates a BO, and
+copies directly into the BO mapping — no intermediate heap buffer.
+
+**`module_config_aie_gen2/plus` and `get_module_config()` removed:**  
+Both config structs and the `get_module_config()` pure virtual are gone.
+`module_run_aie_gen2` and `module_run_aie_gen2_plus` hold only `m_elf_impl`
+and call buffer accessors directly.  `elf_parent` back-pointer eliminated.
+
+**`has_pdi()` added to `aiebu::elf`:**  
+`get_ert_opcode()` originally checked `!m_pdi_buf_map.empty()` — true if any
+`.pdi.*` section is present in the ELF, regardless of relocations.  An
+intermediate draft used `get_patch_points()` iteration (O(N)) and then
+`!m_ctrl_pdi_map.empty()` (only true when a relocation references a PDI
+symbol), both of which are subtly different from the original.  The final
+implementation backs `has_pdi()` with `!m_pdi_buf_map.empty()`, which is
+faithful to the original semantic and O(1).
+
+**`aiebu::detail::span` relocated:**  
+`detail/span.h` moved to `aiebu/detail/span.h` so that consumers linking
+against `aiebu_static` can reach it via the aiebu include interface.
+
+**ELFIO transitional include in `elf_int.h`:**  
+`<elfio/elfio.hpp>` is re-added to `elf_int.h` with a transitional comment
+because external submodules (`xdna-driver` shim tests, `xdp` elf_helpers)
+access `ELFIO::elfio` through `elf_impl::get_elfio()`.  Removed in Step 1.3.
+
+**`get_elfio()` escape hatch:**  
+`get_elfio()` is added to both `aiebu::elf` (returning `const ELFIO::elfio&`)
+and `elf_impl` (forwarding to `m_elf.get_elfio()`).  Marked transitional;
+removed in Step 1.3.
+
+**`get_patch_points()` — no copy, cleared after use:**  
+`get_patch_points()` now returns `const&` into `elf_reader::m_patch_points`
+(zero allocation).  `create_arg2patcher()` iterates this reference once to
+build `m_arg2patcher`, then the `elf_impl` constructor calls
+`m_elf.clear_patch_points()` to free `m_patch_points` immediately.  This
+eliminates the steady-state duplication that would otherwise exist between
+`m_patch_points` and `m_arg2patcher` for the ELF's lifetime.
+
+The type boundary between `aiebu::elf::patch_point` and
+`xrt_core::elf_patcher::patch_config` means `m_arg2patcher` cannot reference
+`m_patch_points` data directly — a translation copy is unavoidable while
+patching lives in XRT.  Both `m_patch_points` and `m_arg2patcher` are
+**Phase 1 only**: Phase 2 removes `m_arg2patcher` (patching moves to AIEBU)
+and with it the need for `m_patch_points` in AIEBU at all.
+
+**`get_pdi_symbols(uint32_t ctrl_code_id)` added to `aiebu::elf`:**  
+`module_run_aie_gen2::create_instruction_buf()` previously called
+`get_patch_points()` and walked all groups and all relocations to find PDI
+symbols for `m_ctrl_code_id` — O(N) with a deep copy.  `get_pdi_symbols()`
+returns `const std::unordered_set<std::string>&` into `m_ctrl_pdi_map`
+directly indexed by `ctrl_code_id` — O(1), zero allocation.
+
+**Critical path unchanged:**  
+`m_arg2patcher` layout, `get_patcher_configs()` raw-pointer return, and
+`symbol_patcher::patch_symbol()` are byte-for-byte identical to Step 1.1.
+The construction-time translation (`create_arg2patcher`) runs once and is
+off the hot path.
 
 ---
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ include(CMake/unitTestSupport.cmake)
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src
   ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core/common/gsl/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp/include
   ${XRT_BINARY_DIR}/gen
   ${XRT_BINARY_DIR}
   )

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(core_common_objects OBJECT scheduler.cpp)
 target_include_directories(core_common_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src
+  ${XRT_SOURCE_DIR}/runtime_src/core/common/gsl/include
   )
 
 xrt_configure_version_file(xrt_coreutil SHARED)
@@ -119,12 +120,14 @@ endif()
 target_include_directories(xrt_coreutil
   PUBLIC
   $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src>
+  $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp/include>
   $<INSTALL_INTERFACE:${XRT_INSTALL_INCLUDE_DIR}>
   )
 
 target_include_directories(xrt_coreutil_static
   PUBLIC
   $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src>
+  $<BUILD_INTERFACE:${XRT_SOURCE_DIR}/runtime_src/core/common/aiebu/src/cpp/include>
   $<INSTALL_INTERFACE:${XRT_INSTALL_INCLUDE_DIR}>
   )
 

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -23,6 +23,7 @@
 #include "ert.h"
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <unordered_set>
 #include <memory>
@@ -210,7 +211,7 @@ public:
   void   copy_pdi(const std::string& sym, aiebu::detail::span<std::byte> d) const { m_elf.copy_pdi(sym, d); }
 
   // gen2: ctrlpkt preemption buffers
-  std::set<std::string> get_ctrlpkt_pm_dynsyms() const { return m_elf.get_ctrlpkt_pm_dynsyms(); }
+  const std::set<std::string>& get_ctrlpkt_pm_dynsyms() const { return m_elf.get_ctrlpkt_pm_dynsyms(); }
   size_t get_ctrlpkt_pm_buf_size(const std::string& sym) const { return m_elf.get_ctrlpkt_pm_buf_size(sym); }
   void   copy_ctrlpkt_pm_buf(const std::string& sym, aiebu::detail::span<std::byte> d) const { m_elf.copy_ctrlpkt_pm_buf(sym, d); }
 
@@ -223,9 +224,15 @@ public:
   void   copy_ctrlcode_col(uint32_t id, uint32_t col, aiebu::detail::span<std::byte> d) const { m_elf.copy_ctrlcode(id, col, d); }
 
   // gen2plus: ctrlpkt buffers
+  // Prefer for_each_ctrlpkt() for iteration — avoids the vector<string> heap allocation.
   std::vector<std::string> get_ctrlpkt_section_names(uint32_t id) const { return m_elf.get_ctrlpkt_section_names(id); }
   size_t get_ctrlpkt_size(uint32_t id, const std::string& name) const { return m_elf.get_ctrlpkt_size(id, name); }
   void   copy_ctrlpkt(uint32_t id, const std::string& name, aiebu::detail::span<std::byte> d) const { m_elf.copy_ctrlpkt(id, name, d); }
+
+  void
+  for_each_ctrlpkt(uint32_t id,
+                   const std::function<void(const std::string&, size_t)>& f) const
+  { m_elf.for_each_ctrlpkt(id, f); }
 
   // gen2plus: dump buffer
   size_t get_dump_buf_size(uint32_t id) const { return m_elf.get_dump_buf_size(id); }

--- a/src/runtime_src/core/common/api/elf_int.h
+++ b/src/runtime_src/core/common/api/elf_int.h
@@ -6,8 +6,15 @@
 // This file defines implementation extensions to the XRT ELF APIs.
 // It provides access to xrt::elf_impl class that is not
 // directly exposed to end users.
+#include "core/common/aiebu/src/cpp/include/aiebu/elf.h"
+
+// TRANSITIONAL: elfio.hpp is included here solely to satisfy external
+// submodules that access ELFIO types through elf_impl::get_elfio().
+// Once those dependencies are updated to use get_aiebu_elf() instead,
+// this include and get_elfio() on elf_impl will be removed in Step 1.3.
+#include <elfio/elfio.hpp>
+
 #include "core/common/config.h"
-#include "core/common/span.h"
 #include "core/common/xclbin_parser.h"
 #include "core/include/xrt/experimental/xrt_elf.h"
 #include "core/include/xrt/xrt_bo.h"
@@ -15,271 +22,21 @@
 
 #include "ert.h"
 
-#include "core/common/aiebu/src/cpp/include/aiebu/aiebu_decompress.h"
-
-#include <elfio/elfio.hpp>
-
 #include <cstdint>
-#include <cstring>
 #include <map>
+#include <unordered_set>
 #include <memory>
 #include <set>
 #include <string>
-#include <unordered_set>
 #include <utility>
-#include <variant>
 #include <vector>
 
 namespace xrt_core { class device; }
 
 namespace xrt {
 
-////////////////////////////////////////////////////////////////
-// buf - wrapper for holding ELF section data
-//
-// Stores non-owning pointers to ELFIO section objects.
-// Compression is fully abstracted — aiebu determines whether
-// decompression is needed via get_section_uncompressed_size() /
-// copy_section_uncompressed_data().
-// Padding stored separately to avoid copying section data.
-////////////////////////////////////////////////////////////////
-struct buf
-{
-  template <typename T> using span = xrt_core::span<T>;
-private:
-  // A view into ELFIO section data, possibly compressed.
-  // For section-backed views, section and elf are non-null.
-  // For padding views, section is null and padding holds the zero buffer.
-  //
-  // Lifetime of section/elf pointers:
-  //   section points into m_elfio's internal section array; elf points to
-  //   m_elfio itself (stored as &elf in append_section_data).  Both m_elfio
-  //   and the buf objects (m_instr_buf_map, m_ctrl_packet_map, etc.) are
-  //   members of the same elf_impl instance (m_elfio in the base class,
-  //   buf maps in the derived classes elf_aie_gen2 / elf_aie_gen2_plus).
-  //   This is why the raw pointers are safe: a buf cannot outlive its
-  //   owning elf_impl because it is a member of it, so m_elfio is
-  //   guaranteed to be alive whenever a view_entry in that buf is accessed.
-  //   At the broader scope, module_impl holds a shared_ptr<elf_impl>
-  //   ensuring elf_impl is not destroyed while the module is in use.
-  //
-  struct view_entry {
-    const ELFIO::section* section = nullptr;   // section-backed view (may be compressed)
-    const ELFIO::elfio* elf = nullptr;         // ELFIO owning the section (see lifetime note above)
-    span<uint8_t> padding;                     // for zero-padding, points into m_padding_buffer
-    std::size_t data_size = 0;                 // effective size (uncompressed if compressed)
-  };
-
-  // Non-owning views into ELFIO or external data
-  std::vector<view_entry> m_views;
-
-  // Padding buffer - only allocated when AIE2PS/AIE4 needs page alignment
-  // Stored separately to avoid copying section data
-  std::vector<uint8_t> m_padding_buffer;
-
-public:
-  buf() = default;
-
-  // Append section data from an ELFIO section.
-  // Compression handling is delegated to aiebu — XRT does not inspect
-  // SHF_COMPRESSED or Chdr headers directly.  Decompression is deferred
-  // until copy_to().
-  void
-  append_section_data(const ELFIO::section* sec, const ELFIO::elfio& elf)
-  {
-    if (!sec || sec->get_size() == 0)
-      return;
-
-    view_entry entry;
-    entry.section = sec;
-    entry.elf = &elf;
-    entry.data_size = aiebu::get_section_uncompressed_size(sec, elf);
-    m_views.push_back(entry);
-  }
-
-  // Overload for smart pointers (from ELFIO range-based for loops)
-  void
-  append_section_data(const std::unique_ptr<ELFIO::section>& sec,
-                      const ELFIO::elfio& elf)
-  {
-    append_section_data(sec.get(), elf);
-  }
-
-  // Add padding to reach target size (for AIE2PS/AIE4 page alignment)
-  // Only allocates memory for padding zeros, NOT for existing section data!
-  void
-  add_padding_to_size(size_t target_size)
-  {
-    size_t current = size();
-    if (target_size <= current)
-      return;
-    
-    size_t padding_size = target_size - current;
-    m_padding_buffer.resize(padding_size, 0);
-    view_entry entry;
-    entry.padding = {m_padding_buffer.data(), m_padding_buffer.size()};
-    entry.data_size = padding_size;
-    m_views.push_back(entry);
-  }
-
-  // Get total size across all views.
-  // For compressed sections, returns the uncompressed size (what copy_to will produce).
-  size_t
-  size() const
-  {
-    size_t total = 0;
-    for (const auto& v : m_views)
-      total += v.data_size;
-
-    return total;
-  }
-
-  // Copy all views to destination buffer.
-  // Compressed sections are decompressed directly into dest via aiebu.
-  // Uncompressed sections and padding are memcpy'd.
-  void
-  copy_to(xrt_core::span<uint8_t> dest) const
-  {
-    if (dest.size() < size())
-      throw std::runtime_error(
-        "buf::copy_to: dest size (" + std::to_string(dest.size())
-        + ") < buf size (" + std::to_string(size()) + ")");
-
-    auto* dst = dest.data();
-    for (const auto& v : m_views) {
-      if (v.section)
-        aiebu::copy_section_uncompressed_data(v.section, *v.elf, dst, v.data_size);
-      else
-        std::memcpy(dst, v.padding.data(), v.data_size);
-
-      dst += v.data_size;
-    }
-  }
-
-  // Get data pointer - only works for single uncompressed view (zero-copy).
-  // Throws if the section is SHF_COMPRESSED — compressed bytes are not valid
-  // instruction data. Use copy_to() for compression-safe access.
-  const uint8_t*
-  data() const
-  {
-    if (m_views.size() == 1 && m_views[0].section) {
-      if (m_views[0].section->get_flags() & ELFIO::SHF_COMPRESSED)
-        throw std::runtime_error(
-          "buf::data() called on compressed section — use copy_to() instead");
-      return reinterpret_cast<const uint8_t*>(m_views[0].section->get_data());
-    }
-
-    // Multiple views: cannot provide direct pointer
-    // Caller should use copy_to() instead
-    throw std::runtime_error(
-      "Cannot get direct pointer from buffer with multiple views. "
-      "Use copy_to() to copy data instead.");
-  }
-
-  // Create std::string from views (for debug/trace).
-  // Decompresses compressed views into the result string.
-  std::string
-  to_string() const
-  {
-    std::string result;
-    result.resize(size());
-    copy_to({reinterpret_cast<uint8_t*>(result.data()), result.size()});
-    return result;
-  }
-
-  static const buf&
-  get_empty_buf()
-  {
-    static const buf b = {};
-    return b;
-  }
-};
-
-// Aliases for different ELF section buffers
-using instr_buf = buf;
-using control_packet = buf;
-using ctrlcode = buf; // represents control code for column or partition
-
 // Alias for kernel argument type
 using xarg = xrt_core::xclbin::kernel_argument;
-
-// Forward declaration
-class elf_impl;
-
-////////////////////////////////////////////////////////////////
-// Platform-specific configuration structures
-// These structures hold references to ELF data needed by
-// module_run classes.
-////////////////////////////////////////////////////////////////
-
-// Configuration for AIE2P platform
-struct module_config_aie_gen2
-{
-  // NOLINTBEGIN
-  // Reference members are safe here: module_run holds shared_ptr<elf_impl>
-  // ensuring data lifetime, and these configs are temporary parameter bundles
-  // used only during construction.
-
-  // Reference to instruction buffer data
-  const instr_buf& instr_data;
-
-  // Reference to control packet buffer (may be empty)
-  const control_packet& ctrl_packet_data;
-
-  // References to preemption save/restore buffers (may be empty)
-  const buf& preempt_save_data;
-  const buf& preempt_restore_data;
-
-  // Size of scratch pad memory per column
-  size_t scratch_pad_mem_size;
-
-  // Control scratch pad memory size (0 if not present)
-  size_t ctrl_scratch_pad_mem_size;
-
-  // Reference to PDI symbols that need patching
-  const std::unordered_set<std::string>& patch_pdi_symbols;
-
-  // Reference to control packet preemption dynamic symbols
-  const std::set<std::string>& ctrlpkt_pm_dynsyms;
-
-  // Reference to control packet preemption buffers map
-  const std::map<std::string, buf>& ctrlpkt_pm_bufs;
-  // NOLINTEND
-
-  // Flag indicating if preemption sections exist
-  bool has_preemption;
-
-  // Parent elf_impl pointer for accessing PDI buffers
-  elf_impl* elf_parent;
-};
-
-// Configuration for AIE2PS/AIE4 platform
-struct module_config_aie_gen2_plus
-{
-  // NOLINTBEGIN
-  // Reference members are safe here: module_run holds shared_ptr<elf_impl>
-  // ensuring data lifetime, and these configs are temporary parameter bundles
-  // used only during construction.
-
-  // Reference to control codes for each column
-  const std::vector<ctrlcode>& ctrlcodes;
-
-  // Reference to control packet buffers map
-  const std::map<std::string, buf>& ctrlpkt_bufs;
-
-  // Reference to dump buffer for debug/trace
-  const buf& dump_buf;
-
-  // Size of scratch pad memory per column
-  size_t scratch_pad_mem_size;
-  // NOLINTEND
-
-  // Parent elf_impl pointer for any mutable operations
-  elf_impl* elf_parent;
-};
-
-// Variant type for platform-specific module configuration
-using module_config = std::variant<module_config_aie_gen2, module_config_aie_gen2_plus>;
 
 ////////////////////////////////////////////////////////////////
 // elf_impl - Base implementation class for xrt::elf
@@ -296,34 +53,12 @@ protected:
   // classes for simplicity and avoids unnecessary boilerplate setters,
   // getters code
   // NOLINTBEGIN
-  ELFIO::elfio m_elfio;
+  aiebu::elf m_elf;
   xrt::elf::platform m_platform;
   std::string m_path; // file path from which elf was loaded, empty if loaded from stream/buffer
 
-  /* Parsed ELF data structures */
-  // lookup map for section index to group index
-  std::map<uint32_t, uint32_t> m_section_to_group_map;
-
-  // map of group id (ctrl code id) to vector of section indices
-  std::map<uint32_t, std::vector<uint32_t>> m_group_to_sections_map;
-
-  // lookup map for kernel + sub kernel name to grp idx(ctrl code id)
-  std::map<std::string, uint32_t> m_kernel_name_to_id_map;
-
-  // Kernel data collected during parsing (name -> args)
-  // This is populated during group section parsing and used to build elf::kernel objects
-  std::map<std::string, std::vector<xarg>> m_kernel_args_map;
-
-  // Map that stores available subkernels/instances of a kernel
-  // key - kernel name, value - vector of subkernel/instance names
-  std::map<std::string, std::vector<std::string>> m_kernel_to_subkernels_map;
-
-  // Final kernel objects built from m_kernel_args_map and m_kernel_to_subkernels_map
+  // Final kernel objects
   std::vector<elf::kernel> m_kernels;
-
-  // Map for custom sections
-  // key - custom section name, value - custom section data
-  std::map<std::string, detail::span<const char>> m_custom_section_map;
 
   /* Patcher related types and data - common between all platforms */
   // Aliases for patcher types
@@ -337,73 +72,13 @@ protected:
   // Stores static configuration only
   std::map<uint32_t, std::map<std::string, patcher_config>> m_arg2patcher;
 
-  // Constants for parsing rela addend field
-  // rela->addend have offset to base-bo-addr info along with schema
-  // [0:3] bit are used for patching schema, [4:31] used for base-bo-addr
-  static constexpr uint32_t addend_shift = 4;
-  static constexpr uint32_t addend_mask = ~((uint32_t)0) << addend_shift;
-  static constexpr uint32_t schema_mask = ~addend_mask;
-
   // NOLINTEND
 
   // elf_impl() - constructor
-  // 
-  // @elfio:  In memory ELFIO object
-  // @platform: ?
-  // @path: file path if ELFIO was loaded from from a file, empty otherwise
-  elf_impl(ELFIO::elfio&& elfio, elf::platform platform, std::string path);
-
-  // Parse sections in the ELF and populate internal maps
-  void
-  parse_sections();
-
-private:
-  ////////////////////////////////////////////////////////////////
-  // Private helper structures and methods
-  ////////////////////////////////////////////////////////////////
-
-  // Symbol information extracted from .symtab section
-  struct symbol_info {
-    std::string name;
-    unsigned char type = 0;
-    ELFIO::Elf_Half section_index = UINT16_MAX;
-  };
-
-  // Get symbol information from .symtab at given index
-  symbol_info
-  get_symbol_from_symtab(uint32_t sym_index) const;
-
-  // Extract kernel name from demangled signature
-  static std::string
-  extract_kernel_name(const std::string& signature);
-
-  // Check if kernel already exists in m_kernel_args_map
-  bool
-  kernel_exists(const std::string& kernel_name) const;
-
-  // Add kernel arguments to m_kernel_args_map during parsing
-  void
-  add_kernel_info(const std::string& kernel_name, const std::string& signature);
-
-  // Build elf::kernel objects from collected kernel data
-  void
-  finalize_kernels();
-
-  // Parse .symtab section to extract kernel and subkernel information
-  std::pair<std::string, std::string>
-  get_kernel_subkernel_from_symtab(uint32_t sym_index);
-
-  // Initialize maps for legacy ELF without .group sections
-  void
-  init_legacy_section_maps();
-
-  // Parse a single .group section and update maps
-  void
-  parse_single_group_section(const ELFIO::section* section);
-
-  // Parse custom sections and populate corresponding map
-  void
-  parse_custom_sections(const std::vector<uint32_t>& custom_section_ids);
+  //
+  // @elf:  Parsed aiebu::elf object
+  // @path: file path if loaded from a file, empty otherwise
+  elf_impl(aiebu::elf&& elf, std::string path);
 
 public:
   virtual ~elf_impl() = default;
@@ -414,14 +89,20 @@ public:
   elf_impl& operator=(const elf_impl&) = delete;
   elf_impl& operator=(elf_impl&&) = delete;
 
-  // Get raw ELFIO object reference.
-  // Compressed sections (.ctrltext*, .ctrldata*, .ctrlpkt*) contain raw compressed
-  // bytes with SHF_COMPRESSED set. Callers that need section data should use
-  // buf::append_section_data() + copy_to() which delegate to aiebu for decompression.
+  // Get the aiebu::elf object (replaces get_elfio() for Step 1.3 call sites)
+  const aiebu::elf&
+  get_aiebu_elf() const
+  {
+    return m_elf;
+  }
+
+  // Temporary escape hatch — forwards to aiebu::elf::get_elfio().
+  // TODO Step 1.3: remove once xrt_kernel.cpp and xdp elf_helper.cpp
+  // are updated to use get_aiebu_elf() directly.
   const ELFIO::elfio&
   get_elfio() const
   {
-    return m_elfio;
+    return m_elf.get_elfio();
   }
 
   // Get the filename this ELF was loaded from (empty if loaded from buffer/stream)
@@ -435,27 +116,22 @@ public:
   xrt::uuid
   get_cfg_uuid() const;
 
-  // Extract section data by name
-  std::vector<uint8_t>
-  get_section(const std::string& sname);
-
-  // Get note data from ELF section
-  std::string
-  get_note(const ELFIO::section* section, ELFIO::Elf_Word note_num) const;
-
   // Get partition size from ELF notes
   uint32_t
   get_partition_size() const;
 
   // Check if this is a full ELF (contains all info for hw context)
   bool
-  is_full_elf() const;
+  is_full_elf() const
+  {
+    return m_elf.is_full_elf();
+  }
 
   // Get OS ABI from ELF header
   uint8_t
   get_os_abi() const
   {
-    return m_elfio.get_os_abi();
+    return m_elf.get_os_abi();
   }
 
   // Get platform type
@@ -475,38 +151,28 @@ public:
   // Get ABI version as (major, minor) pair
   // Version byte format: upper nibble = major, lower nibble = minor
   std::pair<uint8_t, uint8_t>
-  get_abi_version() const;
+  get_abi_version() const
+  {
+    return m_elf.get_abi_version();
+  }
 
   // Check if ELF uses .group sections (version-dependent)
   virtual bool
   is_group_elf() const = 0;
 
-  // Get module configuration for a specific control code id
-  // Returns variant containing platform-specific config structure
-  // for the platform. Derived classes override to provide their
-  // specific configuration.
-  virtual module_config
-  get_module_config(uint32_t ctrl_code_id) = 0;
-
-
-  // PDI buffer accessors
-  // These remain as virtual methods since PDI buffers may be
-  // created lazily and cached
-  // Get PDI buffer data for a symbol
-  virtual const buf&
-  get_pdi(const std::string&) const
+  // Get control code id from kernel name — identical for all platforms.
+  uint32_t
+  get_ctrlcode_id(const std::string& name) const
   {
-    throw std::runtime_error("get_pdi not supported on this platform");
+    return m_elf.get_ctrlcode_id(name);
   }
 
-  // Get control code id from kernel name
-  // Looks up kernel + subkernel name in the kernel name to id map
-  virtual uint32_t
-  get_ctrlcode_id(const std::string& name) const = 0;
+  // Get the ERT command opcode in ELF flow
+  virtual ert_cmd_opcode
+  get_ert_opcode() const = 0;
 
-  // Get patcher configs for a specific ctrl code id
-  // Returns const pointer to shared configs owned by elf_impl (avoids copying)
-  // module_run creates symbol_patcher objects from these configs
+  // Get patcher configs for a specific ctrl code id.
+  // Returns const pointer into m_arg2patcher — zero-copy, used on hot path.
   const std::map<std::string, patcher_config>*
   get_patcher_configs(uint32_t ctrl_code_id) const
   {
@@ -516,14 +182,54 @@ public:
     return nullptr;
   }
 
-  // Get the ERT command opcode in ELF flow
-  virtual ert_cmd_opcode
-  get_ert_opcode() const = 0;
+  // ---- All buffer accessors forward directly to aiebu::elf ----
+  // module_run calls these with the ctrl_code_id it already holds,
+  // allocates a BO of the returned size, then copies into the BO mapping.
 
-  // Get custom section data by name
-  // Returns span of custom section data
-  detail::span<const char>
-  get_custom_section(const std::string& name) const;
+  // gen2: instruction buffer
+  size_t get_instr_buf_size(uint32_t id) const { return m_elf.get_instr_buf_size(id); }
+  void   copy_instr_buf(uint32_t id, aiebu::detail::span<std::byte> d) const { m_elf.copy_instr_buf(id, d); }
+
+  // gen2: control packet buffer
+  size_t get_ctrl_packet_size(uint32_t id) const { return m_elf.get_ctrl_packet_size(id); }
+  void   copy_ctrl_packet(uint32_t id, aiebu::detail::span<std::byte> d) const { m_elf.copy_ctrl_packet(id, d); }
+
+  // gen2: preemption save / restore buffers
+  size_t get_preempt_save_size(uint32_t id) const { return m_elf.get_preempt_save_size(id); }
+  void   copy_preempt_save(uint32_t id, aiebu::detail::span<std::byte> d) const { m_elf.copy_preempt_save(id, d); }
+  size_t get_preempt_restore_size(uint32_t id) const { return m_elf.get_preempt_restore_size(id); }
+  void   copy_preempt_restore(uint32_t id, aiebu::detail::span<std::byte> d) const { m_elf.copy_preempt_restore(id, d); }
+  bool   has_preemption() const { return m_elf.has_preemption(); }
+
+  // gen2: PDI buffers
+  // O(1) lookup of PDI symbols for a ctrl-code-id; no copy.
+  const std::unordered_set<std::string>&
+  get_pdi_symbols(uint32_t ctrl_code_id) const { return m_elf.get_pdi_symbols(ctrl_code_id); }
+
+  size_t get_pdi_size(const std::string& sym) const { return m_elf.get_pdi_size(sym); }
+  void   copy_pdi(const std::string& sym, aiebu::detail::span<std::byte> d) const { m_elf.copy_pdi(sym, d); }
+
+  // gen2: ctrlpkt preemption buffers
+  std::set<std::string> get_ctrlpkt_pm_dynsyms() const { return m_elf.get_ctrlpkt_pm_dynsyms(); }
+  size_t get_ctrlpkt_pm_buf_size(const std::string& sym) const { return m_elf.get_ctrlpkt_pm_buf_size(sym); }
+  void   copy_ctrlpkt_pm_buf(const std::string& sym, aiebu::detail::span<std::byte> d) const { m_elf.copy_ctrlpkt_pm_buf(sym, d); }
+
+  // gen2: ctrl scratch pad memory size
+  size_t get_ctrl_scratch_pad_mem_size() const { return m_elf.get_ctrl_scratch_pad_mem_size(); }
+
+  // gen2plus: column ctrl-code buffers
+  size_t get_column_count(uint32_t id) const { return m_elf.get_column_count(id); }
+  size_t get_ctrlcode_col_size(uint32_t id, uint32_t col) const { return m_elf.get_ctrlcode_size(id, col); }
+  void   copy_ctrlcode_col(uint32_t id, uint32_t col, aiebu::detail::span<std::byte> d) const { m_elf.copy_ctrlcode(id, col, d); }
+
+  // gen2plus: ctrlpkt buffers
+  std::vector<std::string> get_ctrlpkt_section_names(uint32_t id) const { return m_elf.get_ctrlpkt_section_names(id); }
+  size_t get_ctrlpkt_size(uint32_t id, const std::string& name) const { return m_elf.get_ctrlpkt_size(id, name); }
+  void   copy_ctrlpkt(uint32_t id, const std::string& name, aiebu::detail::span<std::byte> d) const { m_elf.copy_ctrlpkt(id, name, d); }
+
+  // gen2plus: dump buffer
+  size_t get_dump_buf_size(uint32_t id) const { return m_elf.get_dump_buf_size(id); }
+  void   copy_dump_buf(uint32_t id, aiebu::detail::span<std::byte> d) const { m_elf.copy_dump_buf(id, d); }
 };
 
 } // namespace xrt

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -22,6 +22,7 @@
 #include "core/common/xclbin_parser.h"
 #include "core/common/runner/capture.h"
 
+#include <chrono>
 #include <cstdint>
 #include <map>
 #include <memory>

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -22,14 +22,9 @@
 #include "core/common/xclbin_parser.h"
 #include "core/common/runner/capture.h"
 
-#include <boost/interprocess/streams/bufferstream.hpp>
-#include <elfio/elfio.hpp>
-
-#include <chrono>
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -48,198 +43,91 @@ static constexpr size_t
 operator"" _mb(unsigned long long v)  { return 1024u * 1024u * v; } // NOLINT
 
 ///////////////////////////////////////////////////////////////
-// Helper functions for kernel signature demangling and parsing
+// aiebu::elf construction helpers
 ///////////////////////////////////////////////////////////////
 
-// Mangled name prefix length for Itanium ABI
-static constexpr size_t mangled_prefix_length = 2;
-static constexpr size_t decimal_base = 10;
-
-// Split string by delimiter
-static std::vector<std::string>
-split(const std::string& s, char delimiter)
+// Translate aiebu::elf::arg -> xrt::xarg
+static xrt::xarg
+make_xarg(const aiebu::elf::arg& a, size_t& offset)
 {
-  std::vector<std::string> tokens;
-  std::stringstream ss(s);
-  std::string item;
+  static constexpr size_t global_arg_size = 0x8;
+  xrt::xarg arg;
+  arg.name     = a.name;
+  arg.hosttype = "no-type";
+  arg.port     = "no-port";
+  arg.index    = a.index;
+  arg.offset   = offset;
+  arg.dir      = xrt::xarg::direction::input;
+  arg.type     = a.is_global
+                   ? xrt::xarg::argtype::global
+                   : xrt::xarg::argtype::scalar;
+  if (arg.type == xrt::xarg::argtype::scalar)
+    throw std::runtime_error("scalar args are not yet supported for this kind of kernel");
 
-  while (getline(ss, item, delimiter))
-    tokens.push_back(item);
-
-  return tokens;
+  arg.size = global_arg_size;
+  offset  += global_arg_size;
+  return arg;
 }
 
-// Basic Itanium ABI type decoding
-static std::string
-get_demangle_type(char c)
+// Translate aiebu::elf::kernel -> xrt::elf::kernel pimpl
+static xrt::elf::kernel
+make_kernel(const aiebu::elf::kernel& k)
 {
-  static const std::map<char, std::string> demangle_type_map = {
-    {'v', "void"},
-    {'c', "char"},
-    {'i', "int"}
-  };
-  auto it = demangle_type_map.find(c);
-  if (it == demangle_type_map.end())
-    throw std::runtime_error("Unknown type character in mangled name: " + std::string(1, c));
-  return it->second;
-}
-
-// Function to demangle kernel name
-// Parse mangled name in Itanium ABI style: _Z<length><name><types>
-// length : number of characters in the name string.
-// name   : kernel name in string
-// types  : kernel argument data type as below.
-//  'c' represents the arg is a char.
-//  'v' represents the arg is a void.
-//  'i' represents the arg is an int.
-//  'P' represents the arg is a pointer.
-// Hence, "Pc" = char*, "Pv" = void*, "Pi" = int*, "PPc" = char**, etc.
-static std::string
-demangle(const std::string& mangled)
-{
-  // Check if mangled prefix "_Z" is present and length is greater than mangled_prefix_length
-  if (mangled.size() <= mangled_prefix_length || mangled.substr(0, mangled_prefix_length) != "_Z")
-    throw std::runtime_error("Doesn't have prefix _Z, not a mangled kernel name");
-
-  size_t idx = 2;
-  size_t len = 0;
-
-  // Extract length of function name
-  while (idx < mangled.size() && std::isdigit(mangled[idx]))
-    len = len * decimal_base + (mangled[idx++] - '0');
-
-  if (idx + len > mangled.size())
-    throw std::runtime_error("Invalid mangled name, doesn't have expected kernel name length");
-
-  std::string name = mangled.substr(idx, len);
-  idx += len;
-  std::vector<std::string> args;
-
-  // Parse the argument types from the mangled name
-  // Each argument can have multiple 'P' prefixes indicating pointer depth
-  // followed by a single character representing the base type
-  while (idx < mangled.size()) {
-    int pointer_depth = 0;
-    // Count pointer depth (number of 'P' characters indicating pointer levels)
-    // For example: "P" = 1 level (char*), "PP" = 2 levels (char**), etc.
-    while (idx < mangled.size() && mangled[idx] == 'P') {
-      ++pointer_depth;
-      ++idx;
-    }
-    if (idx >= mangled.size())
-      throw std::runtime_error("demangle arg index out of bounds");
-
-    std::string type = get_demangle_type(mangled[idx++]);
-    for (int i = 0; i < pointer_depth; ++i)
-      type += "*";
-    args.push_back(type);
-  }
-
-  // Append arguments to the function name
-  std::string result = name + "(";
-  for (size_t i = 0; i < args.size(); ++i) {
-    if (i > 0)
-      result += ", ";
-    result += args[i];
-  }
-  result += ")";
-
-  return result;
-}
-
-// Function that constructs kernel arguments from signature
-// kernel signature has name followed by args
-// kernel signature - name(argtype, argtype ...)
-// eg : DPU(char*, char*, char*)
-static std::vector<xrt::xarg>
-construct_kernel_args(const std::string& signature)
-{
-  std::vector<xrt::xarg> args;
-
-  size_t start_pos = signature.find('(');
-  size_t end_pos = signature.find(')', start_pos);
-
-  if (start_pos == std::string::npos)
-    return args; // kernel with no args
-
-  if ((start_pos != std::string::npos) && (end_pos == std::string::npos || start_pos > end_pos))
-    throw std::runtime_error("Failed to construct kernel args");
-
-  std::string argstring = signature.substr(start_pos + 1, end_pos - start_pos - 1);
-  std::vector<std::string> argstrings = split(argstring, ',');
-
-  size_t count = 0;
+  std::vector<xrt::xarg> xargs;
   size_t offset = 0;
-  for (const std::string& str : argstrings) {
-    xrt::xarg arg;
-    arg.name = "argv" + std::to_string(count);
-    arg.hosttype = "no-type";
-    arg.port = "no-port";
-    arg.index = count;
-    arg.offset = offset;
-    arg.dir = xrt::xarg::direction::input;
-    // if arg has pointer(*) in its name (eg: char*, void*) it is of type global otherwise scalar
-    arg.type = (str.find('*') != std::string::npos)
-      ? xrt::xarg::argtype::global
-      : xrt::xarg::argtype::scalar;
+  for (const auto& a : k.args)
+    xargs.push_back(make_xarg(a, offset));
 
-    // At present only global args are supported
-    // TODO : Add support for scalar args in ELF flow
-    if (arg.type == xrt::xarg::argtype::scalar)
-      throw std::runtime_error("scalar args are not yet supported for this kind of kernel");
-    else {
-      // global arg
-      static constexpr size_t global_arg_size = 0x8;
-      arg.size = global_arg_size;
+  std::vector<xrt::elf::kernel::instance> instances;
+  for (const auto& inst : k.instances)
+    instances.emplace_back(std::make_shared<xrt::elf::kernel::instance_impl>(inst));
 
-      offset += global_arg_size;
+  return xrt::elf::kernel{std::make_shared<xrt::elf::kernel_impl>(
+    k.name, std::move(xargs), std::move(instances))};
+}
+
+// Translate aiebu::elf kernels into the XRT pimpl kernel objects.
+static std::vector<xrt::elf::kernel>
+create_kernels(const aiebu::elf& elf)
+{
+  std::vector<xrt::elf::kernel> kernels;
+  for (const auto& k : elf.get_kernels())
+    kernels.push_back(make_kernel(k));
+
+  return kernels;
+}
+
+// Translate patch_points from aiebu::elf into an m_arg2patcher map.
+// The key-string format and patcher_config/patch_config field layout
+// are intentionally identical to the old ELFIO-based parsing, so the
+// hot-path get_patcher_configs() / symbol_patcher::patch_symbol() are unchanged.
+static std::map<uint32_t, std::map<std::string, xrt_core::elf_patcher::patcher_config>>
+create_arg2patcher(const aiebu::elf& elf)
+{
+  using patcher_config   = xrt_core::elf_patcher::patcher_config;
+  using patch_config     = xrt_core::elf_patcher::patch_config;
+  using patcher_buf_type = xrt_core::elf_patcher::buf_type;
+  using patcher_sym_type = xrt_core::elf_patcher::symbol_type;
+
+  std::map<uint32_t, std::map<std::string, patcher_config>> out;
+  for (const auto& [grp_idx, key_map] : elf.get_patch_points()) {
+    for (const auto& [key, pts] : key_map) {
+      for (const auto& pp : pts) {
+        patch_config pc{pp.section_offset, pp.base_bo_offset, pp.mask};
+        auto btype  = static_cast<patcher_buf_type>(pp.target_buf);
+        auto schema = static_cast<patcher_sym_type>(pp.schema);
+
+        auto& slot = out[grp_idx];
+        auto  it   = slot.find(key);
+        if (it != slot.end())
+          it->second.add_patch(pc);
+        else
+          slot.emplace(key, patcher_config{schema, {pc}, btype});
+
+      }
     }
-
-    args.emplace_back(std::move(arg));
-    count++;
   }
-  return args;
-}
-
-///////////////////////////////////////////////////////////////
-// ELFIO loading functions - used overloaded functions instead
-// of template to display specific error messages
-///////////////////////////////////////////////////////////////
-
-// Load ELFIO from file path
-static ELFIO::elfio
-load_elfio(const std::string& fnm)
-{
-  ELFIO::elfio elfio;
-  if (!elfio.load(fnm))
-    throw std::runtime_error(fnm + " is not found or is not a valid ELF file");
-
-  if (xrt_core::config::get_xrt_debug()) {
-    std::string message = "Loaded elf file " + fnm;
-    xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_elf", message);
-  }
-  return elfio;
-}
-
-// Load ELFIO from stream
-static ELFIO::elfio
-load_elfio(std::istream& stream)
-{
-  ELFIO::elfio elfio;
-  if (!elfio.load(stream))
-    throw std::runtime_error("not a valid ELF stream");
-  return elfio;
-}
-
-// Load ELFIO from buffer
-static ELFIO::elfio
-load_elfio(const void* data, size_t size)
-{
-  ELFIO::elfio elfio;
-  boost::interprocess::ibufferstream istr(static_cast<const char*>(data), size);
-  if (!elfio.load(istr))
-    throw std::runtime_error("not valid ELF data");
-  return elfio;
+  return out;
 }
 
 } // namespace
@@ -337,222 +225,17 @@ public:
 // (class declaration is in elf_int.h)
 ////////////////////////////////////////////////////////////////
 
-// Protected constructor
 elf_impl::
-elf_impl(ELFIO::elfio&& elfio, elf::platform platform, std::string path)
-  : m_elfio{std::move(elfio)}
-  , m_platform{platform}
+elf_impl(aiebu::elf&& elf, std::string path)
+  : m_elf{std::move(elf)}
+  , m_platform{static_cast<xrt::elf::platform>(m_elf.get_os_abi())}
   , m_path{std::move(path)}
-{}
-
-// Get symbol information from .symtab at given index
-elf_impl::symbol_info
-elf_impl::
-get_symbol_from_symtab(uint32_t sym_index) const
+  , m_kernels{create_kernels(m_elf)}
+  , m_arg2patcher{create_arg2patcher(m_elf)}
 {
-  ELFIO::section* symtab = m_elfio.sections[".symtab"];
-  if (!symtab)
-    throw std::runtime_error("No .symtab section found");
-
-  const ELFIO::symbol_section_accessor symbols(m_elfio, symtab);
-
-  symbol_info info;
-  ELFIO::Elf64_Addr value{};
-  ELFIO::Elf_Xword size{};
-  unsigned char bind{};
-  unsigned char other{};
-
-  if (!symbols.get_symbol(sym_index, info.name, value, size, bind,
-                          info.type, info.section_index, other))
-    throw std::runtime_error(
-      "Unable to find symbol in .symtab section with index: " +
-      std::to_string(sym_index));
-
-  return info;
-}
-
-// Extract kernel name from demangled signature
-std::string
-elf_impl::
-extract_kernel_name(const std::string& signature)
-{
-  auto pos = signature.find('(');
-  return (pos == std::string::npos) ? signature : signature.substr(0, pos);
-}
-
-// Check if kernel already exists in m_kernel_args_map
-bool
-elf_impl::
-kernel_exists(const std::string& kernel_name) const
-{
-  return m_kernel_args_map.find(kernel_name) != m_kernel_args_map.end();
-}
-
-// Add kernel arguments to m_kernel_args_map during parsing
-void
-elf_impl::
-add_kernel_info(const std::string& kernel_name, const std::string& signature)
-{
-  m_kernel_args_map[kernel_name] = construct_kernel_args(signature);
-}
-
-// Build elf::kernel objects from collected kernel data
-void
-elf_impl::
-finalize_kernels()
-{
-  for (const auto& [kernel_name, args] : m_kernel_args_map) {
-    // Build instance objects from subkernel names
-    std::vector<elf::kernel::instance> instances;
-    auto it = m_kernel_to_subkernels_map.find(kernel_name);
-    if (it != m_kernel_to_subkernels_map.end()) {
-      for (const auto& subkernel_name : it->second) {
-        instances.emplace_back(
-          std::make_shared<elf::kernel::instance_impl>(subkernel_name));
-      }
-    }
-
-    // Create kernel with name, args, and instances
-    m_kernels.emplace_back(
-      std::make_shared<elf::kernel_impl>(kernel_name, args, std::move(instances)));
-  }
-}
-
-// Parse .symtab section to extract kernel and subkernel information
-std::pair<std::string, std::string>
-elf_impl::
-get_kernel_subkernel_from_symtab(uint32_t sym_index)
-{
-  // Get subkernel symbol - must be of type OBJECT
-  auto subkernel_sym = get_symbol_from_symtab(sym_index);
-  if (subkernel_sym.type != ELFIO::STT_OBJECT)
-    throw std::runtime_error(
-      "Symbol doesn't point to subkernel entry (expected STT_OBJECT)");
-
-  // Get parent kernel symbol - must be of type FUNC
-  auto kernel_sym = get_symbol_from_symtab(subkernel_sym.section_index);
-  if (kernel_sym.type != ELFIO::STT_FUNC)
-    throw std::runtime_error(
-      "Subkernel doesn't point to kernel entry (expected STT_FUNC)");
-
-  // Demangle kernel name and extract signature
-  auto demangled_signature = demangle(kernel_sym.name);
-  auto kernel_name = extract_kernel_name(demangled_signature);
-
-  // Cache kernel info if not already present
-  if (!kernel_exists(kernel_name))
-    add_kernel_info(kernel_name, demangled_signature);
-
-  return {kernel_name, subkernel_sym.name};
-}
-
-// Initialize maps for legacy ELF without .group sections
-void
-elf_impl::
-init_legacy_section_maps()
-{
-  std::vector<uint32_t> all_section_ids;
-
-  for (const auto& sec : m_elfio.sections) {
-    auto sec_id = sec->get_index();
-    all_section_ids.push_back(sec_id);
-    m_section_to_group_map[sec_id] = no_ctrl_code_id;
-  }
-
-  // Use empty string as kernel name for legacy ELF
-  m_kernel_name_to_id_map[""] = no_ctrl_code_id;
-  m_group_to_sections_map.emplace(no_ctrl_code_id, std::move(all_section_ids));
-}
-
-// Parse a single .group section and update maps
-void
-elf_impl::
-parse_single_group_section(const ELFIO::section* section)
-{
-  const auto* data = section->get_data();
-  const auto size = section->get_size();
-  auto group_id = section->get_index();
-
-  // .group section data: flags followed by section indices
-  if (data == nullptr || size < sizeof(ELFIO::Elf_Word))
-    return;
-
-  // Parse kernel/subkernel from symtab using .group's info field
-  auto [kernel_name, subkernel_name] =
-    get_kernel_subkernel_from_symtab(section->get_info());
-
-  // Update kernel maps
-  m_kernel_to_subkernels_map[kernel_name].push_back(subkernel_name);
-  m_kernel_name_to_id_map[kernel_name + subkernel_name] = group_id;
-
-  // Parse member section indices (skip flags at index 0)
-  const auto* word_data =
-    reinterpret_cast<const ELFIO::Elf_Word*>(data);
-  const auto word_count = size / sizeof(ELFIO::Elf_Word);
-
-  std::vector<uint32_t> member_sections;
-  for (std::size_t i = 1; i < word_count; ++i) {
-    auto member_id = word_data[i];
-    member_sections.push_back(member_id);
-    m_section_to_group_map[member_id] = group_id;
-  }
-
-  m_group_to_sections_map.emplace(group_id, std::move(member_sections));
-}
-
-void
-elf_impl::
-parse_custom_sections(const std::vector<uint32_t>& custom_section_ids)
-{
-  auto section_span = [](const ELFIO::section* sec) {
-    return detail::span<const char>(sec->get_data(), sec->get_size());
-  };
-
-  for (auto sec_id : custom_section_ids) {
-    auto sec = m_elfio.sections[sec_id];
-    if (!sec)
-      continue;
-
-    auto sec_name = sec->get_name();
-    auto data = section_span(sec);
-
-    m_custom_section_map[sec_name] = data;
-  }
-}
-
-// Parse ELF sections and populate all maps
-void
-elf_impl::
-parse_sections()
-{
-  if (!is_group_elf()) { // older ELF format without .group sections
-    init_legacy_section_maps();
-    finalize_kernels();
-    m_kernel_args_map.clear();
-    return;
-  }
-
-  // collect custom sections and parse .group sections to populate maps
-  std::vector<uint32_t> custom_section_ids;
-  constexpr ELFIO::Elf_Word custom_section_type = ELFIO::SHT_LOUSER + 1;
-  for (const auto& section : m_elfio.sections) {
-    if (!section)
-      continue;
-
-    if (section->get_type() == ELFIO::SHT_GROUP)
-      parse_single_group_section(section.get());
-    else if (section->get_type() == custom_section_type)
-      custom_section_ids.push_back(section->get_index());
-  }
-
-  // Build elf::kernel objects after all group sections are parsed
-  finalize_kernels();
-
-  // parse and collect custom sections from ELF
-  parse_custom_sections(custom_section_ids);
-
-  // Free parsing-only data, not used after parse_sections().
-  m_kernel_args_map.clear();
+  // m_patch_points has been translated into m_arg2patcher; release it to
+  // avoid retaining a duplicate copy for the lifetime of the ELF object.
+  m_elf.clear_patch_points();
 }
 
 // Get configuration UUID from ELF
@@ -561,50 +244,17 @@ xrt::uuid
 elf_impl::
 get_cfg_uuid() const
 {
+  // Returns an empty UUID if the section is absent (e.g. partial ELFs).
   constexpr size_t uuid_size = 16;
-  constexpr ELFIO::Elf_Word first_note = 0;
-
-  auto section = m_elfio.sections[".note.xrt.UID"];
-  if (!section)
+  try {
+    auto data = m_elf.get_cfg_uuid();
+    xuid_t uuid_data;
+    std::memcpy(uuid_data, data.data(), uuid_size);
+    return xrt::uuid(uuid_data);
+  }
+  catch (const std::exception&) {
     return {};
-
-  auto data = get_note(section, first_note);
-  if (data.size() != uuid_size)
-    return {};
-
-  xuid_t uuid_data;
-  std::memcpy(uuid_data, data.data(), uuid_size);
-  return xrt::uuid(uuid_data);
-}
-
-// Extract section data by name
-std::vector<uint8_t>
-elf_impl::
-get_section(const std::string& sname)
-{
-  auto sec = m_elfio.sections[sname];
-  if (!sec)
-    throw std::runtime_error("Failed to find section: " + sname);
-
-  auto data = sec->get_data();
-  std::vector<uint8_t> vec(data, data + sec->get_size());
-  return vec;
-}
-
-// Get note data from ELF section
-std::string
-elf_impl::
-get_note(const ELFIO::section* section, ELFIO::Elf_Word note_num) const
-{
-  // NOLINTNEXTLINE - ELFIO API requires non-const pointer despite not modifying
-  ELFIO::note_section_accessor accessor(m_elfio, const_cast<ELFIO::section*>(section));
-  ELFIO::Elf_Word type = 0;
-  std::string name;
-  char* desc = nullptr;
-  ELFIO::Elf_Word desc_size = 0;
-  if (!accessor.get_note(note_num, type, name, desc, desc_size))
-    throw std::runtime_error("Failed to get note, note not found\n");
-  return std::string{desc, desc_size};
+  }
 }
 
 // Get partition size from ELF notes
@@ -612,432 +262,39 @@ uint32_t
 elf_impl::
 get_partition_size() const
 {
-  auto section = m_elfio.sections[".note.xrt.configuration"];
-  if (!section)
-    throw std::runtime_error("ELF is missing xrt configuration info\n");
-
-  uint32_t value = 0;
-  auto data = get_note(section, 0);
-  std::memcpy(&value, data.data(), std::min(data.size(), sizeof(uint32_t)));
-  return value;
-}
-
-// Check if this is a full ELF
-bool
-elf_impl::
-is_full_elf() const
-{
-  return m_elfio.sections[".note.xrt.configuration"] != nullptr;
-}
-
-// Get ABI version as (major, minor) pair
-std::pair<uint8_t, uint8_t>
-elf_impl::
-get_abi_version() const
-{
-  constexpr uint8_t major_ver_mask = 0xF0;
-  constexpr uint8_t minor_ver_mask = 0x0F;
-  constexpr uint8_t shift = 4;
-
-  auto abi_version = m_elfio.get_abi_version();
-  auto major = static_cast<uint8_t>((abi_version & major_ver_mask) >> shift);
-  auto minor = static_cast<uint8_t>(abi_version & minor_ver_mask);
-  return {major, minor};
-}
-
-detail::span<const char>
-elf_impl::
-get_custom_section(const std::string& name) const
-{
-  if (auto it = m_custom_section_map.find(name); it != m_custom_section_map.end())
-    return it->second;
-
-  throw std::runtime_error("Cannot get custom section " + name + " data, section not found in ELF");
+  return m_elf.get_partition_size();
 }
 
 ////////////////////////////////////////////////////////////////
-// Derived class for aie2p (gen2) platform
+// elf_aie_gen2 — AIE2P (gen2) platform
+//
+// No buffer maps — all section data lives in aiebu::elf (elf_reader_aie2p).
+// This class only provides the XRT-specific virtual interface.
 ////////////////////////////////////////////////////////////////
 class elf_aie_gen2 : public elf_impl
 {
-  // Elfs can have multiple kernels and its corresponding sub kernels
-  // We use ctrl code id or grp idx to represent kernel + sub kernel combination
-  // Below maps store data for each ctrl code id
-  // key - ctrl code id, value - section buffer data
-  std::map<uint32_t, instr_buf> m_instr_buf_map;
-  std::map<uint32_t, control_packet> m_ctrl_packet_map;
-  std::map<uint32_t, buf> m_save_buf_map;
-  std::map<uint32_t, buf> m_restore_buf_map;
-
-  // Elfs with preemption sections uses different opcode
-  // Below variable is set to true if these sections exist
-  bool m_preemption_exist = false;
-
-  // maps related to PDI sections
-  std::map<std::string, buf> m_pdi_buf_map; // pdi_section_name (.pdi.*) -> section buffer data
-  // map that stores pdi symbols that needs patching in corresponding ctrl codes
-  // key - ctrl code id, value - set of pdi symbols that needs patching
-  std::map<uint32_t, std::unordered_set<std::string>> m_ctrl_pdi_map;
-
-  // size of control scratch pad memory
-  size_t m_ctrl_scratch_pad_mem_size = 0;
-
-  // set of preemption dynsyms in elf
-  std::set<std::string> m_ctrlpkt_pm_dynsyms;
-  // map storing preemption section buffers
-  // key - preemption section name (.ctrlpkt.pm.*)
-  // value - section buffer data
-  std::map<std::string, buf> m_ctrlpkt_pm_bufs;
-
-  ////////////////////////////////////////////////////////////////
-  // Buffer initialization helper functions
-  ////////////////////////////////////////////////////////////////
-
-  // Initialize buffer map for given section type
-  void
-  initialize_section_buf_map(patcher_buf_type type, std::map<uint32_t, buf>& buf_map)
-  {
-    auto section_pattern = xrt_core::elf_patcher::get_section_name(type);
-    for (const auto& sec : m_elfio.sections) {
-      auto name = sec->get_name();
-      if (name.find(section_pattern) == std::string::npos)
-        continue;
-
-      auto grp_idx = m_section_to_group_map[sec->get_index()];
-      buf_map[grp_idx].append_section_data(sec, m_elfio);
-    }
-  }
-
-  // Initialize preempt save/restore buffers from ELF sections
-  void
-  initialize_save_restore_buf_map()
-  {
-    auto save_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::preempt_save);
-    auto restore_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::preempt_restore);
-
-    for (const auto& [grp_id, sec_ids] : m_group_to_sections_map) {
-      bool has_save = false;
-      bool has_restore = false;
-
-      for (auto sec_idx : sec_ids) {
-        const auto& sec = m_elfio.sections[sec_idx];
-        auto name = sec->get_name();
-
-        if (name.find(save_pattern) != std::string::npos) {
-          m_save_buf_map[grp_id].append_section_data(sec, m_elfio);
-          has_save = true;
-        }
-        else if (name.find(restore_pattern) != std::string::npos) {
-          m_restore_buf_map[grp_id].append_section_data(sec, m_elfio);
-          has_restore = true;
-        }
-      }
-
-      if (has_save != has_restore)
-        throw std::runtime_error("Invalid ELF: preempt save and restore sections are not paired");
-
-      // If both save and restore sections are found, we set preemption exist flag
-      // At present this flag is set at Elf level assuming if one kernel + sub kernel has these
-      // sections, all others will have these sections
-      // TODO : Move this logic to group(kernel + sub kernel) level
-      if (has_save && has_restore)
-        m_preemption_exist = true;
-    }
-  }
-
-  // Initialize PDI buffers from ELF sections
-  void
-  initialize_pdi_buf_map()
-  {
-    auto pdi_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::pdi);
-    for (const auto& sec : m_elfio.sections) {
-      auto name = sec->get_name();
-      if (name.find(pdi_pattern) == std::string::npos)
-        continue;
-
-      m_pdi_buf_map[name].append_section_data(sec, m_elfio);
-    }
-  }
-
-  // Initialize control packet preemption buffers from ELF sections
-  void
-  initialize_ctrlpkt_pm_buf_map()
-  {
-    auto pm_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::ctrlpkt_pm);
-    for (const auto& sec : m_elfio.sections) {
-      auto name = sec->get_name();
-      if (name.find(pm_pattern) == std::string::npos)
-        continue;
-
-      m_ctrlpkt_pm_bufs[name].append_section_data(sec, m_elfio);
-    }
-  }
-
-  // Initialize section buffers
-  void
-  initialize_section_buffer_maps()
-  {
-    initialize_section_buf_map(patcher_buf_type::ctrltext, m_instr_buf_map);
-    initialize_section_buf_map(patcher_buf_type::ctrldata, m_ctrl_packet_map);
-    initialize_save_restore_buf_map();
-    initialize_pdi_buf_map();
-    initialize_ctrlpkt_pm_buf_map();
-  }
-
-  ////////////////////////////////////////////////////////////////
-  // Argument patcher initialization
-  ////////////////////////////////////////////////////////////////
-
-  // Determine section type and size based on section name
-  std::pair<size_t, patcher_buf_type>
-  determine_section_type(const std::string& section_name, uint32_t id)
-  {
-    // Use static constexpr to compute section names at compile time
-    static constexpr auto ctrltext_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::ctrltext);
-    static constexpr auto ctrldata_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::ctrldata);
-    static constexpr auto save_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::preempt_save);
-    static constexpr auto restore_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::preempt_restore);
-    static constexpr auto pdi_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::pdi);
-
-    if (section_name.find(ctrltext_pattern) != std::string::npos) {
-      if (m_instr_buf_map.find(id) == m_instr_buf_map.end())
-        throw std::runtime_error("Invalid section passed, section info is not cached\n");
-      return { m_instr_buf_map[id].size(), patcher_buf_type::ctrltext };
-    }
-    else if (!m_ctrl_packet_map.empty() &&
-             section_name.find(ctrldata_pattern) != std::string::npos) {
-      if (m_ctrl_packet_map.find(id) == m_ctrl_packet_map.end())
-        throw std::runtime_error("Invalid section passed, section info is not cached\n");
-      return { m_ctrl_packet_map[id].size(), patcher_buf_type::ctrldata };
-    }
-    else if (section_name.find(save_pattern) != std::string::npos) {
-      if (m_save_buf_map.find(id) == m_save_buf_map.end())
-        throw std::runtime_error("Invalid section passed, section info is not cached\n");
-      return { m_save_buf_map[id].size(), patcher_buf_type::preempt_save };
-    }
-    else if (section_name.find(restore_pattern) != std::string::npos) {
-      if (m_restore_buf_map.find(id) == m_restore_buf_map.end())
-        throw std::runtime_error("Invalid section passed, section info is not cached\n");
-      return { m_restore_buf_map[id].size(), patcher_buf_type::preempt_restore };
-    }
-    else if (!m_pdi_buf_map.empty() &&
-             section_name.find(pdi_pattern) != std::string::npos) {
-      if (m_pdi_buf_map.find(section_name) == m_pdi_buf_map.end())
-        throw std::runtime_error("Invalid section passed, section info is not cached\n");
-      return { m_pdi_buf_map[section_name].size(), patcher_buf_type::pdi };
-    }
-
-    throw std::runtime_error("Invalid section passed\n");
-  }
-
-  // Initialize argument patchers from ELF relocation sections
-  void
-  initialize_arg_patchers()
-  {
-    static constexpr const char* Control_ScratchPad_Symbol = "scratch-pad-ctrl";
-    static constexpr const char* ctrlpkt_pm_dynsym = "ctrlpkt-pm";
-
-    auto dynsym = m_elfio.sections[".dynsym"];
-    auto dynstr = m_elfio.sections[".dynstr"];
-    auto dynsec = m_elfio.sections[".rela.dyn"];
-
-    if (!dynsym || !dynstr || !dynsec)
-      return;
-
-    // Iterate over all relocations and construct a patcher for each
-    // relocation that refers to a symbol in the .dynsym section.
-    auto begin = reinterpret_cast<const ELFIO::Elf32_Rela*>(dynsec->get_data());
-    auto end = begin + dynsec->get_size() / sizeof(const ELFIO::Elf32_Rela);
-    for (auto rela = begin; rela != end; ++rela) {
-      auto symidx = ELFIO::get_sym_and_type<ELFIO::Elf32_Rela>::get_r_sym(rela->r_info);
-      auto type = ELFIO::get_sym_and_type<ELFIO::Elf32_Rela>::get_r_type(rela->r_info);
-
-      auto dynsym_offset = symidx * sizeof(ELFIO::Elf32_Sym);
-      if (dynsym_offset >= dynsym->get_size())
-        throw std::runtime_error("Invalid symbol index " + std::to_string(symidx));
-
-      auto sym = reinterpret_cast<const ELFIO::Elf32_Sym*>(dynsym->get_data() + dynsym_offset);
-      auto dynstr_offset = sym->st_name;
-      if (dynstr_offset >= dynstr->get_size())
-        throw std::runtime_error("Invalid symbol name offset " + std::to_string(dynstr_offset));
-
-      auto symname = dynstr->get_data() + dynstr_offset;
-      if (!m_ctrl_scratch_pad_mem_size && (strcmp(symname, Control_ScratchPad_Symbol) == 0)) {
-        m_ctrl_scratch_pad_mem_size = static_cast<size_t>(sym->st_size);
-      }
-
-      if (std::string(symname).find(ctrlpkt_pm_dynsym) != std::string::npos) {
-        // store ctrlpkt preemption symbols which is later used for patching instr buf
-        m_ctrlpkt_pm_dynsyms.emplace(symname);
-      }
-
-      // Get control code section referenced by the symbol, col, and page
-      auto section = m_elfio.sections[sym->st_shndx];
-      if (!section)
-        throw std::runtime_error("Invalid section index " + std::to_string(sym->st_shndx));
-
-      auto offset = rela->r_offset;
-      auto sec_index = section->get_index();
-      auto grp_idx = m_section_to_group_map[sec_index];
-      auto [sec_size, buf_type] = determine_section_type(section->get_name(), grp_idx);
-
-      if (offset >= sec_size)
-        throw std::runtime_error("Invalid offset " + std::to_string(offset));
-
-      if (std::string(symname).find("pdi") != std::string::npos) {
-        // pdi symbol, add to map of which ctrl code needs it
-        m_ctrl_pdi_map[grp_idx].insert(symname);
-      }
-
-      patcher_symbol_type patch_scheme = patcher_symbol_type::scalar_32bit_kind;
-      uint32_t add_end_addr = 0;
-      auto abi_version = static_cast<uint16_t>(m_elfio.get_abi_version());
-      if (abi_version != 1) {
-        add_end_addr = rela->r_addend;
-        patch_scheme = static_cast<patcher_symbol_type>(type);
-      }
-      else {
-        // rela addend have offset to base_bo_addr info along with schema
-        add_end_addr = (rela->r_addend & addend_mask) >> addend_shift;
-        patch_scheme = static_cast<patcher_symbol_type>(rela->r_addend & schema_mask);
-      }
-
-      std::string argnm{ symname, symname + std::min(strlen(symname), dynstr->get_size()) };
-      patch_config pc = patch_scheme == patcher_symbol_type::scalar_32bit_kind
-        // st_size is is encoded using register value mask for scaler_32
-        // for other pacthing scheme it is encoded using size of dma
-        ? patch_config{ offset, add_end_addr, static_cast<uint32_t>(sym->st_size) }
-        : patch_config{ offset, add_end_addr, 0 };
-
-      auto key_string = xrt_core::elf_patcher::generate_key_string(argnm, buf_type);
-
-      auto search = m_arg2patcher[grp_idx].find(key_string);
-      if (search != m_arg2patcher[grp_idx].end()) {
-        search->second.add_patch(pc);
-      }
-      else
-        m_arg2patcher[grp_idx].emplace(std::move(key_string), patcher_config{patch_scheme, {pc}, buf_type});
-    }
-  }
-
 public:
-  elf_aie_gen2(ELFIO::elfio&& elfio, elf::platform platform, std::string path)
-    : elf_impl{std::move(elfio), platform, std::move(path)}
+  explicit
+  elf_aie_gen2(aiebu::elf&& elf, std::string path)
+    : elf_impl{std::move(elf), std::move(path)}
   {
     XRT_TRACE_POINT_SCOPE(xrt_elf_aie_gen2);
-    // Parse ELF sections to populate kernel and section maps
-    parse_sections();
-    // Initialize all section buffer maps
-    initialize_section_buffer_maps();
-    // Initialize argument patchers from relocation sections
-    initialize_arg_patchers();
   }
 
-  // AIE2P: uses group sections if version >= 1.0 (for 1.0 and 2.0 + versions)
   bool
   is_group_elf() const override
   {
-    constexpr uint8_t group_elf_major_version = 1;
     auto [major, minor] = get_abi_version();
-    return major >= group_elf_major_version;
-  }
-
-  ////////////////////////////////////////////////////////////////
-  // Virtual accessor overrides
-  ////////////////////////////////////////////////////////////////
-
-  // Get module configuration for module_run_aie_gen2
-  module_config
-  get_module_config(uint32_t ctrl_code_id) override
-  {
-    // Get instruction buffer (required)
-    auto instr_it = m_instr_buf_map.find(ctrl_code_id);
-    if (instr_it == m_instr_buf_map.end())
-      throw std::runtime_error("Instruction buffer not found for ctrl_code_id: " + std::to_string(ctrl_code_id));
-
-    // Get optional buffers with fallback to empty
-    auto ctrl_pkt_it = m_ctrl_packet_map.find(ctrl_code_id);
-    auto save_it = m_save_buf_map.find(ctrl_code_id);
-    auto restore_it = m_restore_buf_map.find(ctrl_code_id);
-    auto pdi_it = m_ctrl_pdi_map.find(ctrl_code_id);
-
-    static const std::unordered_set<std::string> empty_pdi_set;
-
-    return module_config_aie_gen2{
-      instr_it->second,                                                          // instr_data
-      ctrl_pkt_it != m_ctrl_packet_map.end() ? ctrl_pkt_it->second : buf::get_empty_buf(), // ctrl_packet_data
-      save_it != m_save_buf_map.end() ? save_it->second : buf::get_empty_buf(),  // preempt_save_data
-      restore_it != m_restore_buf_map.end() ? restore_it->second : buf::get_empty_buf(), // preempt_restore_data
-      512_kb,                                                                     // scratch_pad_mem_size  // NOLINT
-      m_ctrl_scratch_pad_mem_size,                                               // ctrl_scratch_pad_mem_size
-      pdi_it != m_ctrl_pdi_map.end() ? pdi_it->second : empty_pdi_set,           // patch_pdi_symbols
-      m_ctrlpkt_pm_dynsyms,                                                      // ctrlpkt_pm_dynsyms
-      m_ctrlpkt_pm_bufs,                                                         // ctrlpkt_pm_bufs
-      m_preemption_exist,                                                        // has_preemption
-      this                                                                       // elf_parent
-    };
-  }
-
-  // PDI buffer accessors (needed for mutable/lazy operations)
-  const buf&
-  get_pdi(const std::string& symbol) const override
-  {
-    auto it = m_pdi_buf_map.find(symbol);
-    if (it == m_pdi_buf_map.end())
-      throw std::runtime_error("PDI buffer not found for symbol: " + symbol);
-    return it->second;
-  }
-
-  uint32_t
-  get_ctrlcode_id(const std::string& name) const override
-  {
-    if (auto pos = name.find(":"); pos != std::string::npos) {
-      // name passed is kernel name + sub kernel name
-      auto key = name.substr(0, pos) + name.substr(pos + 1);
-      auto it = m_kernel_name_to_id_map.find(key);
-      if (it == m_kernel_name_to_id_map.end())
-        throw std::runtime_error(std::string{"Unable to find group idx for given kernel: "} + name);
-
-      auto id = it->second;
-      if ((m_instr_buf_map.find(id) == m_instr_buf_map.end()) &&
-          (m_ctrl_packet_map.find(id) == m_ctrl_packet_map.end()))
-        throw std::runtime_error(std::string{"Unable to find ctrlcode entry for given kernel: "} + name);
-
-      return id;
-    }
-
-    // If user doesn't provide sub kernel we default to first entry
-    // if its the only availble sub kernel of given kernel
-    // otherwise an exception is thrown
-    // check if given kernel is present
-    if (auto entry = m_kernel_to_subkernels_map.find(name); entry != m_kernel_to_subkernels_map.end()) {
-      if (entry->second.size() == 1) {
-        auto key = name + *(entry->second.begin());
-        auto it = m_kernel_name_to_id_map.find(key);
-        if (it == m_kernel_name_to_id_map.end())
-          throw std::runtime_error(std::string{"Unable to find group idx for given kernel: "} + key);
-
-        auto id = it->second;
-        if ((m_instr_buf_map.find(id) == m_instr_buf_map.end()) &&
-            (m_ctrl_packet_map.find(id) == m_ctrl_packet_map.end()))
-          throw std::runtime_error(std::string{"Unable to find ctrlcode entry for given kernel: "} + name);
-
-        return id;
-      }
-      else
-        throw std::runtime_error("Multiple sub kernels present for given kernel, cannot choose sub kernel\n");
-    }
-
-    throw std::runtime_error(std::string{"cannot get ctrlcode id from given kernel name: "} + name);
+    return major >= 1;
   }
 
   ert_cmd_opcode
   get_ert_opcode() const override
   {
-    if (!m_pdi_buf_map.empty())
+    if (m_elf.has_pdi())
       return ERT_START_NPU_PREEMPT_ELF;
 
-    if (m_preemption_exist)
+    if (m_elf.has_preemption())
       return ERT_START_NPU_PREEMPT;
 
     return ERT_START_NPU;
@@ -1045,425 +302,26 @@ public:
 };
 
 ////////////////////////////////////////////////////////////////
-// Derived class for aie2ps, aie4, aie4a, aie4z (gen2 +) platforms
+// elf_aie_gen2_plus — AIE2PS / AIE4 family
+//
+// No buffer maps — all section data lives in aiebu::elf (elf_reader_gen2plus).
+// This class only provides the XRT-specific virtual interface.
 ////////////////////////////////////////////////////////////////
 class elf_aie_gen2_plus : public elf_impl
 {
-  // Control code is padded to page size
-  static constexpr size_t elf_page_size = 8192;  // AIE_COLUMN_PAGE_SIZE
-
-  // map for holding control code data for each sub kernel
-  // key : control code id (grp sec idx), value : vector of column ctrlcodes
-  std::map<uint32_t, std::vector<ctrlcode>> m_ctrlcodes_map;
-
-  // map for holding multiple ctrl pkt sections data for each sub kernel
-  // key : control code id (grp sec idx), value : map of ctrl pkt section name and data
-  std::map<uint32_t, std::map<std::string, buf>> m_ctrlpkt_buf_map;
-
-  // map to hold .dump section of different sub kernels used for debug/trace
-  std::map<uint32_t, buf> m_dump_buf_map;
-
-  ////////////////////////////////////////////////////////////////
-  // Helper functions
-  ////////////////////////////////////////////////////////////////
-
-  // Returns true for merged-format ELFs where all pages per column are packed
-  // into a single .ctrltext.<col> section with no separate .ctrldata sections.
-  // Merged versions: 0x21 (config elf .target).
-  bool
-  is_merged_format() const
-  {
-    auto abi_ver = m_elfio.get_abi_version();
-    return (abi_ver == 0x21); // NOLINT
-  }
-
-  // Extract the column and page information from the section name.
-  // Partial ELF format: .ctrltext.<col>.<page> -> returns {col, page}
-  // Full ELF Per-page format: .ctrltext.<col>.<page>[.<group_id>] -> returns {col, page}
-  // Full ELF Merged format:   .ctrltext.<col>[.<group_id>]        -> returns {col, 0}
-  //
-  static std::pair<uint32_t, uint32_t>
-  get_column_and_page(const std::string& name, bool is_merged)
-  {
-    constexpr size_t col_token_id  = 1;
-    constexpr size_t page_token_id = 2;
-
-    std::vector<std::string> tokens;
-    std::stringstream ss(name);
-    std::string token;
-    while (std::getline(ss, token, '.')) {
-      if (!token.empty())
-        tokens.emplace_back(std::move(token));
-    }
-
-    try {
-      if (tokens.size() <= col_token_id)
-        return {0, 0}; // section has no column token (e.g. ctrlpkt in partial ELF)
-
-      // 2 tokens: .ctrltext.<col> — no page or group_id present
-      if (tokens.size() == (col_token_id + 1))
-        return {std::stoul(tokens[col_token_id]), 0};
-
-      // 3+ tokens: merged treats token[2] as group_id (page always 0);
-      //            per-page treats token[2] as page index.
-      return {std::stoul(tokens[col_token_id]),
-              is_merged ? 0 : std::stoul(tokens[page_token_id])};
-    }
-    catch (const std::exception&) {
-      throw std::runtime_error("Invalid section name passed to parse col or page index\n");
-    }
-  }
-
-  ////////////////////////////////////////////////////////////////
-  // Buffer initialization functions
-  ////////////////////////////////////////////////////////////////
-
-  // Extract control code from ELF sections organized by columns and pages
-  void
-  initialize_column_ctrlcode(std::map<uint32_t, std::vector<size_t>>& pad_offsets)
-  {
-    static constexpr auto ctrltext_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::ctrltext);
-    static constexpr auto ctrldata_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::ctrldata);
-    static constexpr auto pad_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::pad);
-
-    // Elf sections for a single page
-    struct elf_page
-    {
-      ELFIO::section* ctrltext = nullptr;
-      ELFIO::section* ctrldata = nullptr;
-    };
-
-    // Elf ctrl code for a partition spanning multiple uC
-    // ucidx -> [page -> [ctrltext, ctrldata]]
-    using page_index = uint32_t;
-    using uc_index = uint32_t;
-    using uc_sections = std::map<uc_index, std::map<page_index, elf_page>>;
-
-    // Elf can have multiple kernel instances
-    // key - instance id(grp idx) : value - uc sections
-    using ctrlcode_map = std::map<uint32_t, uc_sections>;
-    ctrlcode_map ctrl_map;
-
-    // Iterate sections for each sub kernel
-    // collect ctrltext and ctrldata per column and page
-    for (const auto& [id, sec_ids] : m_group_to_sections_map) {
-      for (auto sec_idx : sec_ids) {
-        const auto& sec = m_elfio.sections[sec_idx];
-        auto name = sec->get_name();
-
-        if (name.find(ctrltext_pattern) != std::string::npos) {
-          auto [col, page] = get_column_and_page(name, is_merged_format());
-          ctrl_map[id][col][page].ctrltext = sec;
-        }
-        else if (name.find(ctrldata_pattern) != std::string::npos) {
-          auto [col, page] = get_column_and_page(name, is_merged_format());
-          ctrl_map[id][col][page].ctrldata = sec;
-        }
-      }
-    }
-
-    // Create uC control code from the collected data
-    bool merged = is_merged_format();
-    for (const auto& [id, uc_sec] : ctrl_map) {
-      auto size = uc_sec.empty() ? 0 : uc_sec.rbegin()->first + 1;
-      m_ctrlcodes_map[id].resize(size);
-      pad_offsets[id].resize(size);
-      for (auto& [ucidx, elf_sects] : uc_sec) {
-        if (merged) {
-          // Merged format: the single .ctrltext.<col> section already contains all
-          // pages laid out at pageNum*PAGE_SIZE offsets with header+text+data+padding
-          // embedded, meaning elf_sects contains only .ctrltext section
-          const auto& page_sec = elf_sects.begin()->second;
-          if (page_sec.ctrltext)
-            m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, m_elfio);
-        }
-        else {
-          // Per-page format: each page has separate ctrltext + ctrldata sections;
-          // pad each page up to page boundary.
-          for (auto& [page, page_sec] : elf_sects) {
-            if (page_sec.ctrltext)
-              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrltext, m_elfio);
-
-            if (page_sec.ctrldata)
-              m_ctrlcodes_map[id][ucidx].append_section_data(page_sec.ctrldata, m_elfio);
-
-            auto current_size = m_ctrlcodes_map[id][ucidx].size();
-            auto target_size = (page + 1) * elf_page_size;
-            if (current_size < target_size)
-              m_ctrlcodes_map[id][ucidx].add_padding_to_size(target_size);
-          }
-        }
-        pad_offsets[id][ucidx] = m_ctrlcodes_map[id][ucidx].size();
-      }
-    }
-
-    // Append pad section to the control code
-    for (const auto& [id, sec_ids] : m_group_to_sections_map) {
-      for (auto sec_idx : sec_ids) {
-        const auto& sec = m_elfio.sections[sec_idx];
-        const auto& name = sec->get_name();
-        if (name.find(pad_pattern) == std::string::npos)
-          continue;
-        auto [col, page] = get_column_and_page(name, is_merged_format());
-        m_ctrlcodes_map[id][col].append_section_data(sec, m_elfio);
-      }
-    }
-  }
-
-  // Parse the ELF and extract all ctrlpkt sections data
-  void
-  initialize_ctrlpkt_bufs()
-  {
-    static constexpr auto ctrlpkt_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::ctrlpkt);
-
-    for (const auto& sec : m_elfio.sections) {
-      auto name = sec->get_name();
-      if (name.find(ctrlpkt_pattern) == std::string::npos)
-        continue;
-
-      buf ctrlpkt_buf;
-      ctrlpkt_buf.append_section_data(sec, m_elfio);
-      auto grp_idx = m_section_to_group_map[sec->get_index()];
-      m_ctrlpkt_buf_map[grp_idx][name] = std::move(ctrlpkt_buf);
-    }
-  }
-
-  // Extract .dump section from ELF sections
-  void
-  initialize_dump_buf()
-  {
-    static constexpr auto dump_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::dump);
-
-    for (const auto& sec : m_elfio.sections) {
-      auto name = sec->get_name();
-      if (name.find(dump_pattern) == std::string::npos)
-        continue;
-
-      auto ctrl_id = m_section_to_group_map[sec->get_index()];
-      m_dump_buf_map[ctrl_id].append_section_data(sec, m_elfio);
-    }
-  }
-
-  // Initialize argument patchers from ELF relocation sections
-  void
-  initialize_arg_patchers(const std::map<uint32_t, std::vector<size_t>>& pad_offsets)
-  {
-    static constexpr auto pad_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::pad);
-    static constexpr auto ctrlpkt_pattern = xrt_core::elf_patcher::get_section_name(patcher_buf_type::ctrlpkt);
-
-    auto dynsym = m_elfio.sections[".dynsym"];
-    auto dynstr = m_elfio.sections[".dynstr"];
-    auto dynsec = m_elfio.sections[".rela.dyn"];
-
-    if (!dynsym || !dynstr || !dynsec)
-      return;
-
-    // Iterate over all relocations and construct a patcher for each
-    auto begin = reinterpret_cast<const ELFIO::Elf32_Rela*>(dynsec->get_data());
-    auto end = begin + dynsec->get_size() / sizeof(const ELFIO::Elf32_Rela);
-
-    for (auto rela = begin; rela != end; ++rela) {
-      auto symidx = ELFIO::get_sym_and_type<ELFIO::Elf32_Rela>::get_r_sym(rela->r_info);
-
-      auto dynsym_offset = symidx * sizeof(ELFIO::Elf32_Sym);
-      if (dynsym_offset >= dynsym->get_size())
-        throw std::runtime_error("Invalid symbol index " + std::to_string(symidx));
-
-      auto sym = reinterpret_cast<const ELFIO::Elf32_Sym*>(dynsym->get_data() + dynsym_offset);
-      auto type = ELFIO::get_sym_and_type<ELFIO::Elf32_Rela>::get_r_type(rela->r_info);
-
-      auto dynstr_offset = sym->st_name;
-      if (dynstr_offset >= dynstr->get_size())
-        throw std::runtime_error("Invalid symbol name offset " + std::to_string(dynstr_offset));
-
-      auto symname = dynstr->get_data() + dynstr_offset;
-      std::string argnm{ symname, symname + std::min(strlen(symname), dynstr->get_size()) };
-
-      // patching can be done to ctrlcode or ctrlpkt section
-      auto patch_sec = m_elfio.sections[sym->st_shndx];
-      if (!patch_sec)
-        throw std::runtime_error("Invalid section index " + std::to_string(sym->st_shndx));
-
-      auto patch_sec_name = patch_sec->get_name();
-      auto [col, page] = get_column_and_page(patch_sec_name, is_merged_format());
-      auto sec_idx = patch_sec->get_index();
-      auto grp_idx = m_section_to_group_map[sec_idx];
-      if (m_ctrlcodes_map.find(grp_idx) == m_ctrlcodes_map.end())
-        throw std::runtime_error(std::string{"Unable to fetch ctrlcode to patch for given symbol: "} + argnm);
-
-      const auto& ctrlcodes = m_ctrlcodes_map[grp_idx];
-      size_t abs_offset = 0;
-      patcher_buf_type buf_type = patcher_buf_type::buf_type_count;
-
-      if (patch_sec_name.find(pad_pattern) != std::string::npos) {
-        const auto& pad_off_vec = pad_offsets.at(grp_idx);
-        for (uint32_t i = 0; i < col; ++i)
-          abs_offset += ctrlcodes[i].size();
-        abs_offset += pad_off_vec[col];
-        abs_offset += rela->r_offset;
-        buf_type = patcher_buf_type::pad;
-      }
-      else if (patch_sec_name.find(ctrlpkt_pattern) != std::string::npos) {
-        // section to patch is ctrlpkt
-        abs_offset += rela->r_offset;
-        buf_type = patcher_buf_type::ctrlpkt;
-        // we have multiple ctrlpkt sections and to uniquely identify symbol
-        // for patching we add ctrlpkt section symbol name to key string
-        auto sym_name =
-            xrt_core::elf_patcher::get_symbol_name_from_section_name(patch_sec_name);
-        argnm += sym_name;
-      }
-      else {
-        // section to patch is ctrlcode
-        auto column_ctrlcode_size = ctrlcodes.at(col).size();
-        // r_offset = T_N + D_bd (T_N excludes the 16B page header).
-        // For merged format, page = 0 (get_column_and_page returns 0 for merged section names)
-        // so page * elf_page_size = 0 and r_offset already encodes the page_base.
-        // Formula works unchanged for both per-page and merged formats.
-        auto sec_offset = page * elf_page_size + rela->r_offset + 16; // NOLINT magic number 16
-        if (sec_offset >= column_ctrlcode_size)
-          throw std::runtime_error("Invalid ctrlcode offset " + std::to_string(sec_offset));
-        // Compute absolute offset across all columns
-        for (uint32_t i = 0; i < col; ++i)
-          abs_offset += ctrlcodes.at(i).size();
-        abs_offset += sec_offset;
-        buf_type = patcher_buf_type::ctrltext;
-      }
-
-      // Construct the patcher config for the argument
-      patcher_symbol_type patch_scheme = patcher_symbol_type::unknown_symbol_kind;
-      uint32_t add_end_addr = 0;
-      auto abi_version = static_cast<uint16_t>(m_elfio.get_abi_version());
-      if (abi_version != 1) {
-        add_end_addr = rela->r_addend;
-        patch_scheme = static_cast<patcher_symbol_type>(type);
-      }
-      else {
-        // rela addend have offset to base_bo_addr info along with schema
-        add_end_addr = (rela->r_addend & addend_mask) >> addend_shift;
-        patch_scheme = static_cast<patcher_symbol_type>(rela->r_addend & schema_mask);
-      }
-
-      auto key_string = xrt_core::elf_patcher::generate_key_string(argnm, buf_type);
-
-      auto search = m_arg2patcher[grp_idx].find(key_string);
-      if (search != m_arg2patcher[grp_idx].end()) {
-        search->second.add_patch(patch_config{abs_offset, add_end_addr, 0});
-      }
-      else
-        m_arg2patcher[grp_idx].emplace(std::move(key_string), patcher_config{patch_scheme, {patch_config{abs_offset, add_end_addr, 0}}, buf_type});
-    }
-  }
-
-  // Initialize all section buffers
-  void
-  initialize_section_buffer_maps()
-  {
-    std::map<uint32_t, std::vector<size_t>> pad_offsets;
-    initialize_column_ctrlcode(pad_offsets);
-    initialize_ctrlpkt_bufs();
-    initialize_dump_buf();
-    initialize_arg_patchers(pad_offsets);
-  }
-
 public:
-  elf_aie_gen2_plus(ELFIO::elfio&& elfio, elf::platform platform, std::string path)
-    : elf_impl{std::move(elfio), platform, std::move(path)}
+  explicit
+  elf_aie_gen2_plus(aiebu::elf&& elf, std::string path)
+    : elf_impl{std::move(elf), std::move(path)}
   {
     XRT_TRACE_POINT_SCOPE(xrt_elf_aie_gen2_plus);
-    // Parse ELF sections to populate kernel and section maps
-    parse_sections();
-    // Initialize all section buffer maps
-    initialize_section_buffer_maps();
   }
 
-  // AIE2PS/AIE4: uses group sections if version >= 0.3 (for 0.3 and 2.0 + versions)
   bool
   is_group_elf() const override
   {
-    constexpr uint8_t group_elf_major_version = 0;
-    constexpr uint8_t group_elf_minor_version = 3;
-
     auto [major, minor] = get_abi_version();
-
-    // Version >= 0.3: major > 0 OR (major == 0 AND minor >= 3)
-    return (major > group_elf_major_version) ||
-           (major == group_elf_major_version && minor >= group_elf_minor_version);
-  }
-
-  ////////////////////////////////////////////////////////////////
-  // Virtual accessor overrides
-  ////////////////////////////////////////////////////////////////
-
-  // Get module configuration for module_run_aie_gen2_plus
-  module_config
-  get_module_config(uint32_t ctrl_code_id) override
-  {
-    // Get control codes (required)
-    auto ctrlcode_it = m_ctrlcodes_map.find(ctrl_code_id);
-    if (ctrlcode_it == m_ctrlcodes_map.end())
-      throw std::runtime_error("Control codes not found for ctrl_code_id: " + std::to_string(ctrl_code_id));
-
-    // Get optional buffers with fallback to empty
-    auto ctrlpkt_it = m_ctrlpkt_buf_map.find(ctrl_code_id);
-    auto dump_it = m_dump_buf_map.find(ctrl_code_id);
-
-    static const std::map<std::string, buf> empty_ctrlpkt_map;
-
-    auto scratch_pad_size = (m_platform == elf::platform::aie4  ||
-                             m_platform == elf::platform::aie4a ||
-                             m_platform == elf::platform::aie4z)
-      ? 3_mb  // NOLINT
-      : 0;
-
-    return module_config_aie_gen2_plus{
-      ctrlcode_it->second,                                                       // ctrlcodes
-      ctrlpkt_it != m_ctrlpkt_buf_map.end() ? ctrlpkt_it->second : empty_ctrlpkt_map, // ctrlpkt_bufs
-      dump_it != m_dump_buf_map.end() ? dump_it->second : buf::get_empty_buf(),  // dump_buf
-      scratch_pad_size,                                                          // scratch_pad_mem_size
-      this                                                                       // elf_parent
-    };
-  }
-
-  uint32_t
-  get_ctrlcode_id(const std::string& name) const override
-  {
-    if (auto pos = name.find(":"); pos != std::string::npos) {
-      // name passed is kernel name + sub kernel name
-      auto key = name.substr(0, pos) + name.substr(pos + 1);
-      auto it = m_kernel_name_to_id_map.find(key);
-      if (it == m_kernel_name_to_id_map.end())
-        throw std::runtime_error(std::string{"Unable to find group idx for given kernel: "} + name);
-
-      auto id = it->second;
-      if (m_ctrlcodes_map.find(id) == m_ctrlcodes_map.end())
-        throw std::runtime_error(std::string{"Unable to find ctrlcode entry for given kernel: "} + name);
-
-      return id;
-    }
-
-    // If user doesn't provide sub kernel we default to first entry
-    // if its the only availble sub kernel of given kernel
-    // otherwise an exception is thrown
-    // check if given kernel is present
-    if (auto entry = m_kernel_to_subkernels_map.find(name); entry != m_kernel_to_subkernels_map.end()) {
-      if (entry->second.size() == 1) {
-        auto key = name + *(entry->second.begin());
-        auto it = m_kernel_name_to_id_map.find(key);
-        if (it == m_kernel_name_to_id_map.end())
-          throw std::runtime_error(std::string{"Unable to find group idx for given kernel: "} + key);
-
-        auto id = it->second;
-        if (m_ctrlcodes_map.find(id) == m_ctrlcodes_map.end())
-          throw std::runtime_error(std::string{"Unable to find ctrlcode entry for given kernel: "} + name);
-
-        return id;
-      }
-      else
-        throw std::runtime_error("Multiple sub kernels present for given kernel, cannot choose sub kernel\n");
-    }
-
-    throw std::runtime_error(std::string{"cannot get ctrlcode id from given kernel name: "} + name);
+    return (major > 0) || (major == 0 && minor >= 3);
   }
 
   ert_cmd_opcode
@@ -1477,25 +335,22 @@ public:
 
 namespace {
 
-// Factory function - creates correct derived type based on platform
+// Factory — dispatch on platform detected by aiebu::elf
 static std::shared_ptr<xrt::elf_impl>
-create_elf_impl(ELFIO::elfio&& elfio, const std::string& path = {})
+create_elf_impl(aiebu::elf&& elf, std::string path = {})
 {
-  auto platform = static_cast<xrt::elf::platform>(elfio.get_os_abi());
-
-  switch (platform) {
-  case xrt::elf::platform::aie2p:
-    return std::make_shared<xrt::elf_aie_gen2>(std::move(elfio), platform, path);
-  case xrt::elf::platform::aie2ps:
-  case xrt::elf::platform::aie2ps_legacy:
-  case xrt::elf::platform::aie4:
-  case xrt::elf::platform::aie4a:
-  case xrt::elf::platform::aie4z:
-    return std::make_shared<xrt::elf_aie_gen2_plus>(std::move(elfio), platform, path);
-  default:
-    throw std::runtime_error("ELF contains unsupported platform OS/ABI: " +
-                             std::to_string(static_cast<int>(platform)));
+  switch (elf.get_platform()) {
+  case aiebu::elf::platform::aie2p:
+    return std::make_shared<xrt::elf_aie_gen2>(std::move(elf), std::move(path));
+  case aiebu::elf::platform::aie2ps:
+  case aiebu::elf::platform::aie2ps_legacy:
+  case aiebu::elf::platform::aie4:
+  case aiebu::elf::platform::aie4a:
+  case aiebu::elf::platform::aie4z:
+    return std::make_shared<xrt::elf_aie_gen2_plus>(std::move(elf), std::move(path));
   }
+  // aiebu::elf::elf() already throws on unknown OS/ABI — unreachable
+  throw std::runtime_error("Unsupported ELF platform");
 }
 
 } // namespace
@@ -1505,9 +360,6 @@ create_elf_impl(ELFIO::elfio&& elfio, const std::string& path = {})
 ////////////////////////////////////////////////////////////////
 namespace xrt {
 
-// Helper to validate elf object is properly initialized.
-// Default constructed elf objects have null handle.
-// Throws if handle is null.
 static void
 valid_or_error(const std::shared_ptr<elf_impl>& handle)
 {
@@ -1517,33 +369,29 @@ valid_or_error(const std::shared_ptr<elf_impl>& handle)
 
 elf::
 elf(const std::string& fnm)
-  : detail::pimpl<elf_impl>{create_elf_impl(load_elfio(fnm), fnm)}
+  : detail::pimpl<elf_impl>{create_elf_impl(aiebu::elf{fnm}, fnm)}
 {
-  // ELFIO cannot be post dumped. Track elf_impl to elf data
   XRT_REPLAY_CAPTURE(elf_ctor, handle.get(), fnm);
 }
 
 elf::
 elf(std::istream& stream)
-  : detail::pimpl<elf_impl>{create_elf_impl(load_elfio(stream))}
+  : detail::pimpl<elf_impl>{create_elf_impl(aiebu::elf{stream})}
 {
-  // ELFIO cannot be post dumped. Track elf_impl to elf data
   XRT_REPLAY_CAPTURE(elf_ctor, handle.get(), stream);
 }
 
 elf::
 elf(const void* data, size_t size)
-  : detail::pimpl<elf_impl>{create_elf_impl(load_elfio(data, size))}
+  : detail::pimpl<elf_impl>{create_elf_impl(aiebu::elf{data, size})}
 {
-  // ELFIO cannot be post dumped. Track elf_impl to elf data
   XRT_REPLAY_CAPTURE(elf_ctor, handle.get(), data, size);
 }
 
 elf::
 elf(const std::string_view& sv)
-  : detail::pimpl<elf_impl>{create_elf_impl(load_elfio(sv.data(), sv.size()))}
+  : detail::pimpl<elf_impl>{create_elf_impl(aiebu::elf{sv.data(), sv.size()})}
 {
-  // ELFIO cannot be post dumped. Track elf_impl to elf data
   XRT_REPLAY_CAPTURE(elf_ctor, handle.get(), sv.data(), sv.size());
 }
 
@@ -1592,7 +440,12 @@ elf::
 get_custom_section(const std::string& section_name) const
 {
   valid_or_error(handle);
-  return handle->get_custom_section(section_name);
+  auto sp = handle->get_aiebu_elf().get_section(section_name);
+  if (sp.empty())
+    throw std::runtime_error("Cannot get custom section " + section_name +
+                             " data, section not found in ELF");
+
+  return detail::span<const char>(reinterpret_cast<const char*>(sp.data()), sp.size());
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_elf.cpp
+++ b/src/runtime_src/core/common/api/xrt_elf.cpp
@@ -251,7 +251,7 @@ get_cfg_uuid() const
     auto data = m_elf.get_cfg_uuid();
     xuid_t uuid_data;
     std::memcpy(uuid_data, data.data(), uuid_size);
-    return xrt::uuid(uuid_data);
+    return {uuid_data};
   }
   catch (const std::exception&) {
     return {};
@@ -446,7 +446,7 @@ get_custom_section(const std::string& section_name) const
     throw std::runtime_error("Cannot get custom section " + section_name +
                              " data, section not found in ELF");
 
-  return detail::span<const char>(reinterpret_cast<const char*>(sp.data()), sp.size());
+  return {reinterpret_cast<const char*>(sp.data()), sp.size()};
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -64,6 +64,7 @@
 #include <condition_variable>
 #include <chrono>
 #include <cstdarg>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -1821,25 +1822,18 @@ private:
     if (!module)
       return nullptr; // applicable only for ELF flows
 
-    // Get control packet data from ELF module configuration
-    // Control packet cache is only applicable for aie2p platform
+    // Get control packet data from ELF — only applicable for aie2p platform
     auto elf_handle = xrt_core::module_int::get_elf_handle(module);
-    auto module_config = elf_handle->get_module_config(id);
-    const auto config = std::get_if<xrt::module_config_aie_gen2>(&module_config);
-    if (!config)
-      return nullptr; // not aie2p platform, no ctrlpkt cache needed
-
-    const auto& ctrl_packet = config->ctrl_packet_data;
-
-    if (ctrl_packet.size() == 0)
+    if (elf_handle->get_platform() != xrt::elf::platform::aie2p)
       return nullptr;
 
-    // Create mutable copy for buffer cache.
-    // copy_to() handles compressed sections transparently; for uncompressed
-    // ELFs this is a plain memcpy.
-    std::vector<uint8_t> ctrlpkt_data(ctrl_packet.size());
-    ctrl_packet.copy_to({ctrlpkt_data.data(), ctrlpkt_data.size()});
-    auto ctrlpkt_buf_size = ctrlpkt_data.size();
+    auto ctrlpkt_buf_size = elf_handle->get_ctrl_packet_size(id);
+    if (ctrlpkt_buf_size == 0)
+      return nullptr;
+
+    // Create mutable copy for buffer cache
+    std::vector<uint8_t> ctrlpkt_data(ctrlpkt_buf_size);
+    elf_handle->copy_ctrl_packet(id, {reinterpret_cast<std::byte*>(ctrlpkt_data.data()), ctrlpkt_buf_size});
 
     constexpr size_t bytes_per_mb = 1024ULL * 1024ULL;
     static auto pool_memory_size = xrt_core::config::get_run_buffer_pool_memory_mb() * bytes_per_mb;
@@ -5229,9 +5223,7 @@ aie_error_message_v1(const ert_packet* epkt, const std::string& msg,
           << ctx_health->aie4.uc_info[i].uc_esr
           << "\n";
 
-      // Decode the opcode at (uc_idx, page_idx, offset) directly from the ELF binary.
-      // AIEDebug handles SHF_COMPRESSED sections internally — only the specific
-      // .ctrltext section is decompressed on demand, not the entire ELF.
+      // Decode the opcode at (uc_idx, page_idx, offset) directly from the ELF binary
       if (elf_impl_ptr) {
         aiebu::AIEDebug dbg(elf_impl_ptr->get_elfio());
         auto info = dbg.get_opcode_information(

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -879,18 +879,19 @@ class module_run_aie_gen2_plus : public module_run
 
   // Allocate and fill one BO per .ctrlpkt section.  The addresses of these
   // BOs are later patched into the instruction buffer by fill_instruction_buffer().
+  // for_each_ctrlpkt() performs a single outer map lookup and iterates the inner
+  // map directly — no intermediate vector<string> is allocated.
   void
   create_ctrlpkt_bufs()
   {
-    for (const auto& name : m_elf_impl->get_ctrlpkt_section_names(m_ctrl_code_id)) {
-      auto sz = m_elf_impl->get_ctrlpkt_size(m_ctrl_code_id, name);
+    m_elf_impl->for_each_ctrlpkt(m_ctrl_code_id, [&](const std::string& name, size_t sz) {
       if (sz == 0)
-        continue;
+        return;
 
       auto& bo = m_ctrlpkt_bos[name] = xbi::create_bo(m_hwctx, sz, xbi::use_type::ctrlpkt);
       m_elf_impl->copy_ctrlpkt(m_ctrl_code_id, name, {bo.map<std::byte*>(), sz});
       bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-    }
+    });
 
     if (is_dump_control_packet()) {
       for (auto& [name, bo] : m_ctrlpkt_bos) {

--- a/src/runtime_src/core/common/api/xrt_module.cpp
+++ b/src/runtime_src/core/common/api/xrt_module.cpp
@@ -27,9 +27,9 @@
 #include "core/common/aiebu/src/cpp/dtrace/dtrace.h"
 
 #include <boost/format.hpp>
-#include <elfio/elfio.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <array>
 #include <atomic>
 #include <cstdint>
@@ -255,16 +255,6 @@ protected:
     return m_id;
   }
 
-  // Fill buffer object with data from buf structure
-  static void
-  fill_bo_with_data(xrt::bo& bo, const xrt::buf& buf, bool sync = true)
-  {
-    auto ptr = bo.map<uint8_t*>();
-    buf.copy_to({ptr, bo.size()});
-    if (sync)
-      bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  }
-
   // Helper function for patching buffer with argument name or index
   bool
   patch_helper(xrt::bo& bo, uint64_t patch, xrt_core::elf_patcher::buf_type type,
@@ -346,35 +336,41 @@ public:
 
 class module_run_aie_gen2 : public module_run
 {
-  // Platform-specific configuration from ELF
-  xrt::module_config_aie_gen2 m_config;
-
-  // Instruction and control packet buffers
+  // Instruction buffer — holds .ctrltext section data; patched in place
+  // before each run and synced to device.
   xrt::bo m_instr_bo;
+
+  // Optional control-packet buffer provided by the caller at construction.
+  // Patched with its device address into the instruction buffer.
   xrt::bo m_ctrlpkt_bo;
 
-  // Preemption buffers
+  // Preemption save / restore buffers — present only when the ELF has
+  // paired .preempt_save / .preempt_restore sections.
   xrt::bo m_preempt_save_bo;
   xrt::bo m_preempt_restore_bo;
 
-  // Control scratch pad memory buffer
+  // Control scratch-pad memory — sized from the "scratch-pad-ctrl" dynsym;
+  // its device address is patched into the instruction buffer.
   xrt::bo m_ctrl_scratch_pad_mem;
 
-  // Map of ctrlpkt preemption buffers
-  // key : section name (.ctrlpkt.pm.*)
-  // value : xrt::bo filled with corresponding section data
+  // Preemption control-packet buffers, keyed by section name (.ctrlpkt.pm.*).
+  // Each gets its own BO; addresses are patched into the instruction buffer.
   std::map<std::string, xrt::bo> m_ctrlpkt_pm_bos;
 
-  // map storing xrt::bo that stores pdi data corresponding to each pdi symbol
+  // PDI image buffers, keyed by PDI symbol name.
+  // Each PDI gets its own BO; addresses are patched into the instruction buffer.
   std::map<std::string, xrt::bo> m_pdi_bo_map;
 
-  // Symbol names for patching specific to aie_gen2 platform
-  static constexpr const char* Control_Packet_Symbol = "control-packet";
+  // ELF dynamic symbol names used to identify special patch targets
+  static constexpr const char* Control_Packet_Symbol    = "control-packet";
   static constexpr const char* Control_ScratchPad_Symbol = "scratch-pad-ctrl";
 
-  ////////////////////////////////////////////////////////////////
-  // Functions that create and fill different buffers
-  ////////////////////////////////////////////////////////////////
+  // Fixed preemption scratch-pad size for AIE2P — passed to
+  // get_scratchpad_mem_buf() so the hw_context allocates enough space
+  // for save/restore context.  Hard-coded for this platform; AIE2PS/AIE4
+  // use a different (larger) value in module_run_aie_gen2_plus.
+  static constexpr size_t scratch_pad_mem_size = 512 * 1024; // 512 KB // NOLINT
+
   void
   create_ctrlpkt_buf(const xrt::bo& ctrlpkt_bo)
   {
@@ -382,25 +378,40 @@ class module_run_aie_gen2 : public module_run
       XRT_DEBUGF("ctrpkt buf is empty\n");
       return;
     }
-
-    m_ctrlpkt_bo = ctrlpkt_bo; // assign pre created buffer
-
+    m_ctrlpkt_bo = ctrlpkt_bo;
     if (is_dump_control_packet()) {
       std::string dump_file_name = "ctr_packet_pre_patch" + std::to_string(get_id()) + ".bin";
       dump_bo(m_ctrlpkt_bo, dump_file_name);
-
       std::stringstream ss;
       ss << "dumped file " << dump_file_name;
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module", ss.str());
     }
   }
 
+  // dynsym names use hyphens (e.g. "ctrlpkt-pm-0") while the corresponding
+  // ELF section names use dots (e.g. ".ctrlpkt.pm.0").
+  static std::string
+  ctrlpkt_pm_dynsym_to_section(const std::string& dynsym)
+  {
+    std::string sec = "." + dynsym;
+    std::replace(sec.begin(), sec.end(), '-', '.');
+    return sec;
+  }
+
   void
   create_ctrlpkt_pm_bufs()
   {
-    for (const auto& [key, buf] : m_config.ctrlpkt_pm_bufs) {
-      m_ctrlpkt_pm_bos[key] = xbi::create_bo(m_hwctx, buf.size(), xbi::use_type::ctrlpkt);
-      fill_bo_with_data(m_ctrlpkt_pm_bos.at(key), buf);
+    for (const auto& dynsym : m_elf_impl->get_ctrlpkt_pm_dynsyms()) {
+      std::string sec_name = ctrlpkt_pm_dynsym_to_section(dynsym);
+
+      auto sz = m_elf_impl->get_ctrlpkt_pm_buf_size(sec_name);
+      if (sz == 0)
+        continue;
+
+      auto& bo = m_ctrlpkt_pm_bos[sec_name] =
+        xbi::create_bo(m_hwctx, sz, xbi::use_type::ctrlpkt);
+      m_elf_impl->copy_ctrlpkt_pm_buf(sec_name, {bo.map<std::byte*>(), sz});
+      bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
     }
   }
 
@@ -409,55 +420,54 @@ class module_run_aie_gen2 : public module_run
   {
     XRT_DEBUGF("-> module_run_aie_gen2::create_instruction_buf()\n");
 
-    // Get instruction buffer from config
-    size_t sz = m_config.instr_data.size();
+    // Step 1: allocate instruction BO and fill it with .ctrltext section data.
+    // All subsequent steps patch addresses into this buffer before it is synced.
+    auto sz = m_elf_impl->get_instr_buf_size(m_ctrl_code_id);
     if (sz == 0)
       throw std::runtime_error("Invalid instruction buffer size");
 
-    // Create and fill instruction buffer object
     m_instr_bo = xbi::create_bo(m_hwctx, sz, xbi::use_type::instruction);
-    fill_bo_with_data(m_instr_bo, m_config.instr_data, false /*don't sync*/);
+    m_elf_impl->copy_instr_buf(m_ctrl_code_id, {m_instr_bo.map<std::byte*>(), sz});
 
     if (is_dump_control_codes()) {
       std::string dump_file_name = "ctr_codes_pre_patch" + std::to_string(get_id()) + ".bin";
       dump_bo(m_instr_bo, dump_file_name);
-
       std::stringstream ss;
-      ss << "dumped file " << dump_file_name << " ctr_codes size: " << std::to_string(sz);
+      ss << "dumped file " << dump_file_name << " ctr_codes size: " << sz;
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module", ss.str());
     }
 
-    // Handle preemption save/restore buffers from config
-    auto preempt_save_size = m_config.preempt_save_data.size();
-    auto preempt_restore_size = m_config.preempt_restore_data.size();
+    // Step 2: if the ELF has preemption sections, create save/restore BOs
+    // and patch the shared scratchpad memory address into both of them.
+    // The scratchpad is a hw_context-owned buffer used to spill AIE state.
+    auto preempt_save_sz    = m_elf_impl->get_preempt_save_size(m_ctrl_code_id);
+    auto preempt_restore_sz = m_elf_impl->get_preempt_restore_size(m_ctrl_code_id);
 
-    if ((preempt_save_size > 0) && (preempt_restore_size > 0)) {
-      m_preempt_save_bo = xbi::create_bo(m_hwctx, preempt_save_size, xbi::use_type::preemption);
-      fill_bo_with_data(m_preempt_save_bo, m_config.preempt_save_data, false);
+    if (preempt_save_sz > 0 && preempt_restore_sz > 0) {
+      m_preempt_save_bo = xbi::create_bo(m_hwctx, preempt_save_sz, xbi::use_type::preemption);
+      m_elf_impl->copy_preempt_save(m_ctrl_code_id, {m_preempt_save_bo.map<std::byte*>(), preempt_save_sz});
 
-      m_preempt_restore_bo = xbi::create_bo(m_hwctx, preempt_restore_size, xbi::use_type::preemption);
-      fill_bo_with_data(m_preempt_restore_bo, m_config.preempt_restore_data, false);
+      m_preempt_restore_bo = xbi::create_bo(m_hwctx, preempt_restore_sz, xbi::use_type::preemption);
+      m_elf_impl->copy_preempt_restore(m_ctrl_code_id, {m_preempt_restore_bo.map<std::byte*>(), preempt_restore_sz});
 
       if (is_dump_preemption_codes()) {
         std::string dump_file_name = "preemption_save_pre_patch" + std::to_string(get_id()) + ".bin";
         dump_bo(m_preempt_save_bo, dump_file_name);
-
         std::stringstream ss;
         ss << "dumped file " << dump_file_name;
         xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module", ss.str());
 
         dump_file_name = "preemption_restore_pre_patch" + std::to_string(get_id()) + ".bin";
         dump_bo(m_preempt_restore_bo, dump_file_name);
-
         ss.str("");
         ss << "dumped file " << dump_file_name;
         xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module", ss.str());
       }
 
-      // Get scratchpad memory and patch preemption buffers
+      // Patch scratchpad address into both preemption buffers so the firmware
+      // knows where to save/restore AIE register state during preemption.
       const auto& scratchpad_mem =
-          xrt_core::hw_context_int::get_scratchpad_mem_buf(m_hwctx, m_config.scratch_pad_mem_size);
-
+        xrt_core::hw_context_int::get_scratchpad_mem_buf(m_hwctx, scratch_pad_mem_size);
       if (!scratchpad_mem)
         throw std::runtime_error("Failed to get scratchpad buffer from context\n");
 
@@ -470,43 +480,51 @@ class module_run_aie_gen2 : public module_run
         std::stringstream ss;
         ss << "patched preemption-codes using scratch_pad_mem at address "
            << std::hex << scratchpad_mem.address()
-           << " size "
-           << std::hex << scratchpad_mem.size();
+           << " size " << std::hex << scratchpad_mem.size();
         xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module", ss.str());
       }
     }
 
-    // Create control scratchpad buffer and patch if symbol is present
-    if (m_config.ctrl_scratch_pad_mem_size > 0) {
-      m_ctrl_scratch_pad_mem = xbi::create_bo(m_hwctx, m_config.ctrl_scratch_pad_mem_size, xbi::use_type::ctrl_scratch_pad);
+    // Step 3: if the ELF references a control scratch-pad symbol, allocate a
+    // dedicated BO for it and patch its address into the instruction buffer.
+    // This is distinct from the preemption scratchpad — it is used by the
+    // firmware for internal control-code bookkeeping, not AIE register spill.
+    auto ctrl_scratch_sz = m_elf_impl->get_ctrl_scratch_pad_mem_size();
+    if (ctrl_scratch_sz > 0) {
+      m_ctrl_scratch_pad_mem = xbi::create_bo(m_hwctx, ctrl_scratch_sz, xbi::use_type::ctrl_scratch_pad);
       patch_helper(m_instr_bo, m_ctrl_scratch_pad_mem.address(),
                    xrt_core::elf_patcher::buf_type::ctrltext, Control_ScratchPad_Symbol, {}, false);
     }
 
-    // Patch all PDI addresses using config's pdi symbols
-    for (const auto& symbol : m_config.patch_pdi_symbols) {
-      const auto& pdi_data = m_config.elf_parent->get_pdi(symbol);
-      auto pdi_bo = xbi::create_bo(m_hwctx, pdi_data.size(), xbi::use_type::pdi);
-      fill_bo_with_data(pdi_bo, pdi_data);
-      // Move bo into map and get reference for patching
-      auto [it, inserted] = m_pdi_bo_map.emplace(symbol, std::move(pdi_bo));
+    // Step 4: allocate a PDI BO for each PDI symbol referenced by this
+    // ctrl-code and patch its device address into the instruction buffer.
+    // get_pdi_symbols() is an O(1) lookup into the pre-computed
+    // m_ctrl_pdi_map — no iteration over all groups or all patch points.
+    for (const auto& symbol : m_elf_impl->get_pdi_symbols(m_ctrl_code_id)) {
+      // Multiple relocations can reference the same PDI symbol; only
+      // create the BO once — patch_helper handles all patch sites.
+      if (m_pdi_bo_map.count(symbol))
+        continue;
 
-      // Patch instr buffer with PDI address
-      patch_helper(m_instr_bo, it->second.address(), xrt_core::elf_patcher::buf_type::ctrltext, symbol, {}, false);
+      auto pdi_sz = m_elf_impl->get_pdi_size(symbol);
+      auto pdi_bo = xbi::create_bo(m_hwctx, pdi_sz, xbi::use_type::pdi);
+      m_elf_impl->copy_pdi(symbol, {pdi_bo.map<std::byte*>(), pdi_sz});
+      pdi_bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+      auto [it, inserted] = m_pdi_bo_map.emplace(symbol, std::move(pdi_bo));
+      patch_helper(m_instr_bo, it->second.address(),
+                   xrt_core::elf_patcher::buf_type::ctrltext, symbol, {}, false);
     }
 
-    // Patch control packet address if present
-    if (m_ctrlpkt_bo) {
+    // Step 5: if a control-packet BO was provided by the caller, patch its
+    // device address into the instruction buffer so the firmware can locate it.
+    if (m_ctrlpkt_bo)
       patch_helper(m_instr_bo, m_ctrlpkt_bo.address(),
                    xrt_core::elf_patcher::buf_type::ctrltext, Control_Packet_Symbol, {}, false);
-    }
 
-    // Patch ctrlpkt preemption buffers using config's dynsyms
-    for (const auto& dynsym : m_config.ctrlpkt_pm_dynsyms) {
-      // Convert symbol name to section name: ctrlpkt-pm-0 -> .ctrlpkt.pm.0
-      std::string sec_name = "." + dynsym;
-      std::replace(sec_name.begin(), sec_name.end(), '-', '.');
-
+    // Step 6: patch the address of each preemption ctrl-pkt BO into the
+    // instruction buffer.  These BOs were created in create_ctrlpkt_pm_bufs().
+    for (const auto& dynsym : m_elf_impl->get_ctrlpkt_pm_dynsyms()) {
+      std::string sec_name = ctrlpkt_pm_dynsym_to_section(dynsym);
       auto bo_itr = m_ctrlpkt_pm_bos.find(sec_name);
       if (bo_itr == m_ctrlpkt_pm_bos.end())
         throw std::runtime_error("Unable to find ctrlpkt pm buffer for symbol " + dynsym);
@@ -555,7 +573,6 @@ public:
   module_run_aie_gen2(const xrt::elf& elf, const xrt::hw_context& hw_context,
                       uint32_t id, const xrt::bo& ctrlpkt_bo)
     : module_run(elf, hw_context, id)
-    , m_config(std::get<xrt::module_config_aie_gen2>(m_elf_impl->get_module_config(id)))
   {
     XRT_TRACE_POINT_SCOPE(xrt_module_run_aie_gen2);
     create_ctrlpkt_buf(ctrlpkt_bo);
@@ -687,22 +704,22 @@ public:
 
 class module_run_aie_gen2_plus : public module_run
 {
-  // Platform-specific configuration from ELF
-  xrt::module_config_aie_gen2_plus m_config;
-
-  // Instruction buffer (combined ctrlcode for all columns)
+  // Combined instruction buffer — all column ctrlcode buffers concatenated
+  // in column order, with page-aligned padding between them.  Patched in
+  // place and synced to device before each run.
   xrt::bo m_buffer;
 
-  // Map of control packet buffers
-  // key: section name (.ctrlpkt.*), value: xrt::bo
+  // Control-packet buffers, keyed by section name (.ctrlpkt.*).
+  // Each section gets its own BO; addresses are patched into m_buffer.
   std::map<std::string, xrt::bo> m_ctrlpkt_bos;
 
-  // Tuple of uC index, address, size, dtrace_addr for each column
-  // Used in ert_dpu_data payload to identify ctrlcode and dtrace buffer per column
+  // Per-column submission metadata packed into the ERT DPU payload.
+  // Each entry holds: uC index, base address in m_buffer, size, dtrace address.
   enum column_bo_index : size_t { col_ucidx = 0, col_base_addr, col_size, col_dtrace_addr };
   std::vector<std::tuple<uint16_t, uint64_t, uint64_t, uint64_t>> m_column_bo_address;
 
-  // Symbol name for control code patching
+  // Dynamic symbol name prefix used to patch per-column ctrlcode addresses
+  // into the instruction buffer.
   static constexpr const char* Control_Code_Symbol = "control-code";
 
   ////////////////////////////////////////////////////////////////
@@ -754,11 +771,15 @@ class module_run_aie_gen2_plus : public module_run
       return false;
     }
 
-    // Get dump buffer data from config
+    // Get dump buffer data from aiebu::elf.
     // Dump map is required only for jprobe; pass empty string when ELF has no .dump section.
-    const std::string map_data = (m_config.dump_buf.size() == 0)
-      ? std::string{}
-      : m_config.dump_buf.to_string();
+    auto dump_sz = m_elf_impl->get_dump_buf_size(m_ctrl_code_id);
+    std::string map_data;
+    if (dump_sz > 0) {
+      map_data.resize(dump_sz);
+      m_elf_impl->copy_dump_buf(m_ctrl_code_id,
+        {reinterpret_cast<std::byte*>(map_data.data()), dump_sz});
+    }
 
     // log level 0: error, 1: warning, 2: info
     auto log_level = static_cast<uint32_t>(xrt_core::config::get_dtrace_log_level());
@@ -844,24 +865,37 @@ class module_run_aie_gen2_plus : public module_run
   // Buffer creation and initialization functions
   ////////////////////////////////////////////////////////////////
 
-  // Create control packet buffers for all ctrlpkt sections
+  // Scratch pad size for gen2plus: 3MB for aie4 family, 0 otherwise
+  size_t
+  scratch_pad_mem_size() const
+  {
+    auto p = m_elf_impl->get_platform();
+    return (p == xrt::elf::platform::aie4  ||
+            p == xrt::elf::platform::aie4a ||
+            p == xrt::elf::platform::aie4z)
+      ? 3UL * 1024 * 1024  // NOLINT
+      : 0;
+  }
+
+  // Allocate and fill one BO per .ctrlpkt section.  The addresses of these
+  // BOs are later patched into the instruction buffer by fill_instruction_buffer().
   void
   create_ctrlpkt_bufs()
   {
-    if (m_config.ctrlpkt_bufs.empty())
-      return; // older ELFs have ctrlpkt in pad section
+    for (const auto& name : m_elf_impl->get_ctrlpkt_section_names(m_ctrl_code_id)) {
+      auto sz = m_elf_impl->get_ctrlpkt_size(m_ctrl_code_id, name);
+      if (sz == 0)
+        continue;
 
-    // Create ctrlpkt bo's for all ctrlpkt sections
-    for (const auto& [name, buf] : m_config.ctrlpkt_bufs) {
-      m_ctrlpkt_bos[name] = xbi::create_bo(m_hwctx, buf.size(), xbi::use_type::ctrlpkt);
-      fill_bo_with_data(m_ctrlpkt_bos[name], buf);
+      auto& bo = m_ctrlpkt_bos[name] = xbi::create_bo(m_hwctx, sz, xbi::use_type::ctrlpkt);
+      m_elf_impl->copy_ctrlpkt(m_ctrl_code_id, name, {bo.map<std::byte*>(), sz});
+      bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
     }
 
     if (is_dump_control_packet()) {
       for (auto& [name, bo] : m_ctrlpkt_bos) {
         std::string dump_file_name = name + "_pre_patch" + std::to_string(get_id()) + ".bin";
         dump_bo(bo, dump_file_name);
-
         std::stringstream ss;
         ss << "dumped file " << dump_file_name;
         xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module", ss.str());
@@ -869,93 +903,89 @@ class module_run_aie_gen2_plus : public module_run
     }
   }
 
-  // Fill instruction buffer with column data, dump pre-patch, then patch
+  // Fill m_buffer with column ctrl-code data and apply all static patches:
+  //  1. Copy column ctrl-codes into m_buffer.
+  //  2. Patch per-column device addresses ("control-code-<n>") into m_buffer.
+  //  3. Obtain the shared scratchpad BO (aie4 family only).
+  //  4. Patch scratchpad and ctrlpkt BO addresses into m_buffer and ctrlpkt BOs.
   void
   fill_instruction_buffer()
   {
-    const auto& col_data = m_config.ctrlcodes;
-
-    // Copy all column control codes to instruction buffer
-    auto ptr = m_buffer.map<uint8_t*>();
-    auto remaining = m_buffer.size();
-    for (const auto& ctrlcode : col_data) {
-      ctrlcode.copy_to({ptr, remaining});
-      ptr += ctrlcode.size();
-      remaining -= ctrlcode.size();
+    // Step 1: copy column ctrl-codes into m_buffer consecutively.
+    auto ncols = m_elf_impl->get_column_count(m_ctrl_code_id);
+    auto ptr   = m_buffer.map<std::byte*>();
+    for (uint32_t col = 0; col < ncols; ++col) {
+      auto sz = m_elf_impl->get_ctrlcode_col_size(m_ctrl_code_id, col);
+      m_elf_impl->copy_ctrlcode_col(m_ctrl_code_id, col, {ptr, sz});
+      ptr += sz;
     }
 
-    // Dump pre-patched instruction buffer
     if (is_dump_control_codes()) {
       std::string dump_file_name = "ctr_codes_pre_patch" + std::to_string(get_id()) + ".bin";
       dump_bo(m_buffer, dump_file_name);
-
       std::stringstream ss;
-      ss << "dumped file " << dump_file_name << " ctr_codes size: " << std::to_string(m_buffer.size());
+      ss << "dumped file " << dump_file_name << " ctr_codes size: " << m_buffer.size();
       xrt_core::message::send(xrt_core::message::severity_level::debug, "xrt_module", ss.str());
     }
 
-    // Patch control-code addresses in instruction buffer
+    // Step 2: patch per-column device addresses ("control-code-0", "control-code-1", ...)
+    // into m_buffer so the firmware can locate each column's instruction stream.
     size_t offset = 0;
-    for (size_t i = 0; i < col_data.size(); ++i) {
-      // Find the control-code-* sym-name and patch it in instruction buffer
+    for (uint32_t i = 0; i < ncols; ++i) {
       auto sym_name = std::string(Control_Code_Symbol) + "-" + std::to_string(i);
       auto type = xrt_core::elf_patcher::buf_type::ctrltext;
       if (patch_helper(m_buffer, m_buffer.address() + offset, type, sym_name, {}, false))
-        m_patched_args.insert(
-            xrt_core::elf_patcher::generate_key_string(sym_name, type));
-      offset += col_data[i].size();
+        m_patched_args.insert(xrt_core::elf_patcher::generate_key_string(sym_name, type));
+
+      offset += m_elf_impl->get_ctrlcode_col_size(m_ctrl_code_id, i);
     }
 
-    // create scratchpad memory buffer and patch it in ctrlpkt buffers and
-    // instruction buffer if symbol is present in ELF
+    // Step 3: obtain the shared scratchpad BO (aie4 family only; null otherwise).
     xrt::bo scratchpad_mem;
-    if (m_config.scratch_pad_mem_size > 0) {
-      scratchpad_mem = xrt_core::hw_context_int::get_scratchpad_mem_buf(m_hwctx, m_config.scratch_pad_mem_size);
+    auto sp_sz = scratch_pad_mem_size();
+    if (sp_sz > 0) {
+      scratchpad_mem = xrt_core::hw_context_int::get_scratchpad_mem_buf(m_hwctx, sp_sz);
       if (!scratchpad_mem)
         throw std::runtime_error("Failed to get scratchpad buffer from context\n");
     }
 
-    // Patch control packet addresses in instruction buffer
+    // Step 4: for each ctrlpkt BO, patch the scratchpad address into the
+    // ctrlpkt buffer (if present), then patch the ctrlpkt BO's own device
+    // address into m_buffer so the firmware can find the control packets.
     auto type = xrt_core::elf_patcher::buf_type::buf_type_count;
     for (auto& [name, ctrlpktbo] : m_ctrlpkt_bos) {
-      auto sym_name =
-          xrt_core::elf_patcher::get_symbol_name_from_section_name(name);
+      auto sym_name = xrt_core::elf_patcher::get_symbol_name_from_section_name(name);
 
-      // Patch scratchpad memory address in ctrlpkt buffer if present
       if (scratchpad_mem) {
         type = xrt_core::elf_patcher::buf_type::ctrlpkt;
         auto symbol = std::string{Scratch_Pad_Mem_Symbol} + sym_name;
         if (patch_helper(ctrlpktbo, scratchpad_mem.address(), type, symbol, {}, false))
-          m_patched_args.insert(
-              xrt_core::elf_patcher::generate_key_string(symbol, type));
+          m_patched_args.insert(xrt_core::elf_patcher::generate_key_string(symbol, type));
       }
 
       type = xrt_core::elf_patcher::buf_type::ctrltext;
       if (patch_helper(m_buffer, ctrlpktbo.address(), type, sym_name, {}, false))
-        m_patched_args.insert(
-            xrt_core::elf_patcher::generate_key_string(sym_name, type));
+        m_patched_args.insert(xrt_core::elf_patcher::generate_key_string(sym_name, type));
     }
 
-    // Patch scratchpad memory address in instruction buffer if present
+    // Patch the scratchpad address into m_buffer itself (ctrltext side).
     if (scratchpad_mem) {
       type = xrt_core::elf_patcher::buf_type::ctrltext;
       if (patch_helper(m_buffer, scratchpad_mem.address(), type, Scratch_Pad_Mem_Symbol, {}, false))
-        m_patched_args.insert(
-            xrt_core::elf_patcher::generate_key_string(Scratch_Pad_Mem_Symbol, type));
+        m_patched_args.insert(xrt_core::elf_patcher::generate_key_string(Scratch_Pad_Mem_Symbol, type));
     }
   }
 
-  // Create instruction buffer with all columns data along with pad section
   void
   create_instruction_buffer()
   {
-    const auto& data = m_config.ctrlcodes;
-
-    // Create bo with combined size of all ctrlcodes
-    size_t sz = std::accumulate(data.begin(), data.end(), static_cast<size_t>(0),
-      [](auto acc, const auto& ctrlcode) {
-        return acc + ctrlcode.size();
-      });
+    // Compute the combined size of all column ctrl-codes so that a single
+    // contiguous BO can hold them back-to-back, with each column's data
+    // at a known offset from the BO base address.
+    auto ncols = m_elf_impl->get_column_count(m_ctrl_code_id);
+    size_t sz = 0;
+    for (uint32_t col = 0; col < ncols; ++col)
+      sz += m_elf_impl->get_ctrlcode_col_size(m_ctrl_code_id, col);
 
     if (sz == 0) {
       XRT_DEBUGF("ctrlcode buf is empty\n");
@@ -963,23 +993,27 @@ class module_run_aie_gen2_plus : public module_run
     }
 
     m_buffer = xbi::create_bo(m_hwctx, sz, xbi::use_type::instruction);
-
     fill_instruction_buffer();
   }
 
-  // Fill column buffer addresses for command submission
-  // Skips empty columns (holes in the ctrlcode array).
+  // Build m_column_bo_address — the per-column metadata written into the ERT
+  // DPU payload at submission time.  Each entry records the uC (micro-controller)
+  // index, the device address of that column's ctrl-code within m_buffer, the
+  // column size, and the optional dtrace buffer address for dynamic tracing.
+  //
+  // Columns with zero size are sparse holes in the ctrl-code layout and are
+  // skipped — they require no submission entry but still advance the base address.
   void
   fill_column_bo_address()
   {
-    const auto& ctrlcodes = m_config.ctrlcodes;
-
+    auto ncols = m_elf_impl->get_column_count(m_ctrl_code_id);
     m_column_bo_address.clear();
     uint16_t ucidx = 0;
     auto base_addr = m_buffer.address();
 
-    for (const auto& ctrlcode : ctrlcodes) {
-      if (auto size = ctrlcode.size()) {
+    for (uint32_t col = 0; col < ncols; ++col) {
+      if (auto size = m_elf_impl->get_ctrlcode_col_size(m_ctrl_code_id, col)) {
+        // Look up the dtrace buffer offset for this uC index, if dtrace is active.
         uint64_t dtrace_addr = 0;
         if (m_dtrace.ctrl_bo) {
           auto it = m_dtrace.buf_offset_map.find(ucidx);
@@ -989,7 +1023,7 @@ class module_run_aie_gen2_plus : public module_run
         m_column_bo_address.emplace_back(ucidx, base_addr, size, dtrace_addr);
       }
       ++ucidx;
-      base_addr += ctrlcode.size();
+      base_addr += m_elf_impl->get_ctrlcode_col_size(m_ctrl_code_id, col);
     }
   }
 
@@ -1037,7 +1071,6 @@ class module_run_aie_gen2_plus : public module_run
 public:
   module_run_aie_gen2_plus(const xrt::elf& elf, const xrt::hw_context& hw_context, uint32_t id)
     : module_run(elf, hw_context, id)
-    , m_config(std::get<xrt::module_config_aie_gen2_plus>(m_elf_impl->get_module_config(id)))
   {
     XRT_TRACE_POINT_SCOPE(xrt_module_run_aie_gen2_plus);
     initialize_dtrace_buf("");  // use config path by default
@@ -1331,43 +1364,39 @@ get_patch_buf_size(const xrt::module& module, xrt_core::elf_patcher::buf_type ty
   auto platform = elf_hdl->get_platform();
 
   if (platform == xrt::elf::platform::aie2p) {
-    auto module_config =
-        std::get<xrt::module_config_aie_gen2>(elf_hdl->get_module_config(ctrl_code_id));
-
     switch (type) {
-      case xrt_core::elf_patcher::buf_type::ctrltext:
-        return module_config.instr_data.size();
-      case xrt_core::elf_patcher::buf_type::ctrldata:
-        return module_config.ctrl_packet_data.size();
-      case xrt_core::elf_patcher::buf_type::preempt_save:
-        return module_config.preempt_save_data.size();
-      case xrt_core::elf_patcher::buf_type::preempt_restore:
-        return module_config.preempt_restore_data.size();
-      default:
-        throw std::runtime_error("Unknown buffer type passed");
+    case xrt_core::elf_patcher::buf_type::ctrltext:
+      return elf_hdl->get_instr_buf_size(ctrl_code_id);
+    case xrt_core::elf_patcher::buf_type::ctrldata:
+      return elf_hdl->get_ctrl_packet_size(ctrl_code_id);
+    case xrt_core::elf_patcher::buf_type::preempt_save:
+      return elf_hdl->get_preempt_save_size(ctrl_code_id);
+    case xrt_core::elf_patcher::buf_type::preempt_restore:
+      return elf_hdl->get_preempt_restore_size(ctrl_code_id);
+    default:
+      throw std::runtime_error("Unknown buffer type passed");
     }
   }
-  else if (platform == xrt::elf::platform::aie2ps || platform == xrt::elf::platform::aie2ps_legacy ||
-          platform == xrt::elf::platform::aie4 || platform == xrt::elf::platform::aie4a ||
-          platform == xrt::elf::platform::aie4z) {
-    auto module_config =
-        std::get<xrt::module_config_aie_gen2_plus>(elf_hdl->get_module_config(ctrl_code_id));
 
-        if (type != xrt_core::elf_patcher::buf_type::ctrltext)
-      throw std::runtime_error("Info of given buffer type not available");
+  // gen2plus: only ctrltext (single column) supported
+  if (type != xrt_core::elf_patcher::buf_type::ctrltext)
+    throw std::runtime_error("Info of given buffer type not available");
 
-    const auto& col_data = module_config.ctrlcodes;
-    if (col_data.empty())
-      throw std::runtime_error{"No control code found for given id"};
-    if (col_data.size() != 1)
-      throw std::runtime_error{"Patch failed: only support patching single column"};
-    return col_data[0].size();
-  }
-  else {
-    throw std::runtime_error{"Patch failed: unsupported ELF ABI"};
-  }
+  auto ncols = elf_hdl->get_column_count(ctrl_code_id);
+  if (ncols == 0)
+    throw std::runtime_error{"No control code found for given id"};
+  if (ncols != 1)
+    throw std::runtime_error{"Patch failed: only support patching single column"};
+
+  return elf_hdl->get_ctrlcode_col_size(ctrl_code_id, 0);
 }
 
+// Copy the requested ELF buffer (identified by ctrl_code_id and buf_type)
+// into ibuf, then apply any caller-supplied argument patches in place.
+// Called from shim-level tests (xdna-driver/test/shim_test/exec_buf.h) that
+// manage their own buffer lifecycle and device sync.
+// The caller is responsible for buffer sizing (use get_patch_buf_size())
+// and sync.  Normal execution paths use module_run::patch() instead.
 void
 patch(const xrt::module& module, uint8_t* ibuf, size_t sz,
       const std::vector<std::pair<std::string, uint64_t>>* args,
@@ -1375,63 +1404,77 @@ patch(const xrt::module& module, uint8_t* ibuf, size_t sz,
 {
   valid_or_error(module);
   auto elf_hdl = module.get_handle()->get_elf_handle();
-  const xrt::buf* inst = nullptr;
   auto platform = elf_hdl->get_platform();
 
+  // Copy the requested ELF section into ibuf, validating the buffer is large enough.
+  size_t buf_sz = 0;
   if (platform == xrt::elf::platform::aie2p) {
-    auto module_config =
-        std::get<xrt::module_config_aie_gen2>(elf_hdl->get_module_config(ctrl_code_id));
     switch (type) {
-      case xrt_core::elf_patcher::buf_type::ctrltext:
-        inst = &module_config.instr_data;
-        break;
-      case xrt_core::elf_patcher::buf_type::ctrldata:
-        inst = &module_config.ctrl_packet_data;
-        break;
-      case xrt_core::elf_patcher::buf_type::preempt_save:
-        inst = &module_config.preempt_save_data;
-        break;
-      case xrt_core::elf_patcher::buf_type::preempt_restore:
-        inst = &module_config.preempt_restore_data;
-        break;
-      default:
-        throw std::runtime_error("Unknown buffer type passed");
+    case xrt_core::elf_patcher::buf_type::ctrltext:
+      buf_sz = elf_hdl->get_instr_buf_size(ctrl_code_id);
+      if (sz < buf_sz)
+        throw std::runtime_error{"Control code buffer passed in is too small"};
+
+      elf_hdl->copy_instr_buf(ctrl_code_id, {reinterpret_cast<std::byte*>(ibuf), buf_sz});
+      break;
+    case xrt_core::elf_patcher::buf_type::ctrldata:
+      buf_sz = elf_hdl->get_ctrl_packet_size(ctrl_code_id);
+      if (sz < buf_sz)
+        throw std::runtime_error{"Control code buffer passed in is too small"};
+
+      elf_hdl->copy_ctrl_packet(ctrl_code_id, {reinterpret_cast<std::byte*>(ibuf), buf_sz});
+      break;
+    case xrt_core::elf_patcher::buf_type::preempt_save:
+      buf_sz = elf_hdl->get_preempt_save_size(ctrl_code_id);
+      if (sz < buf_sz)
+        throw std::runtime_error{"Control code buffer passed in is too small"};
+
+      elf_hdl->copy_preempt_save(ctrl_code_id, {reinterpret_cast<std::byte*>(ibuf), buf_sz});
+      break;
+    case xrt_core::elf_patcher::buf_type::preempt_restore:
+      buf_sz = elf_hdl->get_preempt_restore_size(ctrl_code_id);
+      if (sz < buf_sz)
+        throw std::runtime_error{"Control code buffer passed in is too small"};
+
+      elf_hdl->copy_preempt_restore(ctrl_code_id, {reinterpret_cast<std::byte*>(ibuf), buf_sz});
+      break;
+    default:
+      throw std::runtime_error("Unknown buffer type passed");
     }
   }
-  else if (platform == xrt::elf::platform::aie2ps || platform == xrt::elf::platform::aie2ps_legacy ||
-           platform == xrt::elf::platform::aie4 || platform == xrt::elf::platform::aie4a ||
-           platform == xrt::elf::platform::aie4z) {
-    auto module_config =
-        std::get<xrt::module_config_aie_gen2_plus>(elf_hdl->get_module_config(ctrl_code_id));
-    const auto& col_data = module_config.ctrlcodes;
+  else {
+    // gen2plus supports patching ctrltext only, and only for single-column ELFs.
+    if (type != xrt_core::elf_patcher::buf_type::ctrltext)
+      throw std::runtime_error{"Patch failed: unsupported buffer type for gen2plus"};
 
-    if (col_data.empty())
+    auto ncols = elf_hdl->get_column_count(ctrl_code_id);
+    if (ncols == 0)
       throw std::runtime_error{"No control code found for given id"};
-    if (col_data.size() != 1)
+
+    if (ncols != 1)
       throw std::runtime_error{"Patch failed: only support patching single column"};
 
-    inst = &col_data[0];
-  }
-  else {
-    throw std::runtime_error{"Patch failed: unsupported ELF ABI"};
+    buf_sz = elf_hdl->get_ctrlcode_col_size(ctrl_code_id, 0);
+    if (sz < buf_sz)
+      throw std::runtime_error{"Control code buffer passed in is too small"};
+
+    elf_hdl->copy_ctrlcode_col(ctrl_code_id, 0, {reinterpret_cast<std::byte*>(ibuf), buf_sz});
   }
 
-  if (sz < inst->size())
-    throw std::runtime_error{"Control code buffer passed in is too small"};
-  inst->copy_to({ibuf, sz});
-
-  // If no args to patch, we're done
+  // If no args to patch, we're done — ibuf holds the raw ELF section data.
   if (!args || args->empty())
     return;
 
-  // Get the patcher configs from module
+  // Get the patcher configs from the module — these encode the relocation
+  // sites within the buffer for each argument.
   const auto* patcher_configs = elf_hdl->get_patcher_configs(ctrl_code_id);
   if (!patcher_configs)
     throw std::runtime_error{"No patcher configs found for given id"};
 
   size_t index = 0;
   for (const auto& [arg_name, arg_addr] : *args) {
-    // Find the patcher config for this argument
+    // Look up by argument name first; fall back to positional index for
+    // callers that don't know the symbol names.
     auto key_string = xrt_core::elf_patcher::generate_key_string(arg_name, type);
     auto it = patcher_configs->find(key_string);
     if (it == patcher_configs->end()) {
@@ -1440,9 +1483,10 @@ patch(const xrt::module& module, uint8_t* ibuf, size_t sz,
       it = patcher_configs->find(index_key);
       if (it == patcher_configs->end())
         throw std::runtime_error{"Failed to patch " + arg_name};
-    }
 
-    // Use static patch method (no state needed for shim tests)
+    }
+    // Use the static patch method — no per-run state needed here since the
+    // caller owns ibuf and handles sync themselves.
     xrt_core::elf_patcher::symbol_patcher::patch_symbol_raw(ibuf, sz, arg_addr, it->second);
     index++;
   }


### PR DESCRIPTION
#### Problem solved by the commit

XRT owns all ELF parsing via a direct dependency on ELFIO, coupling XRT to the ELFIO library and duplicating ELF knowledge that belongs in AIEBU. This PR is Phase 1 of migrating ELF ownership from XRT to AIEBU, replacing `ELFIO::elfio m_elfio` in `elf_impl` with `aiebu::elf m_elf`.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

No regression introduced.  A PDI symbol detection bug (`m_ctrl_pdi_map` matching target section name instead of dynamic symbol name) was discovered during integration testing and fixed in AIEBU before this PR.

A Release-build segfault caused by ELFIO moving an `elfio` object after sections were created (dangling raw `&convertor` pointers) was fixed by bumping AIEBU's ELFIO submodule to the version used by XRT (`f849001`), which converts the convertor to `shared_ptr`.

#### How problem was solved, alternative solutions (if any) and why they were rejected

**Step 1.1 — add `aiebu::elf` reader to AIEBU:**
A new `aiebu::elf` class owns all ELF parsing, exposing a domain-level API that hides ELFIO from callers.  Platform-specific subclasses (`elf_reader_aie2p`, `elf_reader_gen2plus`) handle AIE gen2 and gen2plus respectively, dispatched via virtual methods — no `dynamic_cast`.

**Step 1.2 — replace `m_elfio` with `m_elf` in `elf_impl`:**
- `struct buf`, `module_config_aie_gen2/plus`, and `get_module_config()` removed
- All buffer access uses size+copy pairs forwarding to `aiebu::elf`, copying  directly into device BO mappings — no intermediate heap allocation
- `elf_aie_gen2` and `elf_aie_gen2_plus` reduced to shells (~20 lines each):  constructor + `is_group_elf` + `get_ert_opcode`; no buffer maps
- `m_arg2patcher` populated by translating `aiebu::elf::get_patch_points()`   once at construction; cleared immediately after to avoid duplication
- `get_patch_points()` returns `const&` (zero allocation); PDI loop replaced   by O(1) `get_pdi_symbols()` lookup
- `module_run` calls `elf_impl` buffer accessors directly; `elf_parent`   back-pointer eliminated
- `struct buf`, `instr_buf`, `ctrlcode` aliases removed from `elf_int.h`
- ELFIO transitional include retained in `elf_int.h` for external submodules   (`xdna-driver` shim tests, xdp elf_helpers) that still use `get_elfio()`;   removed in Step 1.3

**Critical path unchanged:** `m_arg2patcher` layout, `get_patcher_configs()`
raw-pointer return, and `symbol_patcher::patch_symbol()` are identical.

**ELF decompression:** `section_buf` redesigned to hold ELFIO section pointers rather than raw `string_view`s; `copy_to()` delegates to `aiebu::copy_section_uncompressed_data()`, decompressing `SHF_COMPRESSED` sections directly into device BO mappings with no intermediate buffer.

**`for_each_ctrlpkt()`** added to `aiebu::elf` to iterate ctrlpkt sections without allocating a `vector<string>`; used in `module_run` construction.

#### Risks (if any) associated the changes in the commit

- `xrt_elf.cpp`, `xrt_module.cpp`, `elf_int.h` significantly refactored
- All buffer data now flows through `aiebu::elf` virtual accessors; validated   end-to-end on AIE2P, AIE2PS, and AIE4 hardware
- `get_cfg_uuid()` now returns empty `xrt::uuid{}` instead of throwing when   `.note.xrt.UID` is absent, consistent with PR #9997

#### What has been tested and how, request additional testing if necessary

- Full XRT test suite on x86_64 Linux
- AIE2P, AIE2PS, AIE4 end-to-end ELF flow with patching and preemption
- Memory footprint validated: no steady-state duplication vs pre-migration
- New `elf_reader_test` harness in AIEBU covers all `aiebu::elf` public APIs
  including buffer accessors, patch points, decompression round-trip
- model_tests
- testcases_v2
- test build with XRT-MCDM

#### Documentation impact (if any)

Design document added: `docs/design/elf-aiebu-migration.md` covers all four phases of the migration with implementation notes for completed steps.