### PR TITLE
CR-1273889: disable UBSAN for the out-of-tree zocl module

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -40,6 +40,12 @@ endif
 
 ccflags-y += -Wall
 
+# ENABLE_KERNEL_DEBUG turns on UBSAN. GCC then embeds absolute
+# kernel-source paths in zocl.ko and those strings are not
+# rewritten by -ffile-prefix-map, so do_package_qa fails with [buildpaths].
+# Keep sanitizers on the in-tree kernel; disable them for this OOT module.
+UBSAN_SANITIZE := n
+
 # Version adjusted to 2.23 for master
 XRT_DRIVER_VERSION ?= 2.23.0
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1273889 ENABLE_KERNEL_DEBUG turns on kernel UBSAN, which embeds absolute kernel-source paths in zocl.ko and fails Yocto do_package_qa [buildpaths].

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Disabling UBSAN only for zocl keeps the kernel sanitizers and avoids hiding the QA check.

#### Risks (if any) associated the changes in the commit
low

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
