### PR TITLE
Enable pyxrt cross-compile for edge using sysroot Python headers.

### DIFF
--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # This cmake file is for embedded system. Only support cross compile aarch64
 # Custom variables imported by this CMake stub which should be defined by parent CMake:
@@ -67,6 +68,9 @@ message("-- Compiler: ${CMAKE_CXX_COMPILER} ${CMAKE_C_COMPILER}")
 include (CMake/lint.cmake)
 
 add_subdirectory(runtime_src)
+
+# --- Python bindings ---
+xrt_add_subdirectory(python)
 
 message("-- XRT version: ${XRT_VERSION_STRING}")
 

--- a/src/CMake/pyxrtCross.cmake
+++ b/src/CMake/pyxrtCross.cmake
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# This cmake file builds pyxrt when XRT is cross compiled for edge.
+# find_package(Python3) cannot be used: Yocto/CMake locate the host
+# interpreter, whose version does not match the Python headers in the
+# sysroot.  The extension is compiled against those headers; symbols
+# are resolved when python loads the module on the target.
+#
+# Optional overrides:
+# XRT_PYTHON_INCLUDE_DIR
+# XRT_PYBIND11_INCLUDE_DIR
+
+set (xrt_py_roots ${CMAKE_SYSROOT} ${CMAKE_FIND_ROOT_PATH} ${sysroot})
+list (REMOVE_ITEM xrt_py_roots "")
+list (REMOVE_DUPLICATES xrt_py_roots)
+
+# --- Python headers ---
+# Prefer the highest python3* directory that contains Python.h
+if (NOT XRT_PYTHON_INCLUDE_DIR)
+  set (xrt_py_version "0.0")
+  foreach (root ${xrt_py_roots})
+    file (GLOB candidates "${root}/usr/include/python3*" "${root}/include/python3*")
+    foreach (candidate ${candidates})
+      if (EXISTS "${candidate}/Python.h"
+          AND candidate MATCHES "python([0-9]+)\\.([0-9]+)")
+        set (version "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+        if (version VERSION_GREATER xrt_py_version)
+          set (xrt_py_version ${version})
+          set (XRT_PYTHON_INCLUDE_DIR ${candidate})
+        endif()
+      endif()
+    endforeach()
+  endforeach()
+endif()
+
+if (XRT_PYTHON_INCLUDE_DIR AND XRT_PYTHON_INCLUDE_DIR MATCHES "python([0-9]+)\\.([0-9]+)")
+  set (xrt_py_version "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+endif()
+
+# --- pybind11 headers ---
+if (NOT XRT_PYBIND11_INCLUDE_DIR)
+  foreach (root ${xrt_py_roots})
+    file (GLOB candidates
+      "${root}/usr/include"
+      "${root}/include"
+      "${root}/usr/lib/python3*/site-packages/pybind11/include"
+      "${root}/usr/lib/python3*/dist-packages/pybind11/include")
+    foreach (candidate ${candidates})
+      if (NOT XRT_PYBIND11_INCLUDE_DIR AND EXISTS "${candidate}/pybind11/pybind11.h")
+        set (XRT_PYBIND11_INCLUDE_DIR ${candidate})
+      endif()
+    endforeach()
+  endforeach()
+endif()
+
+if (NOT XRT_PYTHON_INCLUDE_DIR OR NOT XRT_PYBIND11_INCLUDE_DIR)
+  message(WARNING "-- pybind11 or python3 libs not found, pybind11 support disabled")
+  return()
+endif()
+
+message("-- Python include: ${XRT_PYTHON_INCLUDE_DIR} (${xrt_py_version})")
+message("-- pybind11 include: ${XRT_PYBIND11_INCLUDE_DIR}")
+
+# pybind11_add_module is not used; it depends on find_package(Python3)
+add_library(pyxrt MODULE ${CMAKE_CURRENT_SOURCE_DIR}/src/pyxrt.cpp)
+
+target_include_directories(pyxrt SYSTEM PRIVATE
+  ${XRT_PYTHON_INCLUDE_DIR}
+  ${XRT_PYBIND11_INCLUDE_DIR})
+
+target_link_libraries(pyxrt PRIVATE xrt_coreutil uuid pthread)
+
+# Hidden visibility matches pybind11_add_module.  SUFFIX .so is used
+# because the target ABI tag cannot be computed without an interpreter.
+set_target_properties(pyxrt PROPERTIES
+  PREFIX ""
+  SUFFIX ".so"
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON)
+
+set (XRT_INSTALL_PYTHON_DIR ${CMAKE_INSTALL_LIBDIR}/python${xrt_py_version}/site-packages)
+message("-- pyxrt install directory: ${CMAKE_INSTALL_PREFIX}/${XRT_INSTALL_PYTHON_DIR}")
+
+install(TARGETS pyxrt
+  LIBRARY DESTINATION ${XRT_INSTALL_PYTHON_DIR} COMPONENT ${XRT_BASE_COMPONENT}
+  )
+
+# Install type stub file for IDE autocompletion and type checking
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pyxrt.pyi
+  DESTINATION ${XRT_INSTALL_PYTHON_DIR} COMPONENT ${XRT_BASE_COMPONENT}
+  )

--- a/src/python/pybind11/CMakeLists.txt
+++ b/src/python/pybind11/CMakeLists.txt
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 
-if( NOT WIN32)
+# Edge / Yocto: host python does not match target headers in the sysroot
+if (XRT_EDGE)
+  include (${XRT_SOURCE_DIR}/CMake/pyxrtCross.cmake)
+elseif( NOT WIN32)
 
 # find_package(PythonLibs is depracted as of cmake 3.12.
 if (CMAKE_VERSION VERSION_LESS "3.12")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Edge/Yocto builds did not build the Python pyxrt module. CMake used the host Python, which does not match the Python headers in the target sysroot, so the module could not be built correctly for the board.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
No bug ID. Found when trying to build pyxrt for edge/Yocto.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Edge builds now include the Python bindings. For edge, CMake file finds Python and pybind11 headers in the sysroot and builds pyxrt.so against those. Native Linux/Windows still use the old path (find_package(Python3)).
find_package(Python3) was not used on edge because it picks host Python.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Yocto and Peta Linux edge builds were tested; pyxrt builds successfully in both.
#### Documentation impact (if any)
NA