### PR TITLE
[XRT-SMI] Cleanup logic into specific files and prune VF specific options

### DIFF
--- a/src/runtime_src/core/common/smi/CMakeLists.txt
+++ b/src/runtime_src/core/common/smi/CMakeLists.txt
@@ -3,7 +3,14 @@
 #
 # OBJECT libraries linked into xrt_coreutil, xrt_core (Alveo/edge), and xrt_driver_xdna / other shims.
 
-add_library(core_common_smi_objects OBJECT smi.cpp smi_ryzen.cpp)
+add_library(core_common_smi_objects OBJECT
+  smi.cpp
+  smi_ryzen.cpp
+  smi_ryzen_npu3.cpp
+  smi_ryzen_pf.cpp
+  smi_ryzen_strix.cpp
+  smi_ryzen_vf.cpp
+  )
 target_include_directories(core_common_smi_objects
   PRIVATE
   ${XRT_SOURCE_DIR}/runtime_src

--- a/src/runtime_src/core/common/smi/smi.cpp
+++ b/src/runtime_src/core/common/smi/smi.cpp
@@ -290,11 +290,19 @@ get_aie_architecture_version(hardware_type hw)
   }
 }
 
-bool
+smi_hardware_config::npu3_variant
 smi_hardware_config::
-is_pf_device(hardware_type hw)
+get_npu3_variant(hardware_type hw)
 {
   switch (hw) {
+  case hardware_type::npu3a_vf:
+  case hardware_type::npu3_B03_vf:
+  case hardware_type::npu7_vf:
+  case hardware_type::npu8_vf:
+  case hardware_type::npu9_vf:
+  case hardware_type::npu10_vf:
+  case hardware_type::npu11_vf:
+    return npu3_variant::vf;
   case hardware_type::npu3a_pf:
   case hardware_type::npu3_B02_pf:
   case hardware_type::npu7_pf:
@@ -302,9 +310,9 @@ is_pf_device(hardware_type hw)
   case hardware_type::npu9_pf:
   case hardware_type::npu10_pf:
   case hardware_type::npu11_pf:
-    return true;
+    return npu3_variant::pf;
   default:
-    return false;
+    return npu3_variant::classic;
   }
 }
 

--- a/src/runtime_src/core/common/smi/smi.h
+++ b/src/runtime_src/core/common/smi/smi.h
@@ -207,11 +207,6 @@ public:
   // Derived classes must implement this method to define hardware-specific configuration logic.
   virtual subcommand 
   create_configure_subcommand() = 0;
-
-  // Clears the validate test list for devices that expose validate but have no runnable tests.
-  virtual void
-  clear_validate_tests()
-  {}
 };
 
 // class smi_hardware_config
@@ -262,6 +257,13 @@ public:
     unknown
   };
 
+  // NPU3 xrt-smi config variant (classic host, VF, or PF).
+  enum class npu3_variant {
+    classic,
+    vf,
+    pf,
+  };
+
   XRT_CORE_COMMON_EXPORT
   smi_hardware_config();
 
@@ -292,9 +294,9 @@ public:
   static bool
   is_aie2_platform(hardware_type hw);
 
-  // True for NPU PF PCIe functions (e.g. npu3a_pf, npu7_pf).
-  static bool
-  is_pf_device(hardware_type hw);
+  // NPU3 variant (classic host, VF, or PF) for xrt-smi config generator selection.
+  static npu3_variant
+  get_npu3_variant(hardware_type hw);
 
   // Validate-runner archive path relative to the platform archive root.
   XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/smi/smi_ryzen.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen.h
@@ -18,13 +18,7 @@ protected:
   std::vector<xrt_core::smi::basic_option> examine_report_desc;
 
 public:
-  config_gen_ryzen();
-
-  void
-  clear_validate_tests() override
-  {
-    validate_test_desc.clear();
-  }
+  config_gen_ryzen() = default;
 
   virtual const std::vector<xrt_core::smi::basic_option>&
   get_validate_test_desc() const
