### PR TITLE
build_edge.sh always sourced build/vitis.build, which hard-coded Vitis 2023.2

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -46,7 +46,13 @@ install_recipes()
     if [ $? != 0 ]; then
         echo "inherit externalsrc" > $XRT_BB
         echo "EXTERNALSRC = \"$XRT_REPO_DIR/src\"" >> $XRT_BB
-        echo "EXTRA_OECMAKE += \"-DMY_VITIS=$XILINX_VITIS -DXRT_EDGE=1 -DXRT_YOCTO=1 -DCMAKE_INSTALL_PREFIX=/usr\"" >> $XRT_BB
+        # MY_VITIS is optional: used only to package PS-kernel xclbins via xclbinutil.
+        # Do not require or auto-source Vitis; a stale XILINX_VITIS breaks PetaLinux Python (CR-1279278).
+        if [[ -n "$XILINX_VITIS" && -d "$XILINX_VITIS" ]]; then
+            echo "EXTRA_OECMAKE += \"-DMY_VITIS=$XILINX_VITIS -DXRT_EDGE=1 -DXRT_YOCTO=1 -DCMAKE_INSTALL_PREFIX=/usr\"" >> $XRT_BB
+        else
+            echo "EXTRA_OECMAKE += \"-DXRT_EDGE=1 -DXRT_YOCTO=1 -DCMAKE_INSTALL_PREFIX=/usr\"" >> $XRT_BB
+        fi
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
 	echo 'DEPENDS += " systemtap"' >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
@@ -293,9 +299,6 @@ if [ -f $SETTINGS_FILE  ] && [ -z $PETALINUX ]; then
 fi
 
 source $PETALINUX/settings.sh
-
-VITIS_FILE="${THIS_SCRIPT_DIR}/vitis.build"
-source $VITIS_FILE
 
 if [[ $AARCH = $aarch64_dir ]]; then
     if [[ -f $PETALINUX/../../bsp/release/zynqmp-common-v$PETALINUX_VER-final.bsp ]]; then

--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -19,7 +19,7 @@ usage()
     echo "          -cache                          path to sstate-cache"
     echo "          -setup                          setup file to use"
     echo "          -clean, clean                   Remove build directories"
-    echo "          -full, full                     Full Petalinux build which builds images along with XRT RPMs"
+    echo "          -full, full                     Full Petalinux build (images + XRT RPMs + APU packages; source Vitis first)"
     echo "          -archiver                       Generate archiver of the project. This is needed to generate LICENSE"
     echo "          -noinit                         Do not initialize Git submodules"
     echo ""
@@ -299,6 +299,19 @@ if [ -f $SETTINGS_FILE  ] && [ -z $PETALINUX ]; then
 fi
 
 source $PETALINUX/settings.sh
+
+if [[ $apu_package == 1 ]]; then
+    if [[ -z "$XILINX_VITIS" || ! -d "$XILINX_VITIS" ]]; then
+        error "-full requires XILINX_VITIS. Source Vitis settings64.sh and rerun."
+    fi
+    if [[ ! -x "$XILINX_VITIS/bin/bootgen" ]]; then
+        error "-full requires bootgen at \$XILINX_VITIS/bin/bootgen ($XILINX_VITIS/bin/bootgen not found)."
+    fi
+    if ! command -v xclbinutil >/dev/null 2>&1 && [[ ! -x "$XILINX_VITIS/bin/xclbinutil" ]]; then
+        error "-full requires xclbinutil (source Vitis so it is on PATH)."
+    fi
+    echo "Using Vitis for APU package: $XILINX_VITIS"
+fi
 
 if [[ $AARCH = $aarch64_dir ]]; then
     if [[ -f $PETALINUX/../../bsp/release/zynqmp-common-v$PETALINUX_VER-final.bsp ]]; then

--- a/build/vitis.build
+++ b/build/vitis.build
@@ -1,1 +1,0 @@
-source /proj/xbuilds/2023.2_daily_latest/installs/lin64/Vitis/2023.2/settings64.sh

--- a/src/runtime_src/tools/scripts/pkgapu.sh
+++ b/src/runtime_src/tools/scripts/pkgapu.sh
@@ -167,10 +167,6 @@ FW_FILE="$BUILD_DIR/lib/firmware/xilinx/xrt-versal-apu.xsabin"
 INSTALL_ROOT="$BUILD_DIR/lib"
 SDK="$BUILD_DIR/lib/firmware/xilinx/sysroot/sdk.sh"
 
-THIS_SCRIPT_DIR="$( cd "$( dirname "${THIS_SCRIPT}" )" >/dev/null 2>&1 && pwd )"
-VITIS_FILE="${THIS_SCRIPT_DIR}/vitis.build"
-source $VITIS_FILE
-
 if [[ $clean == 1 ]]; then
 	echo $PWD
 	echo "/bin/rm -rf $BUILD_DIR"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
build_edge.sh always sourced build/vitis.build, which hard-coded Vitis 2023.2. That overwrote whatever XILINX_VITIS the caller already had. With 2026.2 Vitis on PYTHONPATH, every PetaLinux Python start printed:

```
Error in sitecustomize; set PYTHONVERBOSE for traceback:
OSError: .../Vitis/2023.2/tps/lnx64/gcc/lib64/libgcc_s.so.1: cannot open shared object file
```
The XRT/zocl RPM build still succeeded. The noise showed up on the 2026.2 XRT RPM path (CR-1279278), not on PetaLinux-only runs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Same PetaLinux + same XRT commit; Vitis 0820 (last pass) vs Vitis 0827+ (fail). 0820 sitecustomize.py dlopen’d $XILINX_VITIS/aietools/tps/lnx64/gcc/lib64/libgcc_s.so.1 (still present on the 2023.2 tree). 0827+ uses $XILINX_VITIS/tps/lnx64/gcc/lib64/libgcc_s.so.1, which is missing on /proj/xbuilds/SWIP/2023.2_1013_2256. Regression sources 2026.2 first; build_edge.sh then overwrote XILINX_VITIS to 2023.2.

#### How problem was solved, alternative solutions (if any) and why they were rejected
- Delete build/vitis.build and stop sourcing it from build_edge.sh.
- Pass -DMY_VITIS only when XILINX_VITIS is already set (optional PS-kernel xclbins).
- Remove the dead source …/scripts/vitis.build from pkgapu.sh (that file never existed next to the script).
- For -full (APU packages), require a sourced Vitis (XILINX_VITIS, bootgen, xclbinutil) and fail before the PetaLinux build if missing.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
