### PR TITLE
xrt::ext::bo: add a use_mode constructor for debug buffers

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1726,6 +1726,19 @@ bo(const xrt::hw_context& hwctx, size_t sz, access_mode access)
   : xrt::bo::bo{alloc_kbuf(device_type{hwctx}, nullptr, sz, adjust_buffer_flags(access))}
 {}
 
+// Both enumerators are defined from XRT_BO_USE_DEBUG, so the cast is sound
+// unless bo_int::use_type stops deriving from the same macro.
+static_assert(static_cast<uint64_t>(bo::use_mode::debug)
+              == static_cast<uint64_t>(xrt_core::bo_int::use_type::debug),
+              "xrt::ext::bo::use_mode::debug must match "
+              "xrt_core::bo_int::use_type::debug");
+
+bo::
+bo(const xrt::hw_context& hwctx, size_t sz, use_mode use)
+  : xrt::bo::bo{xrt_core::bo_int::create_bo(
+      hwctx, sz, static_cast<xrt_core::bo_int::use_type>(use)).get_handle()}
+{}
+
 bo::
 bo(const xrt::hw_context& hwctx, size_t sz)
   : bo{hwctx, sz, xrt::ext::bo::access_mode::local}

--- a/src/runtime_src/core/include/xrt/experimental/xrt_ext.h
+++ b/src/runtime_src/core/include/xrt/experimental/xrt_ext.h
@@ -109,6 +109,21 @@ public:
   }
 
   /**
+   * @enum use_mode - what the buffer's content is for
+   *
+   * @var debug
+   *   Buffer receives debug data from driver or firmware
+   *
+   * A use mode reaches the buffer use flags in xrt_mem.h, which the
+   * access mode constructors do not.  It decides both how the buffer
+   * is allocated and how the device is given access to it.
+   */
+  enum class use_mode : uint64_t
+  {
+    debug = XRT_BO_USE_DEBUG
+  };
+
+  /**
    * bo() - Constructor with user host buffer and access mode
    *
    * @param device
@@ -208,6 +223,26 @@ public:
    */
   XRT_API_EXPORT
   bo(const xrt::hw_context& hwctx, size_t sz, access_mode access);
+
+  /**
+   * bo() - Constructor for a buffer object with a specific use mode
+   *
+   * @param hwctx
+   *  The hardware context that this buffer object uses for queue
+   *  operations such as syncing and residency operations.
+   * @param sz
+   *  Size of buffer
+   * @param use
+   *  What the buffer's content is for (see `enum use_mode`)
+   *
+   * A debug buffer receives data written by driver or firmware rather
+   * than by a kernel, so it is attached to the hardware context for its
+   * lifetime instead of being passed as a kernel argument.  Supported on
+   * specific platforms only.  The access mode constructors cover the
+   * ordinary case of a buffer that is a kernel argument.
+   */
+  XRT_API_EXPORT
+  bo(const xrt::hw_context& hwctx, size_t sz, use_mode use);
 
   /**
    * bo() - Constructor for buffer object


### PR DESCRIPTION
#### Problem solved by the commit

There is no public way to allocate a debug buffer. `XRT_BO_USE_DEBUG` sits in an
installed header, but `xrt_mem.h` marks the use field "for internal use only",
and `bo_int.h` repeats that over `use_type` itself. The only path to it is
`xrt_core::bo_int::create_bo`, so a caller who needs one declares that symbol
by hand against `libxrt_coreutil` and keeps a private copy of `use_type` in
step with yours. `bo_int.h` names the gap in its own comment on `create_bo`:
"All the public xrt::bo constructors doesnt use 64 bit flags."

The use case is register readback. `TXN_OPC_READ_REGS` on the ordinary
`EXEC_NPU` path writes its results into the debug buffer attached to the
hardware context; with no buffer attached the command still completes and the
values are dropped. I use this to hardware-test `aiex.npu.read_reg` in
Xilinx/mlir-aie#3660, outside XDP and outside any profiling flow. Ryzen AI 9
465, NPU firmware 1.1.2.64, amdxdna 7.2.0, XRT 2.21.75: `COMPLETED` with the
expected register values at the start of the buffer, 3/3 runs.

The mechanism is already load bearing in this tree, and not only in XDP:
`xrt::runner` lets a recipe declare a `"debug"` buffer
(`core/common/runner/recipe.md`), and `xrt-smi validate`'s GEMM test reads
per-core cycle counts back through a `uc_debug` buffer
(`TestGemm.cpp:145-149`). XDP's `aie_debug` client does read registers this way
on NPU, but it submits its transaction against its own `XDP_KERNEL`
(`xdp/profile/plugin/aie_debug/client/aie_debug.cpp:53-70`). What no in-tree
consumer offers is the same read riding an ordinary compiler emitted runtime
sequence on `EXEC_NPU`, which is where my caller sits.

#### How problem was solved, alternative solutions (if any) and why they were rejected

Added `xrt::ext::bo::use_mode` and a `bo(hwctx, sz, use_mode)` constructor,
mirroring how `access_mode` is already exposed on the same class.

The first revision of this PR exposed eleven uses. Only `debug` survives, and
the other ten are dropped for three separate reasons:

- Eight are created by the runtime for its own lifetime: `log` and
  `scratch_pad` by `xrt::hw_context`, `instruction`, `preemption`,
  `ctrl_scratch_pad`, `pdi` and `dtrace` by `xrt::module`, and `ctrlpkt` by
  `xrt::module` and by `xrt::kernel`'s buffer cache. A public constructor for
  those is a public way to make a second one of something the runtime owns.
- `uc_debug` is unusable without `bo_int::config_bo`, which stays internal, so
  the constructor alone would ship half an API. The same holds for `log`.
- `host_only` names the allocation `xrt::ext::bo` already makes
  unconditionally.

Reinforcing the first point: in the amdxdna shim the use value selects a
distinct buffer implementation only for the debug family. For `instruction`,
`preemption`, `pdi` and `ctrl_scratch_pad` it changes nothing but a string in a
debug log, and the same memory is already reachable through
`xrt::bo::flags::cacheable`.

Debug is the one use whose point is not the memory but the attachment: the shim
binds it to the hardware context and detaches it on destruction, and reads it
back through the driver. Nothing in the public API expresses that.

Installing `bo_int.h` was rejected: it exports `buffer_handle`, `hwctx_handle`
and `config_bo` alongside, which are genuinely internal.

#### Risks (if any) associated the changes in the commit

Additive, no existing signature changes.

`xrt::ext::bo` documents itself as "always a host only BO" in `xrt_bo.cpp`, and
a debug buffer is `XRT_BO_FLAGS_CACHEABLE`, so this constructor is the first
exception to that. If you would rather hold that invariant, the same capability
fits on `xrt::hw_context` instead; say so and I will move it.

`XRT_BO_USE_DEBUG` is documented as supported on specific platforms only.

#### What has been tested and how, request additional testing if necessary

What I ran on hardware is the `create_bo(hwctx, sz, use_type::debug)` path
itself, through the hand-declared prototype described above. The new
constructor is a compile-tested wrapper over exactly that call. I have not
rebuilt XRT and rerun the probe through the public constructor, and I have not
run the XRT test suite, so a debug-buffer round trip through this API is worth
adding before merge.

#### Documentation impact (if any)

The new enum and constructor carry doxygen comments in the same style as the
surrounding `xrt::ext::bo` API.