@@ -52,28 +46,6 @@ public:
 class config_gen_phoenix : public config_gen_ryzen {
 public:
   config_gen_phoenix();
-};
-
-class config_gen_strix : public config_gen_ryzen {
-};
-
-class config_gen_npu3 : public config_gen_ryzen {
-  std::vector<xrt_core::smi::basic_option> examine_report_desc;
-
-public:
-  config_gen_npu3();
-
-  const std::vector<xrt_core::smi::basic_option>&
-  get_examine_report_desc() const override
-  {
-    return examine_report_desc;
-  }
-
-  xrt_core::smi::subcommand
-  create_validate_subcommand() override;
-
-  xrt_core::smi::subcommand
-  create_examine_subcommand() override;
 };
 
 void

--- a/src/runtime_src/core/common/smi/smi_ryzen_npu3.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen_npu3.cpp
@@ -3,50 +3,49 @@
 
 #define XRT_CORE_COMMON_SOURCE
 
-#include "core/common/smi/smi_ryzen.h"
 #include "core/common/smi/smi_ryzen_npu3.h"
-#include "core/common/smi/smi_ryzen_pf.h"
-#include "core/common/smi/smi_ryzen_strix.h"
-#include "core/common/smi/smi_ryzen_vf.h"
-
-#include "core/common/query_requests.h"
 
 using namespace xrt_core::smi;
 
 namespace xrt_core::smi::ryzen {
 
-config_gen_phoenix::
-config_gen_phoenix()
+config_gen_npu3::
+config_gen_npu3()
 {
   examine_report_desc = {
     {"aie-partitions", "AIE partition information", "common"},
     {"all", "All known reports are produced", "common"},
-    {"host", "Host information (default)", "common"},
+    {"host", "Host information", "common"},
     {"platform", "Platforms flashed on the device", "common"},
-    {"telemetry", "Telemetry data for the device", "hidden"},
-    {"preemption", "Preemption telemetry data for the device", "hidden"},
+    {"telemetry", "Telemetry data for the device", "common"},
+    {"preemption", "Preemption telemetry data for the device", "common"},
     {"clocks", "Clock frequency information", "hidden"},
     {"debug", "Debug configuration settings for the device", "hidden"}
   };
 
   validate_test_desc = {
     {"all", "All applicable validate tests will be executed (default)", "common"},
+    {"runlist-latency", "Run end-to-end latency test using runlist", "hidden"},
+    {"runlist-throughput", "Run end-to-end throughput test using runlist", "hidden"},
     {"df-bw", "Run bandwidth test on data fabric", "hidden"},
+    {"shim-dma-bw", "Run 2xRead/1xWrite bandwidth test for SHIM DMA", "hidden"},
     {"latency", "Run end-to-end latency test", "common"},
-    {"tct-all-col", "Measure average TCT processing time for all columns", "hidden"},
-    {"tct-one-col", "Measure average TCT processing time for one column", "hidden"},
     {"throughput", "Run end-to-end throughput test", "common"},
+    {"tct-one-col", "Measure average TCT processing time for one column", "hidden"},
+    {"tct-all-col", "Measure average TCT processing time for all columns", "hidden"},
+    {"gemm", "Measure the TOPS value of GEMM INT8operations", "common"},
+    {"sanity", "Run a small model and validate sanity of the device", "hidden"},
+    {"preemption-overhead", "Measure preemption overhead at noop and memtile levels", "hidden"}
   };
 }
 
 subcommand
-config_gen_ryzen::create_validate_subcommand()
+config_gen_npu3::create_validate_subcommand()
 {
   std::map<std::string, std::shared_ptr<option>> validate_suboptions;
   validate_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
-  validate_suboptions.emplace("format", std::make_shared<option>("format", "f", "Report output format. Valid values are:\n"
-                                "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema (legacy)", "common", "JSON", "string"));
+  validate_suboptions.emplace("json", std::make_shared<option>("json", "", "JSON ABI version for file output. Valid values are:\n"
+                                "\tdefault - Latest JSON schema (default)", "common", "default", "string"));
   validate_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   validate_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   validate_suboptions.emplace("run", std::make_shared<listable_description_option>("run", "r", "Run a subset of the test suite. Valid options are:\n",
@@ -59,13 +58,12 @@ config_gen_ryzen::create_validate_subcommand()
 }
 
 subcommand
-config_gen_ryzen::create_examine_subcommand()
+config_gen_npu3::create_examine_subcommand()
 {
   std::map<std::string, std::shared_ptr<option>> examine_suboptions;
   examine_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
-  examine_suboptions.emplace("format", std::make_shared<option>("format", "f", "Report output format. Valid values are:\n"
-                                "\tJSON        - Latest JSON schema\n"
-                                "\tJSON-2020.2 - JSON 2020.2 schema (legacy)", "common", "JSON", "string"));
+  examine_suboptions.emplace("json", std::make_shared<option>("json", "", "JSON ABI version for file output. Valid values are:\n"
+                                "\tdefault - Latest JSON schema (default)", "common", "default", "string"));
   examine_suboptions.emplace("output", std::make_shared<option>("output", "o", "Direct the output to the given file", "common", "", "string"));
   examine_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
   examine_suboptions.emplace("watch", std::make_shared<option>("watch", "", "Refresh interval in seconds between examine updates. Exit with Ctrl+C.", "hidden", "0", "string"));
@@ -78,7 +76,7 @@ config_gen_ryzen::create_examine_subcommand()
 }
 
 subcommand
-config_gen_ryzen::create_configure_subcommand()
+config_gen_npu3::create_configure_subcommand()
 {
   std::map<std::string, std::shared_ptr<option>> configure_suboptions;
   configure_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
@@ -90,59 +88,6 @@ config_gen_ryzen::create_configure_subcommand()
   configure_suboptions.emplace("auto-coredump", std::make_shared<option>("auto-coredump", "", "Enable|disable automatic coredump on error", "hidden", "", "string", true));
 
   return {"configure", "Device and host configuration", "common", std::move(configure_suboptions)};
-}
-
-static std::shared_ptr<config_gen_ryzen>
-create_config_generator(smi_hardware_config::hardware_type hw)
-{
-  switch (smi_hardware_config::get_family(hw)) {
-  case smi_hardware_config::hardware_family::phoenix:
-    return std::make_shared<config_gen_phoenix>();
-  case smi_hardware_config::hardware_family::strix:
-    return std::make_shared<config_gen_strix>();
-  case smi_hardware_config::hardware_family::npu3:
-    switch (smi_hardware_config::get_npu3_variant(hw)) {
-    case smi_hardware_config::npu3_variant::vf:
-      return std::make_shared<config_gen_npu3_vf>();
-    case smi_hardware_config::npu3_variant::pf:
-      return std::make_shared<config_gen_npu3_pf>();
-    case smi_hardware_config::npu3_variant::classic:
-      return std::make_shared<config_gen_npu3>();
-    }
-  default:
-    return std::make_shared<config_gen_strix>();
-  }
-}
-
-void
-populate_smi_instance(xrt_core::smi::smi* smi_instance, const xrt_core::device* device)
-{
-  smi_hardware_config smi_hrdw;
-  const auto pcie_id = xrt_core::device_query<xrt_core::query::pcie_id>(device);
-  const auto hw = smi_hrdw.get_hardware_type(pcie_id);
-  const auto generator = create_config_generator(hw);
-
-  smi_instance->add_subcommand("validate",  generator->create_validate_subcommand());
-  smi_instance->add_subcommand("examine",  generator->create_examine_subcommand());
-  smi_instance->add_subcommand("configure",  generator->create_configure_subcommand());
-}
-
-std::string
-get_smi_config(const xrt_core::device* device)
-{
-  auto smi_instance = xrt_core::smi::instance();
-
-  populate_smi_instance(smi_instance, device);
-
-  return smi_instance->build_json();
-}
-
-xrt_core::smi::tuple_vector
-get_subcommands_list(const xrt_core::device* device)
-{
-  auto smi_instance = xrt_core::smi::instance();
-  populate_smi_instance(smi_instance, device);
-  return smi_instance->get_subcommands_list();
 }
 
 } // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen_npu3.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen_npu3.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "core/common/smi/smi_ryzen.h"
+
+namespace xrt_core::smi::ryzen {
+
+class config_gen_npu3 : public config_gen_ryzen {
+protected:
+  std::vector<xrt_core::smi::basic_option> examine_report_desc;
+
+public:
+  config_gen_npu3();
+  const std::vector<xrt_core::smi::basic_option>&
+  get_examine_report_desc() const override
+  {
+    return examine_report_desc;
+  }
+
+  xrt_core::smi::subcommand
+  create_validate_subcommand() override;
+
+  xrt_core::smi::subcommand
+  create_examine_subcommand() override;
+
+  xrt_core::smi::subcommand
+  create_configure_subcommand() override;
+};
+
+} // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen_pf.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen_pf.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#define XRT_CORE_COMMON_SOURCE
+
+#include "core/common/smi/smi_ryzen_pf.h"
+
+using namespace xrt_core::smi;
+
+namespace xrt_core::smi::ryzen {
+
+config_gen_npu3_pf::
+config_gen_npu3_pf()
+  : config_gen_npu3()
+{
+  validate_test_desc = {};
+}
+
+subcommand
+config_gen_npu3_pf::create_configure_subcommand()
+{
+  std::map<std::string, std::shared_ptr<option>> configure_suboptions;
+  configure_suboptions.emplace("device", std::make_shared<option>("device", "d", "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest", "common", "", "string"));
+  configure_suboptions.emplace("help", std::make_shared<option>("help", "h", "Help to use this sub-command", "common", "", "none"));
+  configure_suboptions.emplace("event-trace", std::make_shared<option>("event-trace", "", "Enable|disable event tracing", "hidden", "", "string", true));
+  configure_suboptions.emplace("firmware-log", std::make_shared<option>("firmware-log", "", "Enable|disable firmware logging", "hidden", "", "string", true));
+  configure_suboptions.emplace("auto-coredump", std::make_shared<option>("auto-coredump", "", "Enable|disable automatic coredump on error", "hidden", "", "string", true));
+
+  return {"configure", "Device and host configuration", "common", std::move(configure_suboptions)};
+}
+
+} // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen_pf.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen_pf.cpp
@@ -14,6 +14,16 @@ config_gen_npu3_pf()
   : config_gen_npu3()
 {
   validate_test_desc = {};
+
+  examine_report_desc = {
+    {"all", "All known reports are produced", "common"},
+    {"host", "Host information", "common"},
+    {"platform", "Platforms flashed on the device", "common"},
+    {"telemetry", "Telemetry data for the device", "common"},
+    {"preemption", "Preemption telemetry data for the device", "common"},
+    {"clocks", "Clock frequency information", "hidden"},
+    {"debug", "Debug configuration settings for the device", "hidden"}
+  };
 }
 
 subcommand

--- a/src/runtime_src/core/common/smi/smi_ryzen_pf.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen_pf.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "core/common/smi/smi_ryzen_npu3.h"
+
+namespace xrt_core::smi::ryzen {
+
+class config_gen_npu3_pf : public config_gen_npu3 {
+public:
+  config_gen_npu3_pf();
+
+  xrt_core::smi::subcommand
+  create_configure_subcommand() override;
+};
+
+} // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen_strix.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen_strix.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#define XRT_CORE_COMMON_SOURCE
+
+#include "core/common/smi/smi_ryzen_strix.h"
+
+namespace xrt_core::smi::ryzen {
+
+config_gen_strix::
+config_gen_strix()
+{
+  examine_report_desc = {
+    {"aie-partitions", "AIE partition information", "common"},
+    {"all", "All known reports are produced", "common"},
+    {"host", "Host information (default)", "common"},
+    {"platform", "Platforms flashed on the device", "common"},
+    {"telemetry", "Telemetry data for the device", "hidden"},
+    {"preemption", "Preemption telemetry data for the device", "hidden"},
+    {"clocks", "Clock frequency information", "hidden"},
+    {"debug", "Debug configuration settings for the device", "hidden"}
+  };
+
+  validate_test_desc = {
+    {"aie-reconfig-overhead", "Run end-to-end array reconfiguration overhead through shim DMA", "hidden"},
+    {"all", "All applicable validate tests will be executed (default)", "common"},
+    {"runlist-latency", "Run end-to-end latency test using runlist", "hidden"},
+    {"runlist-throughput", "Run end-to-end throughput test using runlist", "hidden"},
+    {"df-bw", "Run bandwidth test on data fabric", "hidden"},
+    {"gemm", "Measure the TOPS value of GEMM INT8operations", "common"},
+    {"sanity", "Run a small model and validate sanity of the device", "hidden"},
+    {"latency", "Run end-to-end latency test", "common"},
+    {"quick", "Run a subset of four tests: \n1. latency \n2. throughput \n3. runlist-latency \n4. runlist-throughput", "hidden"},
+    {"tct-all-col", "Measure average TCT processing time for all columns", "hidden"},
+    {"tct-one-col", "Measure average TCT processing time for one column", "hidden"},
+    {"throughput", "Run end-to-end throughput test", "common"},
+    {"temporal-sharing-overhead", "Run end-to-end temporal sharing overhead test", "hidden"},
+    {"preemption-overhead", "Measure preemption overhead at noop and memtile levels", "hidden"}
+  };
+}
+
+} // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen_strix.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen_strix.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "core/common/smi/smi_ryzen.h"
+
+namespace xrt_core::smi::ryzen {
+
+class config_gen_strix : public config_gen_ryzen {
+public:
+  config_gen_strix();
+};
+
+} // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen_vf.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen_vf.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#define XRT_CORE_COMMON_SOURCE
+
+#include "core/common/smi/smi_ryzen_vf.h"
+
+using namespace xrt_core::smi;
+
+namespace xrt_core::smi::ryzen {
+
+config_gen_npu3_vf::
+config_gen_npu3_vf()
+  : config_gen_npu3()
+{
+  examine_report_desc = {
+    {"all", "All known reports are produced", "common"},
+    {"host", "Host information", "common"},
+    {"platform", "Platforms flashed on the device", "common"},
+    {"telemetry", "Telemetry data for the device", "common"},
+    {"clocks", "Clock frequency information", "hidden"},
+    {"debug", "Debug configuration settings for the device", "hidden"}
+  };
+}
+
+} // namespace xrt_core::smi::ryzen

--- a/src/runtime_src/core/common/smi/smi_ryzen_vf.cpp
+++ b/src/runtime_src/core/common/smi/smi_ryzen_vf.cpp
@@ -14,6 +14,7 @@ config_gen_npu3_vf()
   : config_gen_npu3()
 {
   examine_report_desc = {
+    {"aie-partitions", "AIE partition information", "common"},
     {"all", "All known reports are produced", "common"},
     {"host", "Host information", "common"},
     {"platform", "Platforms flashed on the device", "common"},

--- a/src/runtime_src/core/common/smi/smi_ryzen_vf.h
+++ b/src/runtime_src/core/common/smi/smi_ryzen_vf.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "core/common/smi/smi_ryzen_npu3.h"
+
+namespace xrt_core::smi::ryzen {
+
+class config_gen_npu3_vf : public config_gen_npu3 {
+public:
+  config_gen_npu3_vf();
+};
+
+} // namespace xrt_core::smi::ryzen


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR cleans up the code and moves device specific logic into their respective files. With the addition of pf/vf classes of devices, there was a need to cleanup code to move logic away from a central smi_ryzen file.
This PR introduces 2 derived classes for pf and vf devices which capture those device specific xrt-smi option configuration. The config logic for npu3 and strix has also been distributed out of smi_ryzen and moved to the respective cpp/h files.
The pf/vf specific classes now handle pruning preemption and aie partitions report which was required for the following ticket.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/AIESW-43829
https://jira.xilinx.com/browse/AIESW-43828

#### How problem was solved, alternative solutions (if any) and why they were rejected
Resolved via maintaining separate lists of configuration for pf and vf devices which might require further changes in the future.
This was cleaner since we dont need to alter common code in future if xrt-smi is required to change for new types of devices.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on all platforms by capturing the help output.

#### Documentation impact (if any)
None
