### PR TITLE
[XRT-SMI] Update platform report

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -169,7 +169,7 @@ add_npu_load_info(const xrt_core::device* device, ptree_type& pt)
     const auto load = xrt_core::device_query<xq::npu_load>(device);
     pt.put("npu_load", std::to_string(load));
   }
-  catch (const xq::exception&) {
+  catch (const std::exception&) {
     pt.put("npu_load", "N/A");
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR updates the xrt-smi platform report to catch general exception and print NA in case the query fails. 
This is required since the NPU load is not supported on strix platforms and should show N/A instead of failing.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

#### How problem was solved, alternative solutions (if any) and why they were rejected
Solved via broadening the exception handling

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on strix platform. The report now shows NA:
```
aktondak@xsjstrix45:/proj/rdi/staff/aktondak/xdna/xdna-driver/xrt/build$ xrt-smi examine -r platform

---------------------------
[0000:c5:00.1] : NPU Strix
---------------------------
Platform
  Name                   : NPU Strix 
  Power Mode             : default 
  Total Columns          : 8 

Estimated Power          : N/A
NPU Load                 : N/A
Temperature (C)          : N/A
```

#### Documentation impact (if any)
None
