### PR TITLE
Changing the XDP submodule branch to vai_6.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,4 +17,4 @@
 [submodule "src/runtime_src/xdp"]
 	path = src/runtime_src/xdp
 	url = https://github.com/Xilinx/XDP.git
-	branch = master
+	branch = vai_6.3


### PR DESCRIPTION
#### Problem solved by the commit
Pointing the XDP submodule so XRT vai_6.3 points to XDP vai_6.3 branch.

