### PR TITLE
Enable run_start callback for halt plugin

### DIFF
--- a/src/runtime_src/core/common/xdp/profile.cpp
+++ b/src/runtime_src/core/common/xdp/profile.cpp
@@ -526,15 +526,18 @@ namespace xrt_core::xdp::aie::halt {
 
 std::function<void (void*)> update_device_cb;
 std::function<void (void*)> finish_flush_device_cb;
+std::function<void(void*, const char*)> run_start_cb;
 
 void
 register_callbacks(void* handle)
 {
   #if defined(XDP_CLIENT_BUILD) || defined(XDP_VE2_BUILD)
     using ftype = void (*)(void*);
+    using rsctype = void (*)(void*, const char*);
     
     update_device_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "updateDeviceAIEHalt"));
     finish_flush_device_cb = reinterpret_cast<ftype>(xrt_core::dlsym(handle, "finishFlushDeviceAIEHalt"));
+    run_start_cb = reinterpret_cast<rsctype>(xrt_core::dlsym(handle, "aieHaltRunStart"));
   #else
     (void)handle;
   #endif
@@ -568,6 +571,29 @@ finish_flush_device(void* handle)
 {
   if (finish_flush_device_cb)
     finish_flush_device_cb(handle);
+}
+
+void
+run_start(const xrt::run_impl* run_impl)
+{
+  if (!run_start_cb)
+    return;
+
+  // Backstop for run_constructor: this fires immediately before the command is
+  // submitted, so halt is still configured before any user code executes.
+  try {
+    xrt_kernel_data data{};
+    xrt_core::kernel_int::get_xdp_kernel_data(run_impl, &data);
+    run_start_cb(data.hwctx.get_handle().get(), data.name.c_str());
+  }
+  catch (const std::exception& e) {
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+      std::string{"AIE Halt run_start hook failed (ignored): "} + e.what());
+  }
+  catch (...) {
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+      "AIE Halt run_start hook failed (ignored): unknown exception");
+  }
 }
 
 } // end namespace xrt_core::xdp::aie::halt
@@ -958,10 +984,11 @@ run_constructor(xrt::run_impl* run_impl)
 void
 run_start(const xrt::run_impl* run_impl)
 {
-  if (!xrt_core::config::get_aie_dtrace())
-    return;
+  if (xrt_core::config::get_aie_halt())
+    xrt_core::xdp::aie::halt::run_start(run_impl);
 
-  xrt_core::xdp::aie::dtrace::run_start(run_impl);
+  if (xrt_core::config::get_aie_dtrace())
+    xrt_core::xdp::aie::dtrace::run_start(run_impl);
 }
 
 void


### PR DESCRIPTION
#### Problem solved by the commit
Initializing the xdp halt plugin within updateDevice when using it on a full elf design could result in an attempt to double lock a mutex.  That would either result in the plugin configuration failure or deadlock.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered as more tests move to full elf

#### How problem was solved, alternative solutions (if any) and why they were rejected
Configuration of the halt plugin is deferred until the first run start when using full elf flow.

#### Risks (if any) associated the changes in the commit
Should be minimal.  Configuration is only deferred for full elf, and mostly halt would not have been working in that case. 

#### What has been tested and how, request additional testing if necessary
Tested on both full elf and xclbin designs 

#### Documentation impact (if any)
None